### PR TITLE
update chat v2 url slug to be /chat

### DIFF
--- a/fern/v2.yml
+++ b/fern/v2.yml
@@ -575,10 +575,10 @@ navigation:
                 skip-slug: true
                 contents:
                   - endpoint: POST /v2/chat
-                    slug: chat-v2
+                    slug: chat
                     title: Chat
                   - endpoint: STREAM /v2/chat
-                    slug: chat-stream-v2
+                    slug: chat-stream
                     title: Chat with Streaming
               - section: "v2/rerank"
                 skip-slug: true


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request makes changes to the `fern/v2.yml` file, specifically to the `slug` values in the `navigation` section.

- The `slug` value for the `POST /v2/chat` endpoint is changed from `chat-v2` to `chat`.
- The `slug` value for the `STREAM /v2/chat` endpoint is changed from `chat-stream-v2` to `chat-stream`.

<!-- end-generated-description -->