### PR TITLE
(chore): update stream naming

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -645,8 +645,10 @@ navigation:
               - section: "/chat"
                 skip-slug: true
                 contents:
-                  - POST /v1/chat
-                  - STREAM /v1/chat
+                  - endpoint: POST /v1/chat
+                    title: Chat Non-streaming
+                  - endpoint: STREAM /v1/chat
+                    title: Chat Streaming
               - section: "/embed"
                 skip-slug: true
                 contents:
@@ -746,8 +748,10 @@ navigation:
               - section: "/generate"
                 skip-slug: true
                 contents:
-                  - POST /v1/generate
-                  - STREAM /v1/generate
+                  - endpoint: POST /v1/generate
+                    title: Chat Non-streaming
+                  - endpoint: STREAM /v1/generate
+                    title: Chat Streaming
               - section: "/summarize"
                 skip-slug: true
                 contents:


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request updates the `fern/docs.yml` file to include endpoint titles for the `POST` and `STREAM` methods in the `/chat` and `/generate` sections.

## Summary

- The `endpoint` field is added to specify the endpoint for the `POST` and `STREAM` methods.
- The `title` field is set to "Chat Non-streaming" for the `POST /v1/chat` endpoint and "Chat Streaming" for the `STREAM /v1/chat` endpoint.
- Similar changes are made for the `/generate` section, with "Chat Non-streaming" and "Chat Streaming" as the respective titles.

<!-- end-generated-description -->