### PR TITLE
preview v2

### DIFF
--- a/fern/v1.yml
+++ b/fern/v1.yml
@@ -576,25 +576,25 @@ navigation:
         api-name: v1
         audiences:
           - public
-          # - v2-beta
+          - v2-beta
         skip-slug: true
         flattened: true
         snippets:
           python: "cohere"
           typescript: "cohere-ai"
         layout:
-          # - section: V2 (beta)
-          #   skip-slug: true
-          #   contents:
-          #     - section: "/v2/chat"
-          #       skip-slug: true
-          #       contents:
-          #         - endpoint: POST /v2/chat
-          #           slug: chat-v2
-          #           title: Chat
-          #         - endpoint: STREAM /v2/chat
-          #           slug: chat-stream-v2
-          #           title: Chat with Streaming
+          - section: V2 (beta)
+            skip-slug: true
+            contents:
+              - section: "/v2/chat"
+                skip-slug: true
+                contents:
+                  - endpoint: POST /v2/chat
+                    slug: chat-v2
+                    title: Chat
+                  - endpoint: STREAM /v2/chat
+                    slug: chat-stream-v2
+                    title: Chat with Streaming
           - section: API Reference
             skip-slug: true
             contents:


### PR DESCRIPTION
<!-- begin-generated-description -->

The PR introduces changes to the `fern/v1.yml` file, specifically within the `navigation` section.

## Changes:
- Adds the `v2-beta` version to the `audiences` list.
- Includes a new `section` named `V2 (beta)` with two endpoints: `POST /v2/chat` and `STREAM /v2/chat`.

<!-- end-generated-description -->