### PR TITLE
No scroll for v2

### DIFF
--- a/fern/v2.yml
+++ b/fern/v2.yml
@@ -557,6 +557,7 @@ navigation:
             hidden: true
             path: pages/command-line-interface/command.mdx
       - api: Cohere API
+        paginated: true
         api-name: v2
         audiences:
           - public


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request adds a new line to the `fern/v2.yml` file, which sets the `paginated` property to `true`.

- The `paginated` property is set to `true` for the `api` section.

<!-- end-generated-description -->