### PR TITLE
fix: doc fixes post migration to v2

### DIFF
--- a/fern/pages/v2/fine-tuning/chat-fine-tuning/chat-starting-the-training.mdx
+++ b/fern/pages/v2/fine-tuning/chat-fine-tuning/chat-starting-the-training.mdx
@@ -197,24 +197,42 @@ To train a custom model, please see the example below for parameters to pass to 
   - `early_stopping_threshold` (float) How much the loss must improve to prevent early stopping. Must be between 0.001 and 0.1. Defaults to **0.001**.
   - `early_stopping_patience` (int) Stops training if the loss metric does not improve beyond the value of `early_stopping_threshold` after this many rounds of evaluation. Must be between 0 and 10. Defaults to **10**.
 
+You can optionally publish the training metrics and hyper parameter values to your [Weights and Biases](https://wandb.ai) account using the `wandb` parameter. This is currently only supported when fine-tuning a Chat model.
+
+- `wandb` (cohere.finetuning.WandbConfig) - The Weights & Biases configuration.
+  - `project` (string) The Weights and Biases project to be used during training. This parameter is mandatory.
+  - `api_key` (string) The Weights and Biases API key to be used during training. This parameter is mandatory and will always be stored securely and automatically deleted after the fine-tuning job completes training.
+  - `entity` (string) The Weights and Biases API entity to be used during training. When not specified, it will assume the default entity for that API key.
+
+When the configuration is valid, the Run ID will correspond to the fine-tuned model ID, and Run display name will be the name of the fine-tuned model specified during creation. When specifying a invalid Weights and Biases configuration, the fine-tuned model creation will proceed but nothing will be logged to your Weights and Biases.
+
+Once a fine-tuned model has been created with a specified Weights and Biases configuration, you may view the fine-tuning job run via the Weights and Biases dashboard. It will be available via the following URL: `https://wandb.ai/<your-entity>/<your-project>/runs/<finetuned-model-id>`.
+
 ## Example
 
 ```python PYTHON
 import cohere
-from cohere.finetuning import Hyperparameters, Settings, BaseModel
+from cohere.finetuning import Hyperparameters, Settings, BaseModel, WandbConfig
 
 co = cohere.ClientV2('Your API key')
 
 chat_dataset = co.datasets.create(name="chat-dataset",
                                   data=open("path/to/train.jsonl", "rb"),
                                   type="chat-finetune-input")
-# optional (define custom  hyperparameters)
+# optional (define custom hyperparameters)
 hp = Hyperparameters(
   early_stopping_patience=10,
   early_stopping_threshold=0.001,
   train_batch_size=16,
   train_epochs=1,
   learning_rate=0.01,
+)
+
+# optional (define wandb configuration)
+wnb_config = WandbConfig(
+    project="test-project",
+    api_key="<<wandbApiKey>>",
+    entity="test-entity",
 )
 
 create_response = co.finetuning.create_finetuned_model(
@@ -224,8 +242,9 @@ create_response = co.finetuning.create_finetuned_model(
       base_model=BaseModel(
         base_type="BASE_TYPE_CHAT",
       ),
-      dataset_id=my-chat_dataset.id,
-      hyperparameters=hp
+      dataset_id=chat_dataset.id,
+      hyperparameters=hp,
+      wandb=wnb_config,
     ),
   ),
 )


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR introduces the ability to publish training metrics and hyperparameter values to a Weights and Biases account during the fine-tuning process of a Chat model. The `wandb` parameter is added to the `FinetunedModel` request, allowing users to specify a Weights and Biases configuration.

## Changes:
- A new section is added to the documentation, explaining the `wandb` parameter and its usage.
- The `WandbConfig` class is imported from `cohere.finetuning`.
- The `wandb` parameter is added to the `FinetunedModel` request, allowing users to specify a Weights and Biases configuration.
- An example configuration is provided, demonstrating how to define the `WandbConfig` with the `project`, `api_key`, and `entity` parameters.

<!-- end-generated-description -->