### PR TITLE
[Docs] Display API V2 announcement banner

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1,5 +1,5 @@
 announcement:
-    message: "🚀 New feature: Announcements are available! (<a href=\"https://buildwithfern.com/learn/docs/building-your-docs/announcements\" target=\"_blank\">Learn more</a>) 🚀"
+    message: "🚀 Announcement: New API V2 endpoints are available! (<a href=\"https://cohere.com/blog/new-api-v2" target=\"_blank\">Learn more</a>) 🚀"
 
 instances:
   - url: cohere.docs.buildwithfern.com

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1,3 +1,6 @@
+announcement:
+    message: "🚀 New feature: Announcements are available! (<a href=\"https://buildwithfern.com/learn/docs/building-your-docs/announcements\" target=\"_blank\">Learn more</a>) 🚀"
+
 instances:
   - url: cohere.docs.buildwithfern.com
     custom-domain: docs.cohere.com

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1,5 +1,5 @@
 announcement:
-    message: "🚀 Announcement: New API V2 endpoints are available! (<a href=\"https://cohere.com/blog/new-api-v2" target=\"_blank\">Learn more</a>) 🚀"
+    message: "🚀 Announcement: New API V2 endpoints are available! (<a href=\"https://cohere.com/blog/new-api-v2\" target=\"_blank\">Learn more</a>) 🚀"
 
 instances:
   - url: cohere.docs.buildwithfern.com


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR introduces a new announcement section to the `fern/docs.yml` file, informing users about the availability of new API V2 endpoints.

## Changes:
- A new `announcement` section is added, containing a message with a link to learn more about the new API V2 endpoints.
- The message is formatted with an emoji and a link to the Cohere blog for further details.

<!-- end-generated-description -->