### PR TITLE
Hide v2 temporarily

### DIFF
--- a/fern/v1.yml
+++ b/fern/v1.yml
@@ -588,18 +588,18 @@ navigation:
           python: "cohere"
           typescript: "cohere-ai"
         layout:
-          - section: V2 (beta)
-            skip-slug: true
-            contents:
-              - section: "/v2/chat"
-                skip-slug: true
-                contents:
-                  - endpoint: POST /v2/chat
-                    slug: chat-v2
-                    title: Chat Non-streaming
-                  - endpoint: STREAM /v2/chat
-                    slug: chat-stream-v2
-                    title: Chat Streaming
+          # - section: V2 (beta)
+          #   skip-slug: true
+          #   contents:
+          #     - section: "/v2/chat"
+          #       skip-slug: true
+          #       contents:
+          #         - endpoint: POST /v2/chat
+          #           slug: chat-v2
+          #           title: Chat Non-streaming
+          #         - endpoint: STREAM /v2/chat
+          #           slug: chat-stream-v2
+          #           title: Chat Streaming
           - section: API Reference
             skip-slug: true
             contents:


### PR DESCRIPTION
<!-- begin-generated-description -->

The pull request makes formatting changes to the `fern/v1.yml` file. Specifically, it:

- Adds comment symbols (#) before the lines related to the `V2 (beta)` section, indicating that these lines are commented out.
- This includes the lines defining the `section`, `skip-slug`, and the nested `contents` section.
- Within the `contents` section, the lines defining the endpoints for `POST /v2/chat` and `STREAM /v2/chat` are also commented out.

<!-- end-generated-description -->