### PR TITLE
fix `fern check`

### DIFF
--- a/cohere-openapi.yaml
+++ b/cohere-openapi.yaml
@@ -6714,90 +6714,116 @@ paths:
             stream: true
           response:
             stream:
-              - type: message-start
-                id: 29f14a5a-11de-4cae-9800-25e4747408ea
-                delta:
-                  message:
-                    role: "assistant"
-                    content: []
-                    tool_plan: ""
-                    tool_calls: []
-                    citations: []
-              - type: content-start
-                index: 0
-                delta:
-                  message:
-                    content:
-                      type: "text"
-                      text: ""
-              - type: content-delta
-                index: 0
-                delta:
-                  message:
-                    content:
-                      text: "Hello"
-              - type: content-delta
-                index: 0
-                delta:
-                  message:
-                    content:
-                      text: "!"
-              - type: content-delta
-                index: 0
-                delta:
-                  message:
-                    content:
-                      text: " How"
-              - type: content-delta
-                index: 0
-                delta:
-                  message:
-                    content:
-                      text: " can"
-              - type: content-delta
-                index: 0
-                delta:
-                  message:
-                    content:
-                      text: " I"
-              - type: content-delta
-                index: 0
-                delta:
-                  message:
-                    content:
-                      text: " help"
-              - type: content-delta
-                index: 0
-                delta:
-                  message:
-                    content:
-                      text: " you"
-              - type: content-delta
-                index: 0
-                delta:
-                  message:
-                    content:
-                      text: " today"
-              - type: content-delta
-                index: 0
-                delta:
-                  message:
-                    content:
-                      text: "?"
-              - type: content-end
-                index: 0
-              - event_type: message-end
-                delta:
-                  finish_reason: complete
-                  usage:
-                    api_version:
-                      version: '2'
-                    billed_units:
-                      input_tokens: 3
-                      output_tokens: 9
-                    tokens:
-                      input_tokens: 69
-                      output_tokens: 9
+              - event: data
+                data:
+                  type: message-start
+                  id: 29f14a5a-11de-4cae-9800-25e4747408ea
+                  delta:
+                    message:
+                      role: "assistant"
+                      # content: []
+                      # tool_plan: ""
+                      # tool_calls: []
+                      # citations: []
+              - event: data
+                data:
+                  type: content-start
+                  index: 0
+                  delta:
+                    message:
+                      content:
+                        type: "text"
+                        text: ""
+              - event: data
+                data:
+                  type: content-delta
+                  index: 0
+                  delta:
+                    message:
+                      content:
+                        text: "Hello"
+              - event: data
+                data:
+                  type: content-delta
+                  index: 0
+                  delta:
+                    message:
+                      content:
+                        text: "!"
+              - event: data
+                data:
+                  type: content-delta
+                  index: 0
+                  delta:
+                    message:
+                      content:
+                        text: " How"
+              - event: data
+                data:
+                  type: content-delta
+                  index: 0
+                  delta:
+                    message:
+                      content:
+                        text: " can"
+              - event: data
+                data:
+                  type: content-delta
+                  index: 0
+                  delta:
+                    message:
+                      content:
+                        text: " I"
+              - event: data
+                data:
+                  type: content-delta
+                  index: 0
+                  delta:
+                    message:
+                      content:
+                        text: " help"
+              - event: data
+                data:
+                  type: content-delta
+                  index: 0
+                  delta:
+                    message:
+                      content:
+                        text: " you"
+              - event: data
+                data:
+                  type: content-delta
+                  index: 0
+                  delta:
+                    message:
+                      content:
+                        text: " today"
+              - event: data
+                data:
+                  type: content-delta
+                  index: 0
+                  delta:
+                    message:
+                      content:
+                        text: "?"
+              - event: data
+                data:
+                  type: content-end
+                  index: 0
+              - event: data
+                data:
+                  type: message-end
+                  delta:
+                    finish_reason: complete
+                    usage:
+                      # api_version:
+                      #   version: '2'
+                      billed_units:
+                        input_tokens: 3
+                        output_tokens: 9
+                      tokens:
+                        input_tokens: 69
+                        output_tokens: 9
         - code-samples:
             - sdk: typescript
               name: Tools
@@ -6941,27 +6967,26 @@ paths:
               id: 9e5f00aa-bf1e-481a-abe3-0eceac18c3ec
               message:
                 role: "assistant"
-                tool_plan: "I will first find the sales summary for 29th September 2023. Then, I
-                  wil"
-            find the details of the products in the 'Electronics' category." tool_calls:
-              - id: query_daily_sales_report_hgxxmkby3wta
-                type: function
-                function:
-                  name: query_daily_sales_report
-                  arguments: "{\"day\": \"2023-09-29\"}"
-              - id: query_product_catalog_rpg0z5h8yyz2
-                type: function
-                function:
-                  name: query_product_catalog
-                  arguments: "{\"category\": \"Electronics\"}"
-            finish_reason: "tool_call"
-            usage:
-              billed_units:
-                input_tokens: 127
-                output_tokens: 69
-              tokens:
-                input_tokens: 1032
-                output_tokens: 124
+                tool_plan: "I will first find the sales summary for 29th September 2023. Then, I will find the details of the products in the 'Electronics' category."
+                tool_calls:
+                  - id: query_daily_sales_report_hgxxmkby3wta
+                    type: function
+                    function:
+                      name: query_daily_sales_report
+                      arguments: "{\"day\": \"2023-09-29\"}"
+                  - id: query_product_catalog_rpg0z5h8yyz2
+                    type: function
+                    function:
+                      name: query_product_catalog
+                      arguments: "{\"category\": \"Electronics\"}"
+              finish_reason: "tool_call"
+              usage:
+                billed_units:
+                  input_tokens: 127
+                  output_tokens: 69
+                tokens:
+                  input_tokens: 1032
+                  output_tokens: 124
   /v1/generate:
     post:
       x-fern-audiences:

--- a/cohere-openapi.yaml
+++ b/cohere-openapi.yaml
@@ -6714,7 +6714,7 @@ paths:
             stream: true
           response:
             stream:
-              - event: data
+              - event: stream-start
                 data:
                   type: message-start
                   id: 29f14a5a-11de-4cae-9800-25e4747408ea
@@ -6725,7 +6725,7 @@ paths:
                       # tool_plan: ""
                       # tool_calls: []
                       # citations: []
-              - event: data
+              - event: text-generation
                 data:
                   type: content-start
                   index: 0
@@ -6734,7 +6734,7 @@ paths:
                       content:
                         type: "text"
                         text: ""
-              - event: data
+              - event: text-generation
                 data:
                   type: content-delta
                   index: 0
@@ -6742,7 +6742,7 @@ paths:
                     message:
                       content:
                         text: "Hello"
-              - event: data
+              - event: text-generation
                 data:
                   type: content-delta
                   index: 0
@@ -6750,7 +6750,7 @@ paths:
                     message:
                       content:
                         text: "!"
-              - event: data
+              - event: text-generation
                 data:
                   type: content-delta
                   index: 0
@@ -6758,7 +6758,7 @@ paths:
                     message:
                       content:
                         text: " How"
-              - event: data
+              - event: text-generation
                 data:
                   type: content-delta
                   index: 0
@@ -6766,7 +6766,7 @@ paths:
                     message:
                       content:
                         text: " can"
-              - event: data
+              - event: text-generation
                 data:
                   type: content-delta
                   index: 0
@@ -6774,7 +6774,7 @@ paths:
                     message:
                       content:
                         text: " I"
-              - event: data
+              - event: text-generation
                 data:
                   type: content-delta
                   index: 0
@@ -6782,7 +6782,7 @@ paths:
                     message:
                       content:
                         text: " help"
-              - event: data
+              - event: text-generation
                 data:
                   type: content-delta
                   index: 0
@@ -6790,7 +6790,7 @@ paths:
                     message:
                       content:
                         text: " you"
-              - event: data
+              - event: text-generation
                 data:
                   type: content-delta
                   index: 0
@@ -6798,7 +6798,7 @@ paths:
                     message:
                       content:
                         text: " today"
-              - event: data
+              - event: text-generation
                 data:
                   type: content-delta
                   index: 0
@@ -6806,11 +6806,11 @@ paths:
                     message:
                       content:
                         text: "?"
-              - event: data
+              - event: text-generation
                 data:
                   type: content-end
                   index: 0
-              - event: data
+              - event: stream-end
                 data:
                   type: message-end
                   delta:


### PR DESCRIPTION
<!-- begin-generated-description -->

The changes in this PR update the structure of the API response for the `"/v1/generate" endpoint. 

Previously, the API response included a `stream` field, indicating a stream of data, and detailed each message and content delta as separate entries. 

The updated structure introduces an `event: data` field, with `data` as its value, to encapsulate the message and content delta details. Each message and content delta is now associated with an `event: data` entry. 

Additionally, the `tool_plan` field has been updated to include the full sentence: "I will first find the sales summary for 29th September 2023. Then, I will find the details of the products in the 'Electronics' category."

**Changes:**
- Introduced a new `event: data` structure to encapsulate message and content delta details.
- Updated the `tool_plan` field to include a complete sentence.

<!-- end-generated-description -->