### PR TITLE
chore(finetuning): doc fixes

### DIFF
--- a/cohere-openapi.yaml
+++ b/cohere-openapi.yaml
@@ -14802,7 +14802,7 @@ paths:
                             name="test-finetuned-model",
                             settings=Settings(
                                 base_model=BaseModel(
-                                    base_type=BaseType.BASE_TYPE_CHAT,
+                                    base_type="BASE_TYPE_CHAT",
                                 ),
                                 dataset_id="my-dataset-id",
                             ),

--- a/snippets/python-async/finetuning/create-finetuned-model.py
+++ b/snippets/python-async/finetuning/create-finetuned-model.py
@@ -1,6 +1,5 @@
 from cohere.finetuning import (
     BaseModel,
-    BaseType,
     FinetunedModel,
     Settings,
 )
@@ -16,7 +15,7 @@ async def main():
             name="test-finetuned-model",
             settings=Settings(
                 base_model=BaseModel(
-                    base_type=BaseType.BASE_TYPE_CHAT,
+                    base_type="BASE_TYPE_CHAT",
                 ),
                 dataset_id="my-dataset-id",
             ),

--- a/snippets/snippets/python-async/finetuning/create-finetuned-model.py
+++ b/snippets/snippets/python-async/finetuning/create-finetuned-model.py
@@ -16,7 +16,7 @@ async def main():
             name="test-finetuned-model",
             settings=Settings(
                 base_model=BaseModel(
-                    base_type=BaseType.BASE_TYPE_CHAT,
+                    base_type="BASE_TYPE_CHAT",
                 ),
                 dataset_id="my-dataset-id",
             ),


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the `base_type` attribute in the `BaseModel` class to use a string value instead of an enum value.

- In cohere-openapi.yaml, the `base_type` attribute in the `BaseModel` class is changed from `BaseType.BASE_TYPE_CHAT` to `"BASE_TYPE_CHAT"</co: 0>`.
- In create-finetuned-model.py, the `base_type` attribute in the `BaseModel` class is changed from `BaseType.BASE_TYPE_CHAT` to `"BASE_TYPE_CHAT"</co: 1,2>`.

<!-- end-generated-description -->