### PR TITLE
(do not merge): test if previews on forks work

### DIFF
--- a/fern/v1.yml
+++ b/fern/v1.yml
@@ -1,6 +1,6 @@
 tabs:
   docs:
-    display-name: Guides and concepts
+    display-name: Guidess and concepts
     slug: docs
   api:
     display-name: API Reference


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request makes a small but significant change to the `display-name` of the `docs` tab in the `fern/v1.yml` file.

- The `display-name` of the `docs` tab has been changed from `Guides and concepts` to `Guidess and concepts`.

<!-- end-generated-description -->