### PR TITLE
fix: minor type for chat and rerank create_finetuned_model example

### DIFF
--- a/fern/pages/fine-tuning/chat-fine-tuning/chat-starting-the-training.mdx
+++ b/fern/pages/fine-tuning/chat-fine-tuning/chat-starting-the-training.mdx
@@ -240,7 +240,7 @@ create_response = co.finetuning.create_finetuned_model(
       base_model=BaseModel(
         base_type="BASE_TYPE_CHAT",
       ),
-      dataset_id=my-chat_dataset.id,
+      dataset_id=chat_dataset.id,
       hyperparameters=hp,
       wandb=wnb_config,
     ),

--- a/fern/pages/fine-tuning/rerank-fine-tuning/rerank-starting-the-training.mdx
+++ b/fern/pages/fine-tuning/rerank-fine-tuning/rerank-starting-the-training.mdx
@@ -102,7 +102,7 @@ create_response = co.finetuning.create_finetuned_model(
         name="english",
         base_type="BASE_TYPE_RERANK",
       ),
-      dataset_id=my-rerank_dataset.id,
+      dataset_id=rerank_dataset.id,
     ),
   )
 )


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the `dataset_id` variable in the `create_finetuned_model` function. The changes are as follows:

- In `fern/pages/fine-tuning/chat-fine-tuning/chat-starting-the-training.mdx`, the `dataset_id` is changed from `my-chat_dataset.id` to `chat_dataset.id`.
- In `fern/pages/fine-tuning/rerank-fine-tuning/rerank-starting-the-training.mdx`, the `dataset_id` is changed from `my-rerank_dataset.id` to `rerank_dataset.id`.

<!-- end-generated-description -->