### PR TITLE
Update chat-api.mdx - replaced string being passed to the "message" parameter

### DIFF
--- a/fern/pages/text-generation/chat-api.mdx
+++ b/fern/pages/text-generation/chat-api.mdx
@@ -117,7 +117,7 @@ response = co.chat(
     {"role": "USER", "text": "Hey, my name is Michael!"},
     {"role": "CHATBOT", "text": "Hey Michael! How can I help you today?"},
   ],
-  message="Can you tell me about LLMs?"
+  message=message
 )
 
 print(response.text) # "Sure thing Michael, LLMs are ..."


### PR DESCRIPTION
Update chat-api.mdx - replaced string being passed to the "message" parameter in the co.chat api call with the "message" object defined above.

section: https://docs.cohere.com/docs/chat-api#multi-turn-conversations