### PR TITLE
Update version dropdown to include "API"

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -14,10 +14,10 @@ title: Cohere
 default-language: python
 
 versions:
-  - display-name: v2
+  - display-name: v2 API
     path: v2.yml
     slug: v2
-  - display-name: v1
+  - display-name: v1 API
     path: v1.yml
     slug: v1
 


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the `display-name` field in the `fern/docs.yml` file. The changes are as follows:

- The `display-name` for the `v2` version is updated to `v2 API`.
- The `display-name` for the `v1` version is updated to `v1 API`.

<!-- end-generated-description -->