### PR TITLE
(fix): filter out `v2-beta`

### DIFF
--- a/fern/v1.yml
+++ b/fern/v1.yml
@@ -581,7 +581,7 @@ navigation:
         api-name: v1
         audiences:
           - public
-          - v2-beta
+          # - v2-beta
         skip-slug: true
         flattened: true
         snippets:


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request makes changes to the `fern/v1.yml` file.

## Summary
The `v2-beta` audience is commented out in the `audiences` list, effectively disabling it.

## Changes
- Comment out the `v2-beta` audience in the `fern/v1.yml` file.

<!-- end-generated-description -->