### PR TITLE
(docs)last of the last

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -231,9 +231,6 @@ redirects:
   - source: /generate-reference
     destination: /reference/generate
     permanent: true
-  - source: /generation-card
-    destination: /docs/generation-card
-    permanent: true
   - source: /going-live
     destination: /docs/going-live
     permanent: true


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR removes the following redirects from the `redirects` list:

- `/generation-card` to `/docs/generation-card`
- `/docs/generation-card` to `/generation-card`

The PR also removes the `permanent` attribute from the redirect, which was previously set to `true`.

<!-- end-generated-description -->