### PR TITLE
Update streaming.mdx - corrected typo in stream-end section

### DIFF
--- a/fern/pages/text-generation/streaming.mdx
+++ b/fern/pages/text-generation/streaming.mdx
@@ -40,7 +40,7 @@ The first event in the stream contains metadata for the request such as the `gen
 
 #### stream-end
 
-A `stream-end` event is the final event of the stream, and is returned only when streaming is finished. This event contains aggregated data from all the other events such as the complete `text`, as well as a `finish_reason` for why the stream ended (i.e. because of it was finished or there was an error). 
+A `stream-end` event is the final event of the stream, and is returned only when streaming is finished. This event contains aggregated data from all the other events such as the complete `text`, as well as a `finish_reason` to indicate why the stream ended (i.e. either because it finished or due to an error). 
 
 Only one `stream-end` event will be returned.
 


### PR DESCRIPTION
current: (i.e. because of it was finished or there was an error).

proposed: (i.e. because it finished or due to an error).

section: https://docs.cohere.com/docs/streaming#stream-end