### PR TITLE
Move v2s to top

### DIFF
--- a/fern/v2.yml
+++ b/fern/v2.yml
@@ -582,6 +582,14 @@ navigation:
           - section: Stable
             skip-slug: true
             contents:
+              - section: "v2/rerank"
+                skip-slug: true
+                contents:
+                  - POST /v2/rerank
+              - section: "v2/embed"
+                skip-slug: true
+                contents:
+                  - POST /v2/embed
               - section: "v1/chat"
                 skip-slug: true
                 contents:
@@ -589,10 +597,6 @@ navigation:
                     title: Chat Non-streaming
                   - endpoint: STREAM /v1/chat
                     title: Chat Streaming
-              - section: "v2/embed"
-                skip-slug: true
-                contents:
-                  - POST /v2/embed
               - embedJobs:
                   title: "v1/embed-jobs"
                   skip-slug: true
@@ -605,10 +609,6 @@ navigation:
                       slug: get-embed-job
                     - endpoint: POST /v1/embed-jobs/{id}/cancel
                       slug: cancel-embed-job
-              - section: "v2/rerank"
-                skip-slug: true
-                contents:
-                  - POST /v2/rerank
               - section: "v1/classify"
                 skip-slug: true
                 contents:


### PR DESCRIPTION
<!-- begin-generated-description -->

The PR introduces changes to the `navigation` section of the `fern/v2.yml` file, specifically within the `Stable` section.

- The `v2/rerank` section is added, containing the `POST /v2/rerank` endpoint.
- The `v2/embed` section is moved to appear after the `v2/rerank` section.
- The `v2/rerank` section is removed from its original position, which was after the `v1/classify` section.

<!-- end-generated-description -->