### PR TITLE
Fix generate title

### DIFF
--- a/fern/v1.yml
+++ b/fern/v1.yml
@@ -710,9 +710,9 @@ navigation:
                 skip-slug: true
                 contents:
                   - endpoint: POST /v1/generate
-                    title: Chat Non-streaming
+                    title: Generate Non-streaming
                   - endpoint: STREAM /v1/generate
-                    title: Chat Streaming
+                    title: Generate Streaming
               - section: "/v1/summarize"
                 skip-slug: true
                 contents:


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request updates the titles of two endpoints in the `fern/v1.yml` file. 

- The `POST /v1/generate` endpoint title is changed from "Chat Non-streaming" to "Generate Non-streaming".
- The `STREAM /v1/generate` endpoint title is changed from "Chat Streaming" to "Generate Streaming".

<!-- end-generated-description -->