### PR TITLE
Add note on credit

### DIFF
--- a/fern/pages/models/the-command-family-of-models/command-r-plus.mdx
+++ b/fern/pages/models/the-command-family-of-models/command-r-plus.mdx
@@ -89,3 +89,6 @@ Command R+ has been trained with multi-step tool use capabilities, with which it
 ## Temporary Context Window Caveat
 
 We have a known issue where prompts between 112K - 128K in length result in bad generations. We are working to get this resolved, and we appreciate your patience in the meantime.
+
+---
+Congrats on reaching the end of this page! Get an extra $1 API credit by entering the `CommandR+Docs` credit code in [your Cohere dashboard](https://dashboard.cohere.com/billing?tab=payment)


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR adds a new section to the end of the page, congratulating the reader on reaching the end and offering an API credit.

- A new section is added to the end of the page.
- The section congratulates the reader on reaching the end of the page.
- It offers an extra $1 API credit to the reader.
- The reader can enter the `CommandR+Docs` credit code in their Cohere dashboard to claim the credit.

<!-- end-generated-description -->