### PR TITLE
add edit-this-page

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1,5 +1,10 @@
 instances:
   - url: cohere.docs.buildwithfern.com
+    edit-this-page:
+      github:
+        owner: cohere-ai
+        repo: cohere-developer-experience
+        branch: main
 title: Cohere
 
 versions:


### PR DESCRIPTION
<!-- begin-generated-description -->

The pull request makes updates to the `fern/docs.yml` file.

## Summary
The changes add a new section, `edit-this-page`, within the `instances` section of the YAML file. This section provides details about the GitHub repository where the page can be edited, including the owner, repository name, and branch.

## Changes
- Adds a new `edit-this-page` section within `instances`.
- Sets the `github` property under `edit-this-page` to specify the GitHub details.
- Sets the `owner` property under `github` to `cohere-ai`.
- Sets the `repo` property to `cohere-developer-experience`.
- Sets the `branch` property to `main`.

<!-- end-generated-description -->