### PR TITLE
docs(finetuning): remove all usages of the verb fine-tune as an adjective or a noun

### DIFF
--- a/fern/pages/fine-tuning/chat-fine-tuning/chat-starting-the-training.mdx
+++ b/fern/pages/fine-tuning/chat-fine-tuning/chat-starting-the-training.mdx
@@ -92,11 +92,11 @@ If you are happy with how the samples look, click on 'Continue' at the bottom of
 
 ### Pricing
 
-This page gives an estimated cost of your finetune. Please see our [latest pricing](https://cohere.com/pricing) for more information.
+This page gives an estimated cost of your fine-tuning job. Please see our [latest pricing](https://cohere.com/pricing) for more information.
 
 <img src='../../../assets/images/b8ddffe-guide-chat-pricing.png' />
 
-Click next to finalize your fine-tune.
+Click next to finalize your fine-tuning job.
 
 ### Start Training
 
@@ -108,7 +108,7 @@ As the training proceeds you'll receive updates with various accuracy and loss m
 
 ## Using the Python SDK
 
-In addition to using the [Web UI](/docs/fine-tuning-with-the-web-ui) for fine-tuning models, customers can also kick off fine-tuning jobs programmatically using the [Cohere Python SDK](https://pypi.org/project/cohere/). This can be useful for fine-tunes that happen on a regular cadence, such as nightly jobs on newly-acquired data.
+In addition to using the [Web UI](/docs/fine-tuning-with-the-web-ui) for fine-tuning models, customers can also kick off fine-tuning jobs programmatically using the [Cohere Python SDK](https://pypi.org/project/cohere/). This can be useful for fine-tuning jobs that happen on a regular cadence, such as nightly jobs on newly-acquired data.
 
 ## Prepare your Dataset
 
@@ -195,16 +195,16 @@ To train a custom model, please see the example below for parameters to pass to 
   - `early_stopping_threshold` (float) How much the loss must improve to prevent early stopping. Must be between 0.001 and 0.1. Defaults to **0.001**.
   - `early_stopping_patience` (int) Stops training if the loss metric does not improve beyond the value of `early_stopping_threshold` after this many rounds of evaluation. Must be between 0 and 10. Defaults to **10**.
 
-You can optionally publish the training metrics and hyper parameter values to your [Weights and Biases](https://wandb.ai) account using the `wandb` parameter. This is currently only supported for chat type finetunes. 
+You can optionally publish the training metrics and hyper parameter values to your [Weights and Biases](https://wandb.ai) account using the `wandb` parameter. This is currently only supported when fine-tuning a Chat model.
 
 - `wandb` (cohere.finetuning.WandbConfig) - The Weights & Biases configuration.
   - `project` (string) The Weights and Biases project to be used during training. This parameter is mandatory.
-  - `api_key` (string) The Weights and Biases API key to be used during training. This parameter is mandatory and will always be stored encrypted and auto-deleted after the finetune creation is complete.
+  - `api_key` (string) The Weights and Biases API key to be used during training. This parameter is mandatory and will always be stored securely and automatically deleted after the fine-tuning job completes training.
   - `entity` (string) The Weights and Biases API entity to be used during training. When not specified, it will assume the default entity for that API key.
 
-When the configuration is valid, the Run ID will correspond to the finetune ID, and Run display name will be the name of the finetune specified during creation. When specifying a invalid Weights and Biases configuration, finetune creation will proceed but nothing will be logged to your Weights and Biases.
+When the configuration is valid, the Run ID will correspond to the fine-tuned model ID, and Run display name will be the name of the fine-tuned model specified during creation. When specifying a invalid Weights and Biases configuration, the fine-tuned model creation will proceed but nothing will be logged to your Weights and Biases.
 
-Once a finetune has been created with a specified Weights and Biases configuration, you may view the finetune run via the Weights and Biases dashboard. It will be available via the following URL: `https://wandb.ai/<your-entity>/<your-project>/runs/<finetune-id>`.
+Once a fine-tuned model has been created with a specified Weights and Biases configuration, you may view the fine-tuning job run via the Weights and Biases dashboard. It will be available via the following URL: `https://wandb.ai/<your-entity>/<your-project>/runs/<finetuned-model-id>`.
 
 ## Example
 
@@ -233,7 +233,7 @@ wnb_config = WandbConfig(
     entity="test-entity",
 )
 
-my_finetune = co.finetuning.create_finetuned_model(
+create_response = co.finetuning.create_finetuned_model(
   request=FinetunedModel(
     name="customer-service-chat-model",
     settings=Settings(
@@ -252,7 +252,7 @@ my_finetune = co.finetuning.create_finetuned_model(
 
 Once your model completes training, you can call it via [co.chat()](/docs/cochat-beta) and pass your custom model's `model_id`.
 
-Please note, the `model_id` is the `id` returned by the finetuned object with the `"-ft"` suffix.
+Please note, the `model_id` is the `id` returned by the fine-tuned model object with the `"-ft"` suffix.
 
 `co.chat()` uses no preamble by default for fine-tuned models. You can specify a preamble using the `preamble` parameter. Note that for the `model` parameter, you must pass the finetune's id with `"-ft"` appended to the end.
 
@@ -264,12 +264,12 @@ Here's a Python script to make this clearer:
 import cohere
 
 co = cohere.Client('Your API key')
-# get the finetuned model object
-ft = co.finetuning.get_finetuned_model(my_finetune.finetuned_model.id)
+# get the fine-tuned model object
+get_response = co.finetuning.get_finetuned_model(create_response.finetuned_model.id)
 
 response = co.chat(
   message="Hi there",
-  model=ft.finetuned_model.id+"-ft",
+  model=get_response.finetuned_model.id+"-ft",
   # optional (to specify a preamble)
   preamble="You are a chatbot trained to answer to my every question. Answer every question with full sentences.",
   # optional
@@ -286,7 +286,7 @@ After your first message with the model, an `id` field will be returned which yo
 # Continuing the above conversation with `response.id`.
 response_2 = co.chat(
   message="How are you?",
-  model=ft.finetuned_model.id+"-ft",
+  model=get_response.finetuned_model.id+"-ft",
   # optional (to specify a preamble)
   preamble_override="You are a chatbot trained to answer to my every question. Answer every question with full sentences",
   # optional

--- a/fern/pages/fine-tuning/classify-fine-tuning/classify-preparing-the-data.mdx
+++ b/fern/pages/fine-tuning/classify-fine-tuning/classify-preparing-the-data.mdx
@@ -12,12 +12,12 @@ updatedAt: "Wed Apr 03 2024 15:23:42 GMT+0000 (Coordinated Universal Time)"
 ---
 In this section, we will walk through how you can prepare your data for fine-tuning models for Classification.
 
-For classification fine-tunes we can choose between two types of datasets:
+For classification fine-tuning jobs we can choose between two types of datasets:
 
 1. Single-label data
 2. Multi-label data
 
-To be able to start a fine-tune you need at least **40** examples. Each label needs to have at least **5** examples and there should be at least **2** unique labels.
+To be able to start a fine-tuning job, you need at least **40** examples. Each label needs to have at least **5** examples and there should be at least **2** unique labels.
 
 ### Single-label Data
 

--- a/fern/pages/fine-tuning/classify-fine-tuning/classify-starting-the-training.mdx
+++ b/fern/pages/fine-tuning/classify-fine-tuning/classify-starting-the-training.mdx
@@ -85,7 +85,7 @@ Text classification is one of the most common language understanding tasks. A lo
 
 ## Create a New Fine-tuned Model
 
-In addition to using the Web UI for fine-tuning models, customers can also kick off fine-tuning jobs programmatically using the [Cohere Python SDK](https://pypi.org/project/cohere/). This can be useful for fine-tunes that happen on a regular cadence, such as nightly jobs on newly-acquired data.
+In addition to using the Web UI for fine-tuning models, customers can also kick off fine-tuning jobs programmatically using the [Cohere Python SDK](https://pypi.org/project/cohere/). This can be useful for fine-tuning jobs that happen on a regular cadence, such as nightly jobs on newly-acquired data.
 
 Using `co.finetuning.create_finetuned_model()`, you can create a fine-tuned model using either a single-label or multi-label dataset.
 
@@ -93,7 +93,7 @@ Using `co.finetuning.create_finetuned_model()`, you can create a fine-tuned mode
 
 Here are some example code snippets for you to use.
 
-### Starting a Single-label Fine-tune
+### Starting a single-label fine-tuning job
 
 ```python PYTHON
 # create dataset
@@ -103,8 +103,8 @@ single_label_dataset = co.datasets.create(name="single-label-dataset",
                                           parse_info=ParseInfo(delimiter=",")) # parse_info is optional
 print(single_label_dataset.await_validation())
                                               
-# start the fine-tune job using this dataset
-finetune = co.finetuning.create_finetuned_model(
+# start the fine-tuning job using this dataset
+create_response = co.finetuning.create_finetuned_model(
   request=FinetunedModel(
     name="single-label-ft",
     settings=Settings(
@@ -116,10 +116,10 @@ finetune = co.finetuning.create_finetuned_model(
   ),
 )
 
-print(f"fine-tune ID: {finetune.id}, fine-tune status: {finetune.status}")
+print(f"fine-tuned model ID: {create_response.finetuned_model.id}, fine-tuned model status: {create_response.finetuned_model.status}")
 ```
 
-### Starting a Multi-label Fine-tune
+### Starting a multi-label fine-tuning job
 
 ```python PYTHON
 # create dataset
@@ -129,8 +129,8 @@ multi_label_dataset = co.create_dataset(name="multi-label-dataset",
   
 print(multi_label_dataset.await_validation())
                                               
-# start the fine-tune job using this dataset
-finetune = co.finetuning.create_finetuned_model(
+# start the fine-tuning job using this dataset
+create_response = co.finetuning.create_finetuned_model(
   request=FinetunedModel(
     name="single-label-ft",
     settings=Settings(
@@ -142,21 +142,20 @@ finetune = co.finetuning.create_finetuned_model(
   ),
 )
 
-print(f"fine-tune ID: {finetune.id}, fine-tune status: {finetune.status}")
+print(f"fine-tuned model ID: {create_response.finetuned_model.id}, fine-tuned model status: {create_response.finetuned_model.status}")
 ```
 
-### Calling a fine-tune
+### Calling a fine-tuned model
 
 ```python PYTHON
 import cohere
 
 co = cohere.Client('Your API key')
-# get the custom model object
-ft = co.finetuning.get_finetuned_model(finetune.finetuned_model.id)
+get_response = co.finetuning.get_finetuned_model(create_response.finetuned_model.id)
 
 response = client.classify(
     inputs=["classify this!"],
-    model=ft.id+"-ft",
+    model=get_response.finetuned_model.id+"-ft",
 )
 
 # Printing the model's response.

--- a/fern/pages/fine-tuning/fine-tuning-on-aws/fine-tuning-cohere-models-on-amazon-bedrock.mdx
+++ b/fern/pages/fine-tuning/fine-tuning-on-aws/fine-tuning-cohere-models-on-amazon-bedrock.mdx
@@ -18,9 +18,9 @@ Customers can kick off fine-tuning jobs by completing the data preparation and v
 
 # Preparing your data
 
-Before a fine-tune job can be started, users must upload a dataset with training and (optionally) evaluation data. The structure of the data for fine-tuning on Amazon Bedrock should be `jsonl`. Read more about preparing the training data for generative fine-tuning on Bedrock [here](https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-prepare.html).
+Before a fine-tuning job can be started, users must upload a dataset with training and (optionally) evaluation data. The structure of the data for fine-tuning on Amazon Bedrock should be `jsonl`. Read more about preparing the training data for generative fine-tuning on Bedrock [here](https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-prepare.html).
 
-To be able to start a fine-tune job, your dataset must contain at least **32** examples. 
+To be able to start a fine-tuning job, your dataset must contain at least **32** examples.
 
 ### Data format
 
@@ -41,9 +41,9 @@ The context length for prompt and a completion pair is 4096 tokens using our tok
 
 # Starting the Chat Fine-tuning
 
-After uploading the dataset, the fine-tune job can begin. 
+After uploading the dataset, the fine-tuning job can begin.
 
-The Bedrock fine-tune job requires:
+The Bedrock fine-tuning job requires:
 
 - an s3 path to the uploaded train dataset
 - an optional s3 path to the eval dataset
@@ -93,19 +93,19 @@ You will be able to see your training job overview as illustrated below.
 <img src='../../../assets/images/577d1cd-start-training.png' />
 
 
-You will receive an email notification when the fine-tune job has completed training. You can explore the evaluation metrics using the AWS Console. Learn more [here](https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-analyze.html). 
+You will receive an email notification when the fine-tuning job has completed training. You can explore the evaluation metrics using the AWS Console. Learn more [here](https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-analyze.html). 
 
-### Fine-tune Job Statuses
+### Fine-tuning Job Statuses
 
-As your fine-tune job runs, it will [progress through various stages](https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-monitor.html). The following table describes the meaning of the various status messages you might encounter. You can also [stop your fine-tuning job](https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-stop.html) while it is in progress. 
+As your fine-tuning job runs, it will [progress through various stages](https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-monitor.html). The following table describes the meaning of the various status messages you might encounter. You can also [stop your fine-tuning job](https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-stop.html) while it is in progress.
 
-| Status      | Meaning                                                                                                                         |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| In Progress | Fine-tune job is in progress                                                                                                    |
-| Stopping    | The Fine-tune job is in the process of stopping.                                                                                |
-| Stopped     | Fine-tune job is currently stopped.                                                                                             |
-| Completed   | Fine-tune job has finished and is ready to be called.                                                                           |
-| Failed      | Fine-tune job has failed. Please contact customer support if you need more help in understanding why your fine-tune has failed. |
+| Status      | Meaning                                                                                                                        |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| In Progress | The Fine-tuning job is in progress                                                                                             |
+| Stopping    | The Fine-tuning job is in the process of stopping.                                                                             |
+| Stopped     | The Fine-tuning job is currently stopped.                                                                                      |
+| Completed   | The Fine-tuning job has finished and is ready to be called.                                                                    |
+| Failed      | The Fine-tuning job has failed. Please contact customer support if you need more help in understanding why the job has failed. |
 
 ## Calling the Fine-tuned Model
 
@@ -113,6 +113,6 @@ In order to call the model -- that is, to use it for inference -- you will need 
 
 # Cohere's AWS SDK
 
-In addition to the Bedrock UI, customers are also able to create programatic fine-tunes using the [Cohere AWS SDK](https://github.com/cohere-ai/cohere-aws). The SDK exposes methods to create fine-tune jobs, monitor progress, provision throughput, and invoke the fine-tuned model. If you would prefer to use the AWS CLI or the AWS Python SDK you can learn more about how to do that [here](https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-inference.html). 
+In addition to the Bedrock UI, customers are also able to create programatic fine-tuning jobs using the [Cohere AWS SDK](https://github.com/cohere-ai/cohere-aws). The SDK exposes methods to create fine-tuning jobs, monitor progress, provision throughput, and invoke the fine-tuned model. If you would prefer to use the AWS CLI or the AWS Python SDK you can learn more about how to do that [here](https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-inference.html).
 
-## Start a fine-tune job
+## Start a fine-tuning job

--- a/fern/pages/fine-tuning/fine-tuning-on-aws/fine-tuning-cohere-models-on-amazon-sagemaker.mdx
+++ b/fern/pages/fine-tuning/fine-tuning-on-aws/fine-tuning-cohere-models-on-amazon-sagemaker.mdx
@@ -16,7 +16,7 @@ Please see [our jupyter notebook](<>) for step by step instructions.
 
 # Preparing your data
 
-Before a fine-tune job can be started, users must upload a dataset with training and (optionally) evaluation data. The structure of the data for fine-tuning on Amazon Sagemaker should be `jsonl`. Read more about preparing the training data for chat fine-tuning in our docs: [Preparing the Chat Fine-tuning Data](/docs/chat-preparing-the-data).
+Before a fine-tuning job can be started, users must upload a dataset with training and (optionally) evaluation data. The structure of the data for fine-tuning on Amazon Sagemaker should be `jsonl`. Read more about preparing the training data for chat fine-tuning in our docs: [Preparing the Chat Fine-tuning Data](/docs/chat-preparing-the-data).
 
 ### Data format
 
@@ -57,9 +57,9 @@ You'll need your input data to be in jsonl file, in our chat format. Please see 
 
 # Starting the Chat Fine-tuning
 
-After uploading the dataset, the fine-tune job can begin. 
+After uploading the dataset, the fine-tuning job can begin.
 
-The Sagemaker fine-tune job requires:
+The Sagemaker fine-tuning job requires:
 
 - an s3 path to the uploaded train dataset
 - an optional s3 path to the eval dataset
@@ -99,28 +99,28 @@ Choose 'Create Fine-tuning job' to begin the job.
 
 You will be able to see your training job overview as illustrated below. 
 
-You will receive an email notification when the fine-tune job has completed training. You can explore the evaluation metrics using the AWS Console. Learn more [here](https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-analyze.html). 
+You will receive an email notification when the fine-tuning job has completed training. You can explore the evaluation metrics using the AWS Console. Learn more [here](https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-analyze.html). 
 
-### Fine-tune Job Statuses
+### Fine-tuning Job Statuses
 
-As your fine-tune job runs, it will [progress through various stages](<>). The following table describes the meaning of the various status messages you might encounter. You can also [stop your fine-tuning job](<>) while it is in progress. 
+As your fine-tuning job runs, it will [progress through various stages](<>). The following table describes the meaning of the various status messages you might encounter. You can also [stop your fine-tuning job](<>) while it is in progress. 
 
-| Status      | Meaning                                                                                                                         |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| In Progress | Fine-tune job is in progress                                                                                                    |
-| Stopping    | The Fine-tune job is in the process of stopping.                                                                                |
-| Stopped     | Fine-tune job is currently stopped.                                                                                             |
-| Completed   | Fine-tune job has finished and is ready to be called.                                                                           |
-| Failed      | Fine-tune job has failed. Please contact customer support if you need more help in understanding why your fine-tune has failed. |
+| Status      | Meaning                                                                                                                        |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| In Progress | The fine-tuning job is in progress                                                                                             |
+| Stopping    | The fine-tuning job is in the process of stopping.                                                                             |
+| Stopped     | The fine-tuning job is currently stopped.                                                                                      |
+| Completed   | The fine-tuning job has finished and is ready to be called.                                                                    |
+| Failed      | The fine-tuning job has failed. Please contact customer support if you need more help in understanding why the job has failed. |
 
 ## Calling the Fine-tuned Model
 
 # Cohere's AWS SDK
 
-In addition to the Sagemaker UI, customers are also able to create programatic fine-tunes using the [Cohere AWS SDK](https://github.com/cohere-ai/cohere-aws). The SDK exposes methods to create fine-tune jobs, monitor progress, and invoke the fine-tuned model. Please see the following ipython notebooks:
+In addition to the Sagemaker UI, customers are also able to create programatic fine-tuning job using the [Cohere AWS SDK](https://github.com/cohere-ai/cohere-aws). The SDK exposes methods to create fine-tuning jobs, monitor progress, and invoke the fine-tuned model. Please see the following ipython notebooks:
 
 - [Command finetuning jupyter notebook](https://github.com/cohere-ai/cohere-aws/blob/main/notebooks/sagemaker/Run%20command%20generative%20finetuning.ipynb)
 
-## Start a fine-tune job
+## Start a fine-tuning job
 
 Please see the notebooks above for full import paths, arns, and explanations.

--- a/fern/pages/fine-tuning/fine-tuning-with-the-cohere-dashboard.mdx
+++ b/fern/pages/fine-tuning/fine-tuning-with-the-cohere-dashboard.mdx
@@ -15,28 +15,26 @@ Customers can kick off fine-tuning jobs by completing the data preparation and v
 
 ## Datasets
 
-Before a fine-tune job can be started, users must upload a [dataset](/docs/datasets) with training and (optionally) evaluation data. The contents and structure of the dataset will vary depending on the type of fine-tuning. Read more about preparing the training data for [Chat](/docs/chat-preparing-the-data), [Classify](/docs/classify-preparing-the-data), and [Rerank](/docs/rerank-preparing-the-data) fine-tuning.
+Before a fine-tuning job can be started, users must upload a [dataset](/docs/datasets) with training and (optionally) evaluation data. The contents and structure of the dataset will vary depending on the type of fine-tuning. Read more about preparing the training data for [Chat](/docs/chat-preparing-the-data), [Classify](/docs/classify-preparing-the-data), and [Rerank](/docs/rerank-preparing-the-data) fine-tuning.
 
 Your Datasets can be managed in the [Datasets dashboard](https://dashboard.cohere.com/datasets).
 
-## Starting a Fine-tune job
+## Starting a Fine-tuning job
 
-After uploading the dataset and going through the validation and review data phases in the UI, the fine-tune job can begin. Read more about starting the fine-tuning jobs for [Chat](/docs/chat-starting-the-training), [Classify](/docs/classify-starting-the-training), and [Rerank](/docs/rerank-starting-the-training).
+After uploading the dataset and going through the validation and review data phases in the UI, the fine-tuning job can begin. Read more about starting the fine-tuning jobs for [Chat](/docs/chat-starting-the-training), [Classify](/docs/classify-starting-the-training), and [Rerank](/docs/rerank-starting-the-training).
 
-## Fine-tune results
+## Fine-tuning results
 
-You will receive an email notification when the fine-tune model is ready. You can explore the evaluation metrics using the [Dashboard](http://dashboard.cohere.com/fine-tuning) and try out your model using one of our APIs on the interactive [Playground](https://dashboard.cohere.com/playground/).
+You will receive an email notification when the fine-tuned model is ready. You can explore the evaluation metrics using the [Dashboard](http://dashboard.cohere.com/fine-tuning) and try out your model using one of our APIs on the interactive [Playground](https://dashboard.cohere.com/playground/).
 
-## Fine-tune job statuses
+## Fine-tuning job statuses
 
-As your fine-tune job progresses, it will progress through various stages. The following table describes the meaning of the various status messages you might encounter:
+As your fine-tuning job progresses, it will progress through various stages. The following table describes the meaning of the various status messages you might encounter:
 
-| Status    | Meaning                                                                                                                         |
-| :-------- | :------------------------------------------------------------------------------------------------------------------------------ |
-| Queued    | Fine-tune job is queued to start.                                                                                               |
-| Created   | Fine-tune job has been created and will start training soon.                                                                    |
-| Training  | Fine-tune job is currently training.                                                                                            |
-| Deploying | Fine-tune job has finished training and is deploying the model endpoint.                                                        |
-| Ready     | Fine-tune job has finished and is ready to be called.                                                                           |
-| Asleep    | Fine-tune job has been paused. To wake the model, you can select the "Wake Model" button on the Status tab.                     |
-| Failed    | Fine-tune job has failed. Please contact customer support if you need more help in understanding why your fine-tune has failed. |
+| Status    | Meaning                                                                                                                        |
+| :-------- | :----------------------------------------------------------------------------------------------------------------------------- |
+| Queued    | The fine-tuning job is queued and will start training soon.                                                                    |
+| Training  | The fine-tuning job is currently training.                                                                                     |
+| Deploying | The fine-tuning job has finished training and is deploying the model endpoint.                                                 |
+| Ready     | The fine-tuning job has finished and is ready to be called.                                                                    |
+| Failed    | The fine-tuning job has failed. Please contact customer support if you need more help in understanding why the job has failed. |

--- a/fern/pages/fine-tuning/fine-tuning-with-the-python-sdk.mdx
+++ b/fern/pages/fine-tuning/fine-tuning-with-the-python-sdk.mdx
@@ -10,11 +10,11 @@ keywords: "python, fine-tuning, fine-tuning large language models"
 createdAt: "Fri Nov 10 2023 18:29:56 GMT+0000 (Coordinated Universal Time)"
 updatedAt: "Thu May 09 2024 02:54:41 GMT+0000 (Coordinated Universal Time)"
 ---
-In addition to using the [Web UI](/docs/fine-tuning-with-the-web-ui) for fine-tuning models, customers can also kick off fine-tuning jobs programmatically using the [Fine-tuning API](/reference/listfinetunedmodels) or via the [Cohere Python SDK](https://pypi.org/project/cohere/). This can be useful for fine-tunes that happen on a regular cadence, such as fine-tuning nightly on newly-acquired data.
+In addition to using the [Web UI](/docs/fine-tuning-with-the-web-ui) for fine-tuning models, customers can also kick off fine-tuning jobs programmatically using the [Fine-tuning API](/reference/listfinetunedmodels) or via the [Cohere Python SDK](https://pypi.org/project/cohere/). This can be useful for fine-tuning jobs that happen on a regular cadence, such as fine-tuning nightly on newly-acquired data.
 
 ## Datasets
 
-Before a fine-tune job can be started, users must upload a [Dataset](/docs/datasets) with training and (optionally) evaluation data. The contents and structure of the dataset will vary depending on the type of fine-tuning. Read more about preparing the training data for [Chat](/docs/chat-preparing-the-data), [Classify](/docs/classify-preparing-the-data), and [Rerank](/docs/rerank-preparing-the-data) fine-tuning.
+Before a fine-tuning job can be started, users must upload a [Dataset](/docs/datasets) with training and (optionally) evaluation data. The contents and structure of the dataset will vary depending on the type of fine-tuning. Read more about preparing the training data for [Chat](/docs/chat-preparing-the-data), [Classify](/docs/classify-preparing-the-data), and [Rerank](/docs/rerank-preparing-the-data) fine-tuning.
 
 The snippet below creates a dataset for fine-tuning a model on records of customer service interactions.
 
@@ -34,7 +34,7 @@ result = co.wait(my_dataset)
 
 ## Starting a Fine-tuning Job
 
-Below is an example of starting a fine-tune job of a generative model for Chat using a dataset of conversational data.
+Below is an example of starting a fine-tuning job of a generative model for Chat using a dataset of conversational data.
 
 ```python PYTHON
 from cohere.finetuning import FinetunedModel, Settings, BaseModel
@@ -55,5 +55,5 @@ finetuned_model = co.finetuning.create_finetuned_model(
 
 ## Fine-tuning results
 
-When the fine-tune model is ready you will receive an email notification. You can explore the evaluation metrics using the Dashboard and try out your model using one of our APIs on the [Playground](https://dashboard.cohere.com/playground/).
+When the fine-tuning model is ready you will receive an email notification. You can explore the evaluation metrics using the Dashboard and try out your model using one of our APIs on the [Playground](https://dashboard.cohere.com/playground/).
 

--- a/fern/pages/fine-tuning/rerank-fine-tuning/rerank-starting-the-training.mdx
+++ b/fern/pages/fine-tuning/rerank-fine-tuning/rerank-starting-the-training.mdx
@@ -76,7 +76,7 @@ Calling your fine-tuned model is currently not support via the Web UI. Please us
 
 ## Python SDK
 
-In addition to using the [Web UI](/docs/fine-tuning-with-the-web-ui) for fine-tuning models, customers can also kick off fine-tuning jobs programmatically using the [Cohere Python SDK](https://pypi.org/project/cohere/). This can be useful for fine-tunes that happen on a regular cadence, such as fine-tuning nightly on newly-acquired data.
+In addition to using the [Web UI](/docs/fine-tuning-with-the-web-ui) for fine-tuning models, customers can also kick off fine-tuning jobs programmatically using the [Cohere Python SDK](https://pypi.org/project/cohere/). This can be useful for fine-tuning jobs that happen on a regular cadence, such as fine-tuning nightly on newly-acquired data.
 
 Using the `co.finetuning.create_finetuned_model()` method of the Cohere client, you can kick off a training job that will result in a fine-tuned model.
 
@@ -84,7 +84,7 @@ Using the `co.finetuning.create_finetuned_model()` method of the Cohere client, 
 
 Here are some example code snippets for you to use.
 
-#### Starting a Fine-tune
+#### Starting a fine-tuning job
 
 ```python PYTHON
 # create dataset
@@ -93,8 +93,8 @@ rerank_dataset = co.datasets.create(name="rerank-dataset",
                                     type="reranker-finetune-input")
 print(co.wait(rerank_dataset))
                                               
-# start the fine-tune job using this dataset
-finetune = co.finetuning.create_finetuned_model(
+# start the fine-tuning job using this dataset
+create_response = co.finetuning.create_finetuned_model(
   request=FinetunedModel(
     name="rerank-ft",
     settings=Settings(
@@ -107,7 +107,7 @@ finetune = co.finetuning.create_finetuned_model(
   )
 )
 
-print(f"fine-tune ID: {finetune.id}, fine-tune status: {finetune.status}")
+print(f"fine-tuned model ID: {create_response.finetuned_model.id}, fine-tuned model status: {create_response.finetuned_model.status}")
 ```
 
 ### Parameters:
@@ -117,19 +117,19 @@ Please see our API docs for the full documentation, for passing the request. For
 - `base_type` -  For rerank, this should always be "BASE_TYPE_RERANK"
 - `name`(str) – The baseline rerank model you would like to train - we currently have two model options: english and multilingual. By default we will always train on the most recent version of the rerank models.
 
-### Calling a fine-tune
+### Calling a fine-tuned model
 
 ```python PYTHON
 import cohere
 
 co = cohere.Client('Your API key')
-# get the finetuned model object
-ft = co.finetuning.get_finetuned_model(my_finetune.finetuned_model.id)
+# get the fine-tuned model object
+get_response = co.finetuning.get_finetuned_model(create_response.finetuned_model.id)
 
 response = client.rerank(
     query="which one is the best doc?",
     documents=["this is the first doc", "this is the second doc"],
-    model=ft.finetuned_model.id+"-ft",
+    model=get_response.finetuned_model.id+"-ft",
 )
 
 # Printing the model's response.

--- a/fern/pages/fine-tuning/troubleshooting-a-fine-tuned-model.mdx
+++ b/fern/pages/fine-tuning/troubleshooting-a-fine-tuned-model.mdx
@@ -23,10 +23,6 @@ To use your trained model in our API or SDKs, you must call it by its model UUID
 
 _This is a screenshot of how to locate the model path to call your custom model._
 
-## Restarting A Paused Fine-tuned Model
-
-Rerank finetuned models are paused after 24 hours of inactivity. To restart your model, select your model in the trained models panel and click on the `Wake` button.
-
 ## Troubleshooting A Failed Training Run
 
 Our engineers review every individual failed training run and will attempt to rectify it, without any action on your part. We reach out to individuals with failed custom models we cannot resolve manually.


### PR DESCRIPTION
This PR introduces changes to the fine-tuning process, including updates to the terminology, dataset requirements, and job statuses. The changes aim to improve clarity and consistency in the documentation, ensuring a smoother experience for users.

- **Updated Terminology:** The PR replaces the term "fine-tune" with "fine-tuning job" throughout the documentation. This change provides a more accurate description of the process, emphasizing the job-like nature of fine-tuning tasks.
- **Dataset Requirements:** The PR updates the minimum dataset size requirements for various fine-tuning jobs. For classification fine-tuning jobs, the minimum number of examples is now **40**, with each label requiring at least **5** examples and at least **2** unique labels. For fine-tuning on Amazon Bedrock and Amazon Sagemaker, the minimum dataset size is **32** examples. These changes ensure that users have sufficient data for successful fine-tuning.
- **Job Statuses:** The PR introduces a new table for fine-tuning job statuses, providing a comprehensive overview of the various stages a job can go through. The table includes statuses such as "Queued," "Training," "Deploying," "Ready," and "Failed," offering users a clear understanding of the job's progress and potential issues.
- **Code Examples:** The PR updates code examples to reflect the changes in terminology and job statuses. This ensures that the examples align with the updated documentation, providing users with accurate and up-to-date guidance.

Closes FIN-675