### PR TITLE
Remove font color on fern-mdx-link

### DIFF
--- a/fern/assets/input.css
+++ b/fern/assets/input.css
@@ -32,7 +32,6 @@ h2 {
 
 .fern-mdx-link {
   font-weight: 400 !important;
-  color: rgb(57 89 77) !important;
 }
 
 .font-semibold {


### PR DESCRIPTION
To improve color accessibility in dark mode, removing the font color on `.fern-mdx-link` will default to a generated primary accent color (a brighter green) that adheres to WCAG's color contrast standards.


| Before | After |
| ----- | ----- |
| <img width="738" alt="Screenshot 2024-09-03 at 10 02 03 AM" src="https://github.com/user-attachments/assets/50870a26-dfe0-449b-aa43-75cbd655c77b"> | <img width="756" alt="Screenshot 2024-09-03 at 10 03 25 AM" src="https://github.com/user-attachments/assets/046ad6a6-2767-4a42-a637-5d567918d0c7"> |
