### PR TITLE
[DO NOT MERGE] v2 preview

### DIFF
--- a/fern/v1.yml
+++ b/fern/v1.yml
@@ -587,25 +587,25 @@ navigation:
         api-name: v1
         audiences:
           - public
-          # - v2-beta
+          - v2-beta
         skip-slug: true
         flattened: true
         snippets:
           python: "cohere"
           typescript: "cohere-ai"
         layout:
-          # - section: V2 (beta)
-          #   skip-slug: true
-          #   contents:
-          #     - section: "/v2/chat"
-          #       skip-slug: true
-          #       contents:
-          #         - endpoint: POST /v2/chat
-          #           slug: chat-v2
-          #           title: Chat Non-streaming
-          #         - endpoint: STREAM /v2/chat
-          #           slug: chat-stream-v2
-          #           title: Chat Streaming
+          - section: V2 (beta)
+            skip-slug: true
+            contents:
+              - section: "/v2/chat"
+                skip-slug: true
+                contents:
+                  - endpoint: POST /v2/chat
+                    slug: chat-v2
+                    title: Chat Non-streaming
+                  - endpoint: STREAM /v2/chat
+                    slug: chat-stream-v2
+                    title: Chat Streaming
           - section: API Reference
             skip-slug: true
             contents:


### PR DESCRIPTION
<!-- begin-generated-description -->

The pull request makes changes to the `fern/v1.yml` file, specifically the `navigation` section.

The changes include:
- Uncommenting the line `- v2-beta` under the `audiences` key, indicating that the `v2-beta` version is now part of the API specification.
- Adding a new section for `V2 (beta)` with `skip-slug: true` and defining its contents.
- Within the `V2 (beta)` section:
- Adding a subsection for `/v2/chat` with `skip-slug: true` and specifying its endpoints.
- Defining two endpoints for the `/v2/chat` section:
- `POST /v2/chat` with `slug: chat-v2` and `title: Chat Non-streaming`.
- `STREAM /v2/chat` with `slug: chat-stream-v2` and `title: Chat Streaming`.

<!-- end-generated-description -->