### PR TITLE
Update preview-docs.yml

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -12,8 +12,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        # with:
-        #   ref: "${{ github.event.pull_request.merge_commit_sha }}"
+        with:
+          ref: "${{ github.event.pull_request.merge_commit_sha }}"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request modifies the workflow for previewing documentation by updating the `ref` parameter in the `Checkout repository` step.

## Changes:
- The `ref` parameter is now set to `"${{ github.event.pull_request.merge_commit_sha }}" to ensure the correct version of the repository is checked out during the preview process.

<!-- end-generated-description -->