### PR TITLE
multiple doc fixes + add documentation for new wandb param for chat finetunes

### DIFF
--- a/cohere-openapi.yaml
+++ b/cohere-openapi.yaml
@@ -11467,7 +11467,7 @@ paths:
                 		&MyReader{Reader: strings.NewReader(`{"text": "The quick brown fox jumps over the lazy dog"}`), name: "test.jsonl"},
                 		&MyReader{Reader: strings.NewReader(""), name: "a.jsonl"},
                 		&cohere.DatasetsCreateRequest{
-                			Name: "prompt-completion-dataset",
+                			Name: "embed-dataset",
                 			Type: cohere.DatasetTypeEmbedResult,
                 		},
                 	)
@@ -11487,9 +11487,9 @@ paths:
 
                 # upload a dataset
                 my_dataset = co.datasets.create(
-                    name="prompt-completion-dataset",
-                    data=open("./prompt-completion.jsonl", "rb"),
-                    type="prompt-completion-finetune-input",
+                    name="chat-dataset",
+                    data=open("./chat.jsonl", "rb"),
+                    type="chat-finetune-input",
                 )
 
                 # wait for validation to complete
@@ -11509,9 +11509,9 @@ paths:
 
                     # upload a dataset
                     response = await co.datasets.create(
-                        name="prompt-completion-dataset",
-                        data=open("./prompt-completion.jsonl", "rb"),
-                        type="prompt-completion-finetune-input",
+                        name="chat-dataset",
+                        data=open("./chat.jsonl", "rb"),
+                        type="chat-finetune-input",
                     )
 
                     # wait for validation to complete
@@ -11542,7 +11542,7 @@ paths:
                     public static void main(String[] args) {
                         Cohere cohere = Cohere.builder().token("<<apiKey>>").clientName("snippet").build();
 
-                        DatasetsCreateResponse response = cohere.datasets().create(null, Optional.empty(), DatasetsCreateRequest.builder().name("prompt-completion-dataset").type(DatasetType.PROMPT_COMPLETION_FINETUNE_INPUT).build());
+                        DatasetsCreateResponse response = cohere.datasets().create(null, Optional.empty(), DatasetsCreateRequest.builder().name("chat-dataset").type(DatasetType.CHAT_FINETUNE_INPUT).build());
 
                         System.out.println(response);
                     }
@@ -14355,14 +14355,14 @@ paths:
               example:
                 finetuned_models:
                   - id: fee37446-7fc7-42f9-a026-c6ba2fcc422d
-                    name: prompt-completion-ft
+                    name: chat-ft
                     creator_id: 7a317d97-4d05-427d-9396-f31b9fb92c55
                     organization_id: 6bdca3d5-3eae-4de0-ac34-786d8063b7ee
                     settings:
                       base_model:
                         name: medium
                         version: 14.2.0
-                        base_type: BASE_TYPE_GENERATIVE
+                        base_type: BASE_TYPE_CHAT
                         strategy: STRATEGY_TFEW
                       dataset_id: my-dataset-d701tr
                       hyperparameters:
@@ -14614,7 +14614,7 @@ paths:
               name: api-test
               settings:
                 base_model:
-                  base_type: BASE_TYPE_GENERATIVE
+                  base_type: BASE_TYPE_CHAT
                 dataset_id: my-dataset-id
         required: true
       parameters:
@@ -14636,7 +14636,7 @@ paths:
                     public static void main(String[] args) {
                         Cohere cohere = Cohere.builder().token("<<apiKey>>").clientName("snippet").build();
 
-                        CreateFinetunedModelResponse response = cohere.finetuning().createFinetunedModel(FinetunedModel.builder().name("test-finetuned-model").settings(Settings.builder().baseModel(BaseModel.builder().baseType(BaseType.BASE_TYPE_GENERATIVE).build()).datasetId("my-dataset-id").build()).build());
+                        CreateFinetunedModelResponse response = cohere.finetuning().createFinetunedModel(FinetunedModel.builder().name("test-finetuned-model").settings(Settings.builder().baseModel(BaseModel.builder().baseType(BaseType.BASE_TYPE_CHAT).build()).datasetId("my-dataset-id").build()).build());
 
                         System.out.println(response);
                     }
@@ -14782,7 +14782,7 @@ paths:
                       "name": "test-finetuned-model",
                       "settings": {
                         "base_model": {
-                          "base_type": "BASE_TYPE_GENERATIVE",
+                          "base_type": "BASE_TYPE_CHAT",
                         },
                         "dataset_id": "test-dataset-id"
                       }
@@ -14928,7 +14928,7 @@ paths:
                     public static void main(String[] args) {
                         Cohere cohere = Cohere.builder().token("<<apiKey>>").clientName("snippet").build();
 
-                        UpdateFinetunedModelResponse response = cohere.finetuning().updateFinetunedModel("test-id", FinetuningUpdateFinetunedModelRequest.builder().name("new name").settings(Settings.builder().baseModel(BaseModel.builder().baseType(BaseType.BASE_TYPE_GENERATIVE).build()).datasetId("my-dataset-id").build()).build());
+                        UpdateFinetunedModelResponse response = cohere.finetuning().updateFinetunedModel("test-id", FinetuningUpdateFinetunedModelRequest.builder().name("new name").settings(Settings.builder().baseModel(BaseModel.builder().baseType(BaseType.BASE_TYPE_CHAT).build()).datasetId("my-dataset-id").build()).build());
 
                         System.out.println(response);
                     }
@@ -15044,14 +15044,14 @@ paths:
               example:
                 finetuned_model:
                   id: fee37446-7fc7-42f9-a026-c6ba2fcc422d
-                  name: prompt-completion-ft
+                  name: chat-ft
                   creator_id: 7a317d97-4d05-427d-9396-f31b9fb92c55
                   organization_id: 6bdca3d5-3eae-4de0-ac34-786d8063b7ee
                   settings:
                     base_model:
                       name: medium
                       version: 14.2.0
-                      base_type: BASE_TYPE_GENERATIVE
+                      base_type: BASE_TYPE_CHAT
                       strategy: STRATEGY_TFEW
                     dataset_id: my-dataset-d701tr
                     hyperparameters:

--- a/cohere-openapi.yaml
+++ b/cohere-openapi.yaml
@@ -14666,7 +14666,7 @@ paths:
                 			Settings: &finetuning.Settings{
                 				DatasetId: "my-dataset-id",
                 				BaseModel: &finetuning.BaseModel{
-                					BaseType: finetuning.BaseTypeBaseTypeGenerative,
+                					BaseType: finetuning.BaseTypeBaseTypeChat,
                 				},
                 			},
                 		},
@@ -14693,7 +14693,7 @@ paths:
                     name: 'test-finetuned-model',
                     settings: {
                       base_model: {
-                        base_type: Cohere.Finetuning.BaseType.BaseTypeGenerative,
+                        base_type: Cohere.Finetuning.BaseType.BaseTypeChat,
                       },
                       dataset_id: 'test-dataset-id',
                     },

--- a/fern/pages/fine-tuning/chat-fine-tuning/chat-starting-the-training.mdx
+++ b/fern/pages/fine-tuning/chat-fine-tuning/chat-starting-the-training.mdx
@@ -195,24 +195,42 @@ To train a custom model, please see the example below for parameters to pass to 
   - `early_stopping_threshold` (float) How much the loss must improve to prevent early stopping. Must be between 0.001 and 0.1. Defaults to **0.001**.
   - `early_stopping_patience` (int) Stops training if the loss metric does not improve beyond the value of `early_stopping_threshold` after this many rounds of evaluation. Must be between 0 and 10. Defaults to **10**.
 
+You can optionally publish the training metrics and hyper parameter values to your [Weights and Biases](https://wandb.ai) account using the `wandb` parameter. This is currently only supported for chat type finetunes. 
+
+- `wandb` (cohere.finetuning.WandbConfig) - The Weights & Biases configuration.
+  - `project` (string) The Weights and Biases project to be used during training. This parameter is mandatory.
+  - `api_key` (string) The Weights and Biases API key to be used during training. This parameter is mandatory and will always be stored encrypted and auto-deleted after the finetune creation is complete.
+  - `entity` (string) The Weights and Biases API entity to be used during training. When not specified, it will assume the default entity for that API key.
+
+When the configuration is valid, the Run ID will correspond to the finetune ID, and Run display name will be the name of the finetune specified during creation. When specifying a invalid Weights and Biases configuration, finetune creation will proceed but nothing will be logged to your Weights and Biases.
+
+Once a finetune has been created with a specified Weights and Biases configuration, you may view the finetune run via the Weights and Biases dashboard. It will be available via the following URL: `https://wandb.ai/<your-entity>/<your-project>/runs/<finetune-id>`.
+
 ## Example
 
 ```python PYTHON
 import cohere
-from cohere.finetuning import Hyperparameters, Settings, BaseModel
+from cohere.finetuning import Hyperparameters, Settings, BaseModel, WandbConfig
 
 co = cohere.Client('Your API key')
 
 chat_dataset = co.datasets.create(name="chat-dataset",
                                   data=open("path/to/train.jsonl", "rb"),
                                   type="chat-finetune-input")
-# optional (define custom  hyperparameters)
+# optional (define custom hyperparameters)
 hp = Hyperparameters(
   early_stopping_patience=10,
   early_stopping_threshold=0.001,
   train_batch_size=16,
   train_epochs=1,
   learning_rate=0.01,
+)
+
+# optional (define wandb configuration)
+wnb_config = WandbConfig(
+    project="test-project",
+    api_key="<<wandbApiKey>>",
+    entity="test-entity",
 )
 
 my_finetune = co.finetuning.create_finetuned_model(
@@ -223,7 +241,8 @@ my_finetune = co.finetuning.create_finetuned_model(
         base_type="BASE_TYPE_CHAT",
       ),
       dataset_id=my-chat_dataset.id,
-      hyperparameters=hp
+      hyperparameters=hp,
+      wandb=wnb_config,
     ),
   ),
 )

--- a/fern/pages/fine-tuning/classify-fine-tuning/classify-starting-the-training.mdx
+++ b/fern/pages/fine-tuning/classify-fine-tuning/classify-starting-the-training.mdx
@@ -116,7 +116,7 @@ finetune = co.finetuning.create_finetuned_model(
   ),
 )
 
-print(f"fine-tune ID: {finetune.id}, fine-tune status: {finetune.status}"
+print(f"fine-tune ID: {finetune.id}, fine-tune status: {finetune.status}")
 ```
 
 ### Starting a Multi-label Fine-tune
@@ -142,7 +142,7 @@ finetune = co.finetuning.create_finetuned_model(
   ),
 )
 
-print(f"fine-tune ID: {finetune.id}, fine-tune status: {finetune.status}"
+print(f"fine-tune ID: {finetune.id}, fine-tune status: {finetune.status}")
 ```
 
 ### Calling a fine-tune

--- a/fern/pages/fine-tuning/fine-tuning-with-the-python-sdk.mdx
+++ b/fern/pages/fine-tuning/fine-tuning-with-the-python-sdk.mdx
@@ -47,7 +47,7 @@ finetuned_model = co.finetuning.create_finetuned_model(
       base_model=BaseModel(
         base_type="BASE_TYPE_CHAT",
       ),
-      dataset_id=my-dataset.id,
+      dataset_id=my_dataset.id,
     ),
   ),
 )

--- a/fern/pages/get-started/datasets.mdx
+++ b/fern/pages/get-started/datasets.mdx
@@ -135,7 +135,7 @@ In the example below, we will create a new dataset and upload an evaluation set 
 # create a dataset
 my_dataset = co.datasets.create(
 	name="shakespeare",
-	dataset_type="prompt-completion-finetune-input",
+	dataset_type="chat-finetune-input",
 	data=open("./shakespeare.csv", "rb"),
   eval_data=open("./shakespeare-eval.csv", "rb")
 )

--- a/fern/pages/get-started/datasets.mdx
+++ b/fern/pages/get-started/datasets.mdx
@@ -62,8 +62,8 @@ Here is an example code snippet illustrating the process of creating a dataset, 
 ```python PYTHON
 my_dataset = co.datasets.create(
 	name="shakespeare",
-	data=open("./shakespeare.csv", "rb"),
-	dataset_type="prompt-completion-finetune-input")
+	data=open("./shakespeare.jsonl", "rb"),
+	dataset_type="chat-finetune-input")
 
 print(my_dataset.id)
 ```

--- a/snippets/curl/finetuning/create-finetuned-model.sh
+++ b/snippets/curl/finetuning/create-finetuned-model.sh
@@ -7,7 +7,7 @@ curl --request POST \
       "name": "test-finetuned-model",
       "settings": {
         "base_model": {
-          "base_type": "BASE_TYPE_GENERATIVE",
+          "base_type": "BASE_TYPE_CHAT",
         },
         "dataset_id": "test-dataset-id"
       }

--- a/snippets/go/dataset-post/main.go
+++ b/snippets/go/dataset-post/main.go
@@ -27,7 +27,7 @@ func main() {
 		&MyReader{Reader: strings.NewReader(`{"text": "The quick brown fox jumps over the lazy dog"}`), name: "test.jsonl"},
 		&MyReader{Reader: strings.NewReader(""), name: "a.jsonl"},
 		&cohere.DatasetsCreateRequest{
-			Name: "prompt-completion-dataset",
+			Name: "embed-dataset",
 			Type: cohere.DatasetTypeEmbedResult,
 		},
 	)

--- a/snippets/go/finetuning/create-finetuned-model/main.go
+++ b/snippets/go/finetuning/create-finetuned-model/main.go
@@ -18,7 +18,7 @@ func main() {
 			Settings: &finetuning.Settings{
 				DatasetId: "my-dataset-id",
 				BaseModel: &finetuning.BaseModel{
-					BaseType: finetuning.BaseTypeBaseTypeGenerative,
+					BaseType: finetuning.BaseTypeBaseTypeChat,
 				},
 			},
 		},

--- a/snippets/java/app/src/main/java/DatasetPost.java
+++ b/snippets/java/app/src/main/java/DatasetPost.java
@@ -10,7 +10,7 @@ public class DatasetPost {
     public static void main(String[] args) {
         Cohere cohere = Cohere.builder().token("<<apiKey>>").clientName("snippet").build();
 
-        DatasetsCreateResponse response = cohere.datasets().create(null, Optional.empty(), DatasetsCreateRequest.builder().name("prompt-completion-dataset").type(DatasetType.PROMPT_COMPLETION_FINETUNE_INPUT).build());
+        DatasetsCreateResponse response = cohere.datasets().create(null, Optional.empty(), DatasetsCreateRequest.builder().name("chat-dataset").type(DatasetType.CHAT_FINETUNE_INPUT).build());
 
         System.out.println(response);
     }

--- a/snippets/java/app/src/main/java/finetuning/CreateFinetunedModel.java
+++ b/snippets/java/app/src/main/java/finetuning/CreateFinetunedModel.java
@@ -7,7 +7,7 @@ public class CreateFinetunedModel {
     public static void main(String[] args) {
         Cohere cohere = Cohere.builder().token("<<apiKey>>").clientName("snippet").build();
 
-        CreateFinetunedModelResponse response = cohere.finetuning().createFinetunedModel(FinetunedModel.builder().name("test-finetuned-model").settings(Settings.builder().baseModel(BaseModel.builder().baseType(BaseType.BASE_TYPE_GENERATIVE).build()).datasetId("my-dataset-id").build()).build());
+        CreateFinetunedModelResponse response = cohere.finetuning().createFinetunedModel(FinetunedModel.builder().name("test-finetuned-model").settings(Settings.builder().baseModel(BaseModel.builder().baseType(BaseType.BASE_TYPE_CHAT).build()).datasetId("my-dataset-id").build()).build());
 
         System.out.println(response);
     }

--- a/snippets/java/app/src/main/java/finetuning/UpdateFinetunedModel.java
+++ b/snippets/java/app/src/main/java/finetuning/UpdateFinetunedModel.java
@@ -12,7 +12,7 @@ public class UpdateFinetunedModel {
     public static void main(String[] args) {
         Cohere cohere = Cohere.builder().token("<<apiKey>>").clientName("snippet").build();
 
-        UpdateFinetunedModelResponse response = cohere.finetuning().updateFinetunedModel("test-id", FinetuningUpdateFinetunedModelRequest.builder().name("new name").settings(Settings.builder().baseModel(BaseModel.builder().baseType(BaseType.BASE_TYPE_GENERATIVE).build()).datasetId("my-dataset-id").build()).build());
+        UpdateFinetunedModelResponse response = cohere.finetuning().updateFinetunedModel("test-id", FinetuningUpdateFinetunedModelRequest.builder().name("new name").settings(Settings.builder().baseModel(BaseModel.builder().baseType(BaseType.BASE_TYPE_CHAT).build()).datasetId("my-dataset-id").build()).build());
 
         System.out.println(response);
     }

--- a/snippets/node/finetuning/create-finetuned-model.ts
+++ b/snippets/node/finetuning/create-finetuned-model.ts
@@ -9,7 +9,7 @@ const cohere = new CohereClient({
     name: 'test-finetuned-model',
     settings: {
       base_model: {
-        base_type: Cohere.Finetuning.BaseType.BaseTypeGenerative,
+        base_type: Cohere.Finetuning.BaseType.BaseTypeChat,
       },
       dataset_id: 'test-dataset-id',
     },

--- a/snippets/python-async/dataset-post.py
+++ b/snippets/python-async/dataset-post.py
@@ -8,9 +8,9 @@ async def main():
 
     # upload a dataset
     response = await co.datasets.create(
-        name="prompt-completion-dataset",
-        data=open("./prompt-completion.jsonl", "rb"),
-        type="prompt-completion-finetune-input",
+        name="chat-dataset",
+        data=open("./chat.jsonl", "rb"),
+        type="chat-finetune-input",
     )
 
     # wait for validation to complete

--- a/snippets/python-async/embed-jobs-post.py
+++ b/snippets/python-async/embed-jobs-post.py
@@ -6,8 +6,8 @@ co = cohere.AsyncClient("<<apiKey>>")
 
 async def main():
     # start an embed job
-    response = await co.embed_jobs.create(
-        dataset_id=ds.id, input_type="search_document", model="embed-english-v3.0"
+    job = await co.embed_jobs.create(
+        dataset_id="my-dataset-id", input_type="search_document", model="embed-english-v3.0"
     )
 
     # poll the server until the job is complete

--- a/snippets/python-async/finetuning/create-finetuned-model.py
+++ b/snippets/python-async/finetuning/create-finetuned-model.py
@@ -16,7 +16,7 @@ async def main():
             name="test-finetuned-model",
             settings=Settings(
                 base_model=BaseModel(
-                    base_type=BaseType.BASE_TYPE_GENERATIVE,
+                    base_type=BaseType.BASE_TYPE_CHAT,
                 ),
                 dataset_id="my-dataset-id",
             ),

--- a/snippets/python/dataset-post.py
+++ b/snippets/python/dataset-post.py
@@ -3,10 +3,10 @@ import cohere
 co = cohere.Client("<<apiKey>>")
 
 # upload a dataset
-response = co.datasets.create(
-    name="prompt-completion-dataset",
-    data=open("./prompt-completion.jsonl", "rb"),
-    type="prompt-completion-finetune-input",
+my_dataset = co.datasets.create(
+    name="chat-dataset",
+    data=open("./chat.jsonl", "rb"),
+    type="chat-finetune-input",
 )
 
 # wait for validation to complete

--- a/snippets/python/embed-jobs-post.py
+++ b/snippets/python/embed-jobs-post.py
@@ -3,8 +3,8 @@ import cohere
 co = cohere.Client("<<apiKey>>")
 
 # start an embed job
-response = co.embed_jobs.create(
-    dataset_id=ds.id, input_type="search_document", model="embed-english-v3.0"
+job = co.embed_jobs.create(
+    dataset_id="my-dataset-id", input_type="search_document", model="embed-english-v3.0"
 )
 
 # poll the server until the job is complete

--- a/snippets/python/finetuning/create-finetuned-model.py
+++ b/snippets/python/finetuning/create-finetuned-model.py
@@ -26,4 +26,4 @@ finetuned_model = co.finetuning.create_finetuned_model(
         ),
     )
 )
-print(response)
+print(finetuned_model)

--- a/snippets/python/finetuning/update-finetuned-model.py
+++ b/snippets/python/finetuning/update-finetuned-model.py
@@ -1,3 +1,7 @@
+from cohere.finetuning import (
+    BaseModel,
+    Settings,
+)
 import cohere
 
 co = cohere.Client("<<apiKey>>")

--- a/snippets/snippets/curl/finetuning/create-finetuned-model.sh
+++ b/snippets/snippets/curl/finetuning/create-finetuned-model.sh
@@ -7,7 +7,7 @@ curl --request POST \
       "name": "test-finetuned-model",
       "settings": {
         "base_model": {
-          "base_type": "BASE_TYPE_GENERATIVE",
+          "base_type": "BASE_TYPE_CHAT",
         },
         "dataset_id": "test-dataset-id"
       }

--- a/snippets/snippets/go/dataset-post/main.go
+++ b/snippets/snippets/go/dataset-post/main.go
@@ -27,7 +27,7 @@ func main() {
 		&MyReader{Reader: strings.NewReader(`{"text": "The quick brown fox jumps over the lazy dog"}`), name: "test.jsonl"},
 		&MyReader{Reader: strings.NewReader(""), name: "a.jsonl"},
 		&cohere.DatasetsCreateRequest{
-			Name: "prompt-completion-dataset",
+			Name: "embed-dataset",
 			Type: cohere.DatasetTypeEmbedResult,
 		},
 	)

--- a/snippets/snippets/go/finetuning/create-finetuned-model/main.go
+++ b/snippets/snippets/go/finetuning/create-finetuned-model/main.go
@@ -18,7 +18,7 @@ func main() {
 			Settings: &finetuning.Settings{
 				DatasetId: "my-dataset-id",
 				BaseModel: &finetuning.BaseModel{
-					BaseType: finetuning.BaseTypeBaseTypeGenerative,
+					BaseType: finetuning.BaseTypeBaseTypeChat,
 				},
 			},
 		},

--- a/snippets/snippets/java/app/src/main/java/DatasetPost.java
+++ b/snippets/snippets/java/app/src/main/java/DatasetPost.java
@@ -10,7 +10,7 @@ public class DatasetPost {
     public static void main(String[] args) {
         Cohere cohere = Cohere.builder().token("<<apiKey>>").clientName("snippet").build();
 
-        DatasetsCreateResponse response = cohere.datasets().create(null, Optional.empty(), DatasetsCreateRequest.builder().name("prompt-completion-dataset").type(DatasetType.PROMPT_COMPLETION_FINETUNE_INPUT).build());
+        DatasetsCreateResponse response = cohere.datasets().create(null, Optional.empty(), DatasetsCreateRequest.builder().name("chat-dataset").type(DatasetType.CHAT_FINETUNE_INPUT).build());
 
         System.out.println(response);
     }

--- a/snippets/snippets/java/app/src/main/java/finetuning/CreateFinetunedModel.java
+++ b/snippets/snippets/java/app/src/main/java/finetuning/CreateFinetunedModel.java
@@ -7,7 +7,7 @@ public class CreateFinetunedModel {
     public static void main(String[] args) {
         Cohere cohere = Cohere.builder().token("<<apiKey>>").clientName("snippet").build();
 
-        CreateFinetunedModelResponse response = cohere.finetuning().createFinetunedModel(FinetunedModel.builder().name("test-finetuned-model").settings(Settings.builder().baseModel(BaseModel.builder().baseType(BaseType.BASE_TYPE_GENERATIVE).build()).datasetId("my-dataset-id").build()).build());
+        CreateFinetunedModelResponse response = cohere.finetuning().createFinetunedModel(FinetunedModel.builder().name("test-finetuned-model").settings(Settings.builder().baseModel(BaseModel.builder().baseType(BaseType.BASE_TYPE_CHAT).build()).datasetId("my-dataset-id").build()).build());
 
         System.out.println(response);
     }

--- a/snippets/snippets/java/app/src/main/java/finetuning/UpdateFinetunedModel.java
+++ b/snippets/snippets/java/app/src/main/java/finetuning/UpdateFinetunedModel.java
@@ -12,7 +12,7 @@ public class UpdateFinetunedModel {
     public static void main(String[] args) {
         Cohere cohere = Cohere.builder().token("<<apiKey>>").clientName("snippet").build();
 
-        UpdateFinetunedModelResponse response = cohere.finetuning().updateFinetunedModel("test-id", FinetuningUpdateFinetunedModelRequest.builder().name("new name").settings(Settings.builder().baseModel(BaseModel.builder().baseType(BaseType.BASE_TYPE_GENERATIVE).build()).datasetId("my-dataset-id").build()).build());
+        UpdateFinetunedModelResponse response = cohere.finetuning().updateFinetunedModel("test-id", FinetuningUpdateFinetunedModelRequest.builder().name("new name").settings(Settings.builder().baseModel(BaseModel.builder().baseType(BaseType.BASE_TYPE_CHAT).build()).datasetId("my-dataset-id").build()).build());
 
         System.out.println(response);
     }

--- a/snippets/snippets/node/finetuning/create-finetuned-model.ts
+++ b/snippets/snippets/node/finetuning/create-finetuned-model.ts
@@ -9,7 +9,7 @@ const cohere = new CohereClient({
     name: 'test-finetuned-model',
     settings: {
       base_model: {
-        base_type: Cohere.Finetuning.BaseType.BaseTypeGenerative,
+        base_type: Cohere.Finetuning.BaseType.BaseTypeChat,
       },
       dataset_id: 'test-dataset-id',
     },

--- a/snippets/snippets/python-async/dataset-post.py
+++ b/snippets/snippets/python-async/dataset-post.py
@@ -8,9 +8,9 @@ async def main():
 
     # upload a dataset
     response = await co.datasets.create(
-        name="prompt-completion-dataset",
-        data=open("./prompt-completion.jsonl", "rb"),
-        type="prompt-completion-finetune-input",
+        name="chat-dataset",
+        data=open("./chat.jsonl", "rb"),
+        type="chat-finetune-input",
     )
 
     # wait for validation to complete

--- a/snippets/snippets/python/dataset-post.py
+++ b/snippets/snippets/python/dataset-post.py
@@ -4,9 +4,9 @@ co = cohere.Client("<<apiKey>>")
 
 # upload a dataset
 my_dataset = co.datasets.create(
-    name="prompt-completion-dataset",
-    data=open("./prompt-completion.jsonl", "rb"),
-    type="prompt-completion-finetune-input",
+    name="chat-dataset",
+    data=open("./chat.jsonl", "rb"),
+    type="chat-finetune-input",
 )
 
 # wait for validation to complete


### PR DESCRIPTION
- fix: include missing imports for update_finetuned_model
- fix: multiple dataset api snippets
- fix: async create_finetuned_model
- fix: end `)` for print statements in classify finetune docs
- move from generative to chat finetune type in api examples / spec