### PR TITLE
remove `.code-block` from custom css to fix code block rendering in dark mode

### DIFF
--- a/fern/assets/input.css
+++ b/fern/assets/input.css
@@ -622,16 +622,6 @@ button[class^="Sidebar-link-buttonWrapper"] {
   width: 100px !important; /* Adjust the width as needed */
   /*height: 20px !important;*/ /* Adjust the height as needed */
 }
-.code-block {
-  background-color: rgb(233 230 222) !important;
-  border-width: 1px !important;
-  border-style: solid !important;
-  border-color: rgb(228 222 210) !important;
-  display: block !important;
-  overflow: auto !important;
-  padding: 1em !important;
-  border-radius:3px !important;
-}
 
 .extra-yellow {
   color: #a31515 !important;


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request removes the styling for the ``.code-block`` class, which previously had a light yellow background with a solid border. 

## File Changes
- `fern/assets/input.css`: Removes the ``.code-block`` class selector and its associated styles.

<!-- end-generated-description -->