### PR TITLE
Update input.css

### DIFF
--- a/fern/assets/input.css
+++ b/fern/assets/input.css
@@ -1,6 +1,10 @@
 @tailwind components;
 @tailwind utilities;
 
+.fern-changelog>main {
+    width: 100%;
+}
+
 h1,
 h2,
 h3,


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR introduces a new CSS class, `.fern-changelog`, which is applied to the `main` element. The class sets the width of the `main` element to 100%.

## Changes
- Added a new CSS class, `.fern-changelog`, to the `main` element.
- Set the width of the `main` element to 100%.

<!-- end-generated-description -->