### PR TITLE
Clean up v1 config

### DIFF
--- a/fern/v1.yml
+++ b/fern/v1.yml
@@ -585,34 +585,22 @@ navigation:
           python: "cohere"
           typescript: "cohere-ai"
         layout:
-          # - section: V2 (beta)
-          #   skip-slug: true
-          #   contents:
-          #     - section: "/v2/chat"
-          #       skip-slug: true
-          #       contents:
-          #         - endpoint: POST /v2/chat
-          #           slug: chat-v2
-          #           title: Chat
-          #         - endpoint: STREAM /v2/chat
-          #           slug: chat-stream-v2
-          #           title: Chat with Streaming
           - section: API Reference
             skip-slug: true
             contents:
-              - section: "/v1/chat"
+              - section: "v1/chat"
                 skip-slug: true
                 contents:
                   - endpoint: POST /v1/chat
                     title: Chat
                   - endpoint: STREAM /v1/chat
                     title: Chat with Streaming
-              - section: "/v1/embed"
+              - section: "v1/embed"
                 skip-slug: true
                 contents:
                   - POST /v1/embed
               - embedJobs:
-                  title: "/v1/embed-jobs"
+                  title: "v1/embed-jobs"
                   skip-slug: true
                   contents:
                     - endpoint: POST /v1/embed-jobs
@@ -623,16 +611,16 @@ navigation:
                       slug: get-embed-job
                     - endpoint: POST /v1/embed-jobs/{id}/cancel
                       slug: cancel-embed-job
-              - section: "/v1/rerank"
+              - section: "v1/rerank"
                 skip-slug: true
                 contents:
                   - POST /v1/rerank
-              - section: "/v1/classify"
+              - section: "v1/classify"
                 skip-slug: true
                 contents:
                   - POST /v1/classify
               - datasets:
-                  title: "/v1/datasets"
+                  title: "v1/datasets"
                   skip-slug: true
                   contents:
                     - endpoint: POST /v1/datasets
@@ -645,16 +633,16 @@ navigation:
                       slug: get-dataset
                     - endpoint: DELETE /v1/datasets/{id}
                       slug: delete-dataset
-              - section: "/v1/tokenize"
+              - section: "v1/tokenize"
                 skip-slug: true
                 contents:
                   - POST /v1/tokenize
-              - section: "/v1/detokenize"
+              - section: "v1/detokenize"
                 skip-slug: true
                 contents:
                   - POST /v1/detokenize
               - connectors:
-                  title: "/v1/connectors"
+                  title: "v1/connectors"
                   skip-slug: true
                   contents:
                     - endpoint: GET /v1/connectors
@@ -670,7 +658,7 @@ navigation:
                     - endpoint: POST /v1/connectors/{id}/oauth/authorize
                       slug: oauthauthorize-connector
               - models:
-                  title: "/v1/models"
+                  title: "v1/models"
                   skip-slug: true
                   contents:
                     - endpoint: GET /v1/models/{model}
@@ -678,7 +666,7 @@ navigation:
                     - endpoint: GET /v1/models
                       slug: list-models
               - finetuning:
-                  title: "/v1/finetuning"
+                  title: "v1/finetuning"
                   skip-slug: true
                   contents:
                     - endpoint: GET /v1/finetuning/finetuned-models
@@ -698,14 +686,14 @@ navigation:
           - section: Legacy
             skip-slug: true
             contents:
-              - section: "/v1/generate"
+              - section: "v1/generate"
                 skip-slug: true
                 contents:
                   - endpoint: POST /v1/generate
                     title: Generate
                   - endpoint: STREAM /v1/generate
                     title: Generate with Streaming
-              - section: "/v1/summarize"
+              - section: "v1/summarize"
                 skip-slug: true
                 contents:
                   - POST /v1/summarize


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request updates the API reference section of the `fern/v1.yml` file. It removes the V2 (beta) section and focuses on the v1 endpoints.

The changes include:
- Removing the V2 (beta) section, which includes the `/v2/chat` and `/v2/chat/stream` endpoints.
- Updating the section titles to use the "v1" prefix instead of the "/v1" prefix for consistency.
- Ensuring the API reference section is up-to-date with the latest v1 endpoints.

<!-- end-generated-description -->