### PR TITLE
Update Oracle Models

### DIFF
--- a/fern/pages/models/models.mdx
+++ b/fern/pages/models/models.mdx
@@ -57,11 +57,11 @@ In this table, we provide some important context for using Cohere Command models
 
 | Model Name              | Amazon Bedrock Model ID         | Amazon SageMaker      | Azure AI Studio Model ID | Oracle OCI Generative AI Service |
 | :---------------------- | :------------------------------ | :-------------------- | :----------------------- | :------------------------------- |
-| `command-r-plus`        | `cohere.command-r-plus-v1:0`    | Unique per deployment | Unique per deployment    | Coming soon!                     |
-| `command-r`             | `cohere.command-r-v1:0`         | Unique per deployment | Unique per deployment    | Coming soon!                     |
-| `command`               | `cohere.command-text-v14`       | N/A                   | N/A                      | `cohere.command`                 |
+| `command-r-plus`        | `cohere.command-r-plus-v1:0`    | Unique per deployment | Unique per deployment    | `cohere.command-r-plus v1.2`     |
+| `command-r`             | `cohere.command-r-v1:0`         | Unique per deployment | Unique per deployment    | `cohere.command-r-16k v1.2`      |
+| `command`               | `cohere.command-text-v14`       | N/A                   | N/A                      | `cohere.command v15.6`           |
 | `command-nightly`       | N/A                             | N/A                   | N/A                      | N/A                              |
-| `command-light`         | `cohere.command-light-text-v14` | N/A                   | N/A                      | `cohere.command-light`           |
+| `command-light`         | `cohere.command-light-text-v14` | N/A                   | N/A                      | `cohere.command-light v15.6`     |
 | `command-light-nightly` | N/A                             | N/A                   | N/A                      | N/A                              |
 |                         |                                 |                       |                          |                                  |
 


### PR DESCRIPTION

[GRO-2081 Update status for R and R+ on OCI from 'coming soon'](https://linear.app/cohereai/issue/GRO-2081/update-status-for-r-and-r-on-oci-from-coming-soon)
<!-- begin-generated-description -->

This PR updates the Amazon Bedrock Model IDs and Oracle OCI Generative AI Service IDs for the `command-r-plus`, `command-r`, and `command` models.

- The `command-r-plus` model ID has been updated to `cohere.command-r-plus-v1:0` and the Oracle OCI Generative AI Service ID to `cohere.command-r-plus v1.2`.
- The `command-r` model ID remains the same, but the Oracle OCI Generative AI Service ID has been updated to `cohere.command-r-16k v1.2`.
- The `command` model ID remains the same, but the Oracle OCI Generative AI Service ID has been updated to `cohere.command v15.6`.
- The `command-light` model ID remains the same, but the Oracle OCI Generative AI Service ID has been updated to `cohere.command-light v15.6`.

<!-- end-generated-description -->