### PR TITLE
Adding knowledge cut off.

### DIFF
--- a/fern/pages/models/the-command-family-of-models/command-r-plus.mdx
+++ b/fern/pages/models/the-command-family-of-models/command-r-plus.mdx
@@ -37,6 +37,8 @@ With the release, both models include the following feature improvements:
 
 What's more, both these updated models can now operate in one of several safety modes, which gives developers more granular control over how models generate output in a variety of different contexts. Find more in these [safety modes docs](https://docs.cohere.com/docs/safety-modes).
 
+These refreshed models were trained with data through February 2023. 
+
 
 ## Unique Command R+ Model Capabilities
 


### PR DESCRIPTION
<!-- begin-generated-description -->

The PR updates the documentation for the Command R+ model, adding information about the training data used.

- The updated models were trained with data through February 2023.

<!-- end-generated-description -->