### PR TITLE
Move migration page

### DIFF
--- a/fern/v2.yml
+++ b/fern/v2.yml
@@ -37,8 +37,6 @@ navigation:
             path: pages/get-started/datasets.mdx
           - page: Improve Cohere Docs
             path: pages/get-started/contribute.mdx
-          - page: Migrating From API v1 to API v2
-            path: pages/v2/text-generation/migrating-v1-to-v2.mdx
       - section: Models
         contents:
           - page: Models Overview
@@ -553,6 +551,8 @@ navigation:
             path: pages/cohere-api/teams-and-roles.mdx
           - page: Errors
             path: pages/cohere-api/errors.mdx
+          - page: Migrating From API v1 to API v2
+            path: pages/v2/text-generation/migrating-v1-to-v2.mdx
           - page: Installation
             hidden: true
             path: pages/command-line-interface/command.mdx


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR makes changes to the `fern/v2.yml` file, specifically within the `navigation` section.

## Changes
- The `page` titled "Migrating From API v1 to API v2" has been removed from the `navigation` section.
- A new `page` titled "Migrating From API v1 to API v2" has been added to the `navigation` section, with a `path` of "pages/v2/text-generation/migrating-v1-to-v2.mdx".

<!-- end-generated-description -->