### PR TITLE
Changing v1 back to the default.

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -14,12 +14,12 @@ title: Cohere
 default-language: python
 
 versions:
-  - display-name: v2
-    path: v2.yml
-    slug: v2
   - display-name: v1
     path: v1.yml
     slug: v1
+  - display-name: v2
+    path: v2.yml
+    slug: v2
 
 logo:
   light: assets/logo.svg

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -14,12 +14,13 @@ title: Cohere
 default-language: python
 
 versions:
-  - display-name: v1
-    path: v1.yml
-    slug: v1
   - display-name: v2
     path: v2.yml
     slug: v2
+  - display-name: v1
+    path: v1.yml
+    slug: v1
+
 
 logo:
   light: assets/logo.svg
@@ -112,6 +113,27 @@ redirects:
   - source: "/docs/llmu{/:path}*"
     destination: "/docs/llmu-2"
     permanent: true
+  - source: "/docs/managing-your-connector"
+    destination: "/v1/docs/managing-your-connector"
+  - source: "/docs/connector-authentication"
+    destination: "/v1/docs/connector-authentication"
+  - source: "/docs/connector-faqs"
+    destination: "/v1/docs/connector-faqs"
+  - source: "/docs/overview-rag-connectors"
+    destination: "/v1/docs/overview-rag-connectors"
+  - source: "/docs/migrating-from-cogenerate-to-cochat"
+    destination: "/v1/docs/migrating-from-cogenerate-to-cochat"
+  - source: "/reference/generate"
+    destination: "/v1/reference/generate"
+  - source: "/v2/docs/embed-2"
+    destination: "/docs/cohere-embed"
+  - source: "/docs/docs/overview-rag-connectors"
+    destination: "/v1/docs/overview-rag-connectors"
+  - source: "/docs/prompt-truncation"
+    destination: "/v1/docs/prompt-truncation"
+  - source: "/classify-reference"
+    destination: "/reference/classify"
+
   - source: "/docs/llmu"
     destination: "/docs/llmu-2"
     permanent: true

--- a/fern/pages/v2/text-embeddings/embeddings.mdx
+++ b/fern/pages/v2/text-embeddings/embeddings.mdx
@@ -48,7 +48,7 @@ calculate_similarity(soup1, london) # 0.16 - not similar!
 
 ## The `input_type` parameter
 
-Cohere embeddings are optimized for different types of inputs. For example, when using embeddings for semantic search, the search query should be embedded by setting `input_type="search_query"` whereas the text passages that are being searched over should be embedded with `input_type="search_document"`.  You can find more details and a code snippet in the [Semantic Search guide](/v2/docs/semantic-search). Similarly, the input type can be set to `classification` ([example](/v2/docs/text-classification-with-embed)) and `clustering` to optimize the embeddings for those use cases.
+Cohere embeddings are optimized for different types of inputs. For example, when using embeddings for semantic search, the search query should be embedded by setting `input_type="search_query"` whereas the text passages that are being searched over should be embedded with `input_type="search_document"`.  You can find more details and a code snippet in the [Semantic Search guide](/v2/docs/semantic-search). Similarly, the input type can be set to `classification` ([example](/v2/docs/text-classification-with-cohere)) and `clustering` to optimize the embeddings for those use cases.
 
 ## Multilingual Support
 

--- a/fern/pages/v2/text-generation/migrating-v1-to-v2.mdx
+++ b/fern/pages/v2/text-generation/migrating-v1-to-v2.mdx
@@ -304,7 +304,7 @@ print(res_v2.message.citations)
 
 ## Connectors
 
-- v1: Supported via the [`connectors` parameter](docs/overview-rag-connectors)
+- v1: Supported via the [`connectors` parameter](/v1/docs/overview-rag-connectors)
 - v2: Supported via user-defined tools.
 
 ## Web search

--- a/fern/pages/v2/text-generation/prompt-engineering/preambles.mdx
+++ b/fern/pages/v2/text-generation/prompt-engineering/preambles.mdx
@@ -22,7 +22,7 @@ A system message is provided to a model at the beginning of a conversation to di
 
 While prompting is a natural way to interact with and instruct an LLM, writing a custom system message is a shortcut to direct the model’s behavior. Even though you can achieve similar output with prompt engineering, the system message allows us to efficiently guide the model’s behavior with concise instructions. 
 
-Default system messages differ from model to model. For example, the default system message in the [Command R](command-r/docs/command-r) model is:
+Default system messages differ from model to model. For example, the default system message in the [Command R](/docs/command-r) model is:
 
 > 💡 Default System Message for Command R and Command R+
 > 

--- a/fern/pages/v2/tutorials/build-things-with-cohere/rag-with-cohere.mdx
+++ b/fern/pages/v2/tutorials/build-things-with-cohere/rag-with-cohere.mdx
@@ -121,7 +121,7 @@ In a basic RAG application, the steps involved are:
 
 Let's now look at the first step—search query generation. The chatbot needs to generate an optimal set of search queries to use for retrieval. 
 
-There are different possible approaches to this. In this example, we'll take a [tool use](./v2/docs/tool-use) approach.
+There are different possible approaches to this. In this example, we'll take a [tool use](/v2/docs/tool-use) approach.
 
 Here, we build a tool that takes a user query and returns a list of relevant document snippets for that query. The tool can generate zero, one or multiple search queries depending on the user query.
 


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR introduces a new version of the documentation, `v2`, to the `fern/docs.yml` file.

- The `versions` section now includes a new entry for `v2`, with the path `v2.yml` and slug `v2`.
- This new version is added alongside the existing `v1` version, ensuring a clear distinction between the two.

<!-- end-generated-description -->