### PR TITLE
Updating rate limits

### DIFF
--- a/fern/pages/going-to-production/rate-limits.mdx
+++ b/fern/pages/going-to-production/rate-limits.mdx
@@ -20,12 +20,12 @@ In this document, we'll discuss some of the limitations associated with a trial 
 Trial keys are rate-limited depending on the endpoint you want to use:
 
 - [Chat](/reference/chat): 20/min
-- Cluster: 5/min
-- [Embed](/reference/embed): 5/min
-- EmbedJob: 5/min
-- [Rerank](/reference/rerank-1): 10/min
-- Generate (legacy): 5/min
-- Summarize (legacy): 5/min
+- Cluster: 5 calls/min
+- [Embed](/reference/embed): 5 calls/min
+- EmbedJob: 5 calls/min
+- [Rerank](/reference/rerank-1): 10 calls/min
+- Generate (legacy): 5 calls/min
+- Summarize (legacy): 5 calls/min
 
 [Chat](/reference/chat) and the [Coral user interface](https://coral.cohere.ai/) are limited to a total of 1,000 calls a month with a trial key. All remaining endpoints are limited to a total of 1,000 calls per month with a trial key. 
 

--- a/fern/pages/going-to-production/rate-limits.mdx
+++ b/fern/pages/going-to-production/rate-limits.mdx
@@ -3,6 +3,11 @@ title: "API Keys and Rate Limits"
 slug: "docs/rate-limits"
 
 hidden: false
+
+description: "This page describes the limitations around Cohere's API."
+image: "../../assets/images/f1cc130-cohere_meta_image.jpg"  
+keywords: "Cohere, large language model API"
+
 createdAt: "Thu Feb 29 2024 18:20:04 GMT+0000 (Coordinated Universal Time)"
 updatedAt: "Wed Jun 05 2024 20:23:51 GMT+0000 (Coordinated Universal Time)"
 ---
@@ -14,11 +19,13 @@ In this document, we'll discuss some of the limitations associated with a trial 
 
 Trial keys are rate-limited depending on the endpoint you want to use:
 
-| Endpoint                                                                                             | Calls per Minute |
-| :--------------------------------------------------------------------------------------------------- | :--------------- |
-| [Embed](/reference/embed)                                                     | 5                |
-| [Rerank](/reference/rerank-1), [Chat](/reference/chat) | 10               |
-| All other endpoints                                                                                  | 100              |
+- Generate (legacy): 5/min
+- [Chat](/reference/chat): 20/min
+- Summarize: 5/min
+- Cluster: 5/min
+- [Embed](/reference/embed): 5/min
+- EmbedJob: 5/min
+- [Rerank](/reference/rerank-1): 10/min
 
 [Chat](/reference/chat) and the [Coral user interface](https://coral.cohere.ai/) are limited to a total of 1,000 calls a month with a trial key. All remaining endpoints are limited to a total of 1,000 calls per month with a trial key. 
 
@@ -35,7 +42,7 @@ With a trial key:
 
 ## Production Key Specifications
 
-Production keys for all endpoints are rate-limited at 10,000 calls per minute and are intended for serving Cohere in a public-facing application and testing purposes. Usage of production keys is metered at price points which can be found on our [pricing page](/docs/how-does-cohere-pricing-work).
+Production keys for all endpoints are rate-limited at 1,000 calls per minute and are intended for serving Cohere in a public-facing application and testing purposes. Usage of production keys is metered at price points which can be found on our [pricing page](/docs/how-does-cohere-pricing-work).
 
 To get a production key, start by navigating to the [API Keys](https://dashboard.cohere.com/api-keys) page in your Cohere dashboard. You'll either need to be the admin of your organization, or ask your organization Admin to complete these steps.
 
@@ -46,5 +53,3 @@ From there, click on _Create Production key_ to finish the process.
 ![](../../assets/images/27062e8-Screenshot_2024-07-01_at_10.33.54_AM.png)
 
 The whole process should complete in less than three minutes, and enables you to generate a production key that you can use to serve Cohere APIs in production. If you deploy without completing the go to production workflow, your API key may be temporarily or permanently revoked.
-
-

--- a/fern/pages/going-to-production/rate-limits.mdx
+++ b/fern/pages/going-to-production/rate-limits.mdx
@@ -19,13 +19,13 @@ In this document, we'll discuss some of the limitations associated with a trial 
 
 Trial keys are rate-limited depending on the endpoint you want to use:
 
-- Generate (legacy): 5/min
 - [Chat](/reference/chat): 20/min
-- Summarize: 5/min
 - Cluster: 5/min
 - [Embed](/reference/embed): 5/min
 - EmbedJob: 5/min
 - [Rerank](/reference/rerank-1): 10/min
+- Generate (legacy): 5/min
+- Summarize (legacy): 5/min
 
 [Chat](/reference/chat) and the [Coral user interface](https://coral.cohere.ai/) are limited to a total of 1,000 calls a month with a trial key. All remaining endpoints are limited to a total of 1,000 calls per month with a trial key. 
 


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request updates the "API Keys and Rate Limits" documentation page. It includes changes to the rate limits for various endpoints and production key specifications.

## Changes:
- Adds a description, image, and keywords to the document metadata.
- Updates the description of the document to specify that it covers limitations around Cohere's API.
- Modifies the rate limits for specific endpoints:
  - Generate (legacy): 5/min
  - Chat: 20/min (increased from 10/min)
  - Summarize: 5/min
  - Cluster: 5/min
  - Embed: 5/min
  - EmbedJob: 5/min
  - Rerank: 10/min
- Reduces the rate limit for production keys from 10,000 calls per minute to 1,000 calls per minute.

<!-- end-generated-description -->