### PR TITLE
(fix): update redirect

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -104,7 +104,7 @@ experimental:
 redirects:
   # fern redirect rules
   - source: "/docs/llmu{/:path}*"
-    destination: "https://cohere.com/llmu"
+    destination: "/docs/llmu-2"
   - source: "/docs/multi-hop-tool-use"
     destination: "/docs/multi-step-tool-use"
   - source: "/docs/command"


### PR DESCRIPTION
This PR makes a temporary update to redirect LLMU path requests to the `docs/llmu-2` page.