### PR TITLE
Add tool use streaming snippets

### DIFF
--- a/fern/pages/v2/text-generation/tools/tool-use.mdx
+++ b/fern/pages/v2/text-generation/tools/tool-use.mdx
@@ -294,6 +294,24 @@ print("Final answer:")
 print(response.message.content[0].text)
 
 ```
+
+<Accordion title='Streaming option'>
+```python PYTHON
+response = co.chat_stream(
+    model="command-r-plus-08-2024",
+    messages=messages,
+    tools=tools
+)
+
+print("Final answer:")
+for chunk in response:
+    if chunk:
+        if chunk.type == "content-delta":
+            print(chunk.delta.message.content.text, end="")
+
+```
+</Accordion>
+
 ```
 # SAMPLE RESPONSE
 
@@ -327,6 +345,17 @@ print("Citations that support the final answer:")
 for citation in response.message.citations:
     print(f"Start: {citation.start} | End: {citation.end} | Text: '{citation.text}'")
 ```
+
+<Accordion title='Streaming option'>
+```python PYTHON {5-6}
+for chunk in response:
+    if chunk:
+        if chunk.type == "content-delta":
+            print(chunk.delta.message.content.text, end="")
+        elif chunk.type == "citation-start":
+            print(f"\n{chunk.delta.message.citations}")
+```
+</Accordion>
 ```
 # SAMPLE RESPONSE
 


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR introduces a new feature called the 'Streaming option' to the `tool-use.mdx` file. The 'Streaming option' allows for the streaming of responses from the `co.chat_stream` function, enabling the printing of final answers and citations in real-time.

## Changes:
- Added a new section titled 'Streaming option' to the file.
- Introduced a Python code block within the new section to demonstrate the streaming of responses.
- The code block initializes the `response` variable by calling the `co.chat_stream` function with specific model, message, and tool parameters.
- The code then enters a loop to process each `chunk` in the response.
- For each `chunk`, it checks its type and prints the content accordingly.
- If the `chunk` type is 'content-delta', it prints the message content text.
- If the `chunk` type is 'citation-start', it prints the citation information.

<!-- end-generated-description -->