### PR TITLE
Color of the links - dark mode

### DIFF
--- a/fern/assets/input.css
+++ b/fern/assets/input.css
@@ -32,7 +32,6 @@ h2 {
 
 .fern-mdx-link {
   font-weight: 400 !important;
-  color: rgb(57 89 77) !important;
 }
 
 .font-semibold {


### PR DESCRIPTION
[GRO-2073](https://linear.app/cohereai/issue/GRO-2073/adjust-green-text-contrast-in-dark-mode-documentation)

<!-- begin-generated-description -->

This PR removes the `color` property from the `.fern-mdx-link` class in the `input.css` file.

- The `color` property is no longer set to `rgb(57 89 77)`.

<!-- end-generated-description -->