### PR TITLE
Make V2 the default version of guides

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -11,12 +11,12 @@ title: Cohere
 default-language: python
 
 versions:
-  - display-name: v1
-    path: v1.yml
-    slug: v1
   - display-name: v2
     path: v2.yml
     slug: v2
+  - display-name: v1
+    path: v1.yml
+    slug: v1
 
 logo:
   light: assets/logo.svg


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR makes a simple change to the `fern/docs.yml` file, adding a new version entry for `v1`.

- A new version entry for `v1` is added to the `versions` list, with the path `v1.yml` and slug `v1`.

<!-- end-generated-description -->