### PR TITLE
(docs)Text styling

### DIFF
--- a/fern/assets/input.css
+++ b/fern/assets/input.css
@@ -1,19 +1,17 @@
 @tailwind components;
 @tailwind utilities;
 
+h1,
 h2,
 h3,
 h4,
 h5,
 h6 {
-  font-weight: 425 !important;
+  font-weight: 400 !important;
   font-family: CohereText !important;
 }
 
 h1 {
-  font-weight: 400 !important;
-  font-variation-settings: "cuts" 300, "move" 300;
-  font-family: CohereHeadline !important;
   font-size: 35px !important;
 }
 
@@ -30,6 +28,23 @@ h2 {
 
 .fern-header-tab-button .font-medium {
   font-weight: 400 !important;
+}
+
+.fern-mdx-link {
+  font-weight: 400 !important;
+  color: rgb(57 89 77) !important;
+}
+
+.font-semibold {
+  font-weight: 500 !important;
+}
+
+.fern-api-property-key {
+  font-weight: 500 !important;
+}
+
+th {
+  font-weight: 500 !important;
 }
 
 @layer utilities {
@@ -64,7 +79,7 @@ button[class^="Sidebar-link-buttonWrapper"] {
 }
 
 .h1-title {
-  font-family: CohereHeadline !important;
+  font-family: CohereText !important;
   letter-spacing: -0.01em;
   font-style: normal;
   font-weight: 400;
@@ -73,16 +88,16 @@ button[class^="Sidebar-link-buttonWrapper"] {
 }
 
 .h2-title {
-  font-family: CohereHeadline !important;
+  font-family: CohereText !important;
   letter-spacing: -0.01em;
   font-style: normal;
-  font-weight: 400;
+  font-weight: 400 !important;
   font-size: 24px !important;
   line-height: 110%;
 }
 
 .h3-title {
-  font-family: CohereHeadline !important;
+  font-family: CohereText !important;
   font-style: normal;
   font-weight: 500;
   font-size: 16.8px !important;


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request updates the font styles in the `fern/assets/input.css` file. 

The changes include:
- Updating the font weight of heading tags (`h1` to `h6`) to `400` and the font family to `CohereText`.
- Removing the `font-variation-settings` property from the `h1` tag.
- Adding new classes:
  - `.fern-mdx-link`: sets font weight to `400` and color to `#39594d`.
  - `.font-semibold`: sets font weight to `500`.
  - `.fern-api-property-key`: sets font weight to `500`.
- Updating the font family of `.h1-title`, `.h2-title`, and `.h3-title` classes to `CohereText`.

<!-- end-generated-description -->