### PR TITLE
Hide check-api-key 

### DIFF
--- a/fern/v1.yml
+++ b/fern/v1.yml
@@ -697,6 +697,11 @@ navigation:
                 skip-slug: true
                 contents:
                   - POST /v1/summarize
+              - section: "v1/check-api-key"
+                skip-slug: true
+                hidden: true
+                contents:
+                  - POST /v1/check-api-key
   - tab: release-notes
   - tab: llmu
   - tab: cookbooks

--- a/fern/v2.yml
+++ b/fern/v2.yml
@@ -703,6 +703,11 @@ navigation:
                 skip-slug: true
                 contents:
                   - POST /v1/summarize
+              - section: "v1/check-api-key"
+                skip-slug: true
+                hidden: true
+                contents:
+                  - POST /v1/check-api-key
   - tab: release-notes
   - tab: llmu
   - tab: cookbooks


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request adds a new section to the navigation menu in both `fern/v1.yml` and `fern/v2.yml` files. The section is named `v1/check-api-key` and is configured to be hidden and skipped in the navigation. It contains a single entry, `POST /v1/check-api-key`, which is likely a new API endpoint.

## Changes:
- Added a new section named `v1/check-api-key` to the navigation menu.
- Set the `skip-slug` and `hidden` properties to `true` for the new section.
- Included a new entry `POST /v1/check-api-key` within the new section.

<!-- end-generated-description -->