### PR TITLE
(docs)Redirects to usage-guidelines

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -552,8 +552,8 @@ redirects:
   - source: /docs/generation-card
     destination: /docs/usage-guidelines
     permanent: true
-  - source: /docs/generation-card
-    destination: /docs/data-statement
+  - source: /docs/data-statement
+    destination: /docs/usage-guidelines
     permanent: true
 
 analytics:


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the `redirects` section in the `fern/docs.yml` file. It modifies the `source` and `destination` paths for a specific redirect rule.

## Changes:
- The `source` path is updated from `/docs/generation-card` to `/docs/data-statement`.
- The `destination` path is changed from `/docs/data-statement` to `/docs/usage-guidelines`.

<!-- end-generated-description -->