### PR TITLE
(chore): correct link

### DIFF
--- a/fern/pages/index.mdx
+++ b/fern/pages/index.mdx
@@ -207,8 +207,8 @@ export const endpoints = [
     }}
   >
     <a
-      href="/docs/llmu"
-      target="_self"
+      href="https://cohere.com/llmu"
+      target="_blank"
       className="flex h-full w-full flex-col justify-between !text-white md:!flex-row"
     >
       <div className="flex h-full flex-col justify-between">


### PR DESCRIPTION
This PR corrects a link on the landing page to open the LLMU curriculum. 