### PR TITLE
Remove CMDR+ caveat

### DIFF
--- a/fern/pages/models/the-command-family-of-models/command-r-plus.mdx
+++ b/fern/pages/models/the-command-family-of-models/command-r-plus.mdx
@@ -86,9 +86,5 @@ Tool use comes in single-step and multi-step variants. In the former, the model 
 
 Command R+ has been trained with multi-step tool use capabilities, with which it is possible to build simple agents. This functionality takes a conversation as input (with an optional user-system preamble), along with a list of available tools. The model will then generate a json-formatted list of actions to execute on a subset of those tools. For more information, check out our dedicated [multi-step tool use](/docs/multi-hop-tool-use) guide.
 
-## Temporary Context Window Caveat
-
-We have a known issue where prompts between 112K - 128K in length result in bad generations. We are working to get this resolved, and we appreciate your patience in the meantime.
-
 ---
 Congrats on reaching the end of this page! Get an extra $1 API credit by entering the `CommandR+Docs` credit code in [your Cohere dashboard](https://dashboard.cohere.com/billing?tab=payment)


### PR DESCRIPTION
<!-- begin-generated-description -->

## Summary
The PR removes the section on the temporary context window caveat, which mentions a known issue with prompts between 112K and 128K in length resulting in bad generations.

## Changes
- The section on the temporary context window caveat has been removed.

<!-- end-generated-description -->