### PR TITLE
(docs)last time I promise

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -133,9 +133,6 @@ redirects:
   - source: "/reference/rerank-1"
     destination: "/reference/rerank"
     permanent: true
-  - source: "/docs/generation-card"
-    destination: "/docs/generation-benchmarks"
-    permanent: true
   - source: "/reference/datasets"
     destination: "/reference/create-dataset"
     permanent: true
@@ -199,7 +196,7 @@ redirects:
     destination: /docs/training-troubleshooting
     permanent: true
   - source: /data-statement
-    destination: /docs/data-statement
+    destination: /docs/usage-guidelines
     permanent: true
   - source: /detokenize-reference
     destination: /reference/detokenize
@@ -372,9 +369,6 @@ redirects:
   - source: /custom-model-troubleshooting
     destination: /docs/training-troubleshooting
     permanent: true
-  - source: /data-statement
-    destination: /docs/data-statement
-    permanent: true
   - source: /detokenize-reference
     destination: /reference/detokenize
     permanent: true
@@ -412,7 +406,7 @@ redirects:
     destination: /reference/generate
     permanent: true
   - source: /generation-card
-    destination: /docs/generation-card
+    destination: /docs/usage-guidelines
     permanent: true
   - source: /going-live
     destination: /docs/going-live
@@ -530,9 +524,6 @@ redirects:
     permanent: true
   - source: /docs/coral-toolkit
     destination: /docs/cohere-toolkit
-    permanent: true
-  - source: /docs/generation-card
-    destination: /docs/generation-benchmarks
     permanent: true
   - source: /docs/representation-card
     destination: /docs/representation-benchmarks


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the `redirects` section in the `fern/docs.yml` file. It modifies the destination paths for specific source URLs, ensuring that users are directed to the correct documentation pages.

## Changes:
- The destination for the source `/docs/generation-card` is changed from `/docs/generation-benchmarks` to `/docs/usage-guidelines`.
- The destination for the source `/data-statement` is updated from `/docs/data-statement` to `/docs/usage-guidelines`.
- The destination for the source `/generation-card` is modified from `/docs/generation-card` to `/docs/usage-guidelines`.

<!-- end-generated-description -->