### PR TITLE
Always publish docs, whichever path is touched

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -2,8 +2,6 @@ name: publish-docs
 
 on:
   push:
-    paths:
-      - "fern/**"
     branches:
       - main
 


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request removes the `paths` and its nested `fern/** field from the `publish-docs.yml` workflow file.

---

- The `paths` field, along with its nested `fern/** path, is removed.

<!-- end-generated-description -->