### PR TITLE
Update rate limits

### DIFF
--- a/fern/pages/going-to-production/rate-limits.mdx
+++ b/fern/pages/going-to-production/rate-limits.mdx
@@ -11,19 +11,21 @@ keywords: "Cohere, large language model API"
 createdAt: "Thu Feb 29 2024 18:20:04 GMT+0000 (Coordinated Universal Time)"
 updatedAt: "Wed Jun 05 2024 20:23:51 GMT+0000 (Coordinated Universal Time)"
 ---
-Cohere offers two kinds of API keys: evaluation keys (free but limited in usage), and production keys (paid and not limited in usage). You can create an evaluation or production key on [the API keys page](https://dashboard.cohere.com/api-keys). For more details on pricing please see our [pricing docs](https://docs.cohere.com/v2/docs/how-does-cohere-pricing-work).
+Cohere offers two kinds of API keys: evaluation keys (free but limited in usage), and production keys (paid and much less limited in usage). You can create an evaluation or production key on [the API keys page](https://dashboard.cohere.com/api-keys). For more details on pricing please see our [pricing docs](https://docs.cohere.com/v2/docs/how-does-cohere-pricing-work).
 
 | Endpoint                                   | Evaluation rate limit | Production rate limit |
 | ------------------------------------------ | --------------------- | --------------------- |
-| [Chat](/reference/chat)                    | 20/min                | no limit              |
-| [Embed](/reference/embed)                  | 100,000/min           | no limit              |
+| [Chat](/reference/chat)                    | 20/min                | 500/min               |
+| [Embed](/reference/embed)                  | 100,000/min           | 2,000/min             |
 | [EmbedJob](/reference/embed-jobs)          | 5/min                 | no limit              |
-| [Rerank](/reference/rerank)                | 10/min                | no limit              |
-| [Generate (legacy)](/reference/generate)   | 5/min                 | no limit              |
+| [Classify](/reference/classify)            | ?/min                 | 1,000/min             |
+| [Rerank](/reference/rerank)                | 10/min                | 1,000/min             |
+| [Generate (legacy)](/reference/generate)   | 5/min                 | 500/min               |
 | [Summarize (legacy)](/reference/summarize) | 5/min                 | no limit              |
+| Default                                    | 500/min               | 500/min               |
 
 
-All endpoints are limited to 1,000 calls per month with a evaluation key. 
+All endpoints are limited to 1,000 calls per month with an evaluation key. 
 
 Organizational evaluation key limitations:
 - Organizations can have unlimited evaluation keys.

--- a/fern/pages/going-to-production/rate-limits.mdx
+++ b/fern/pages/going-to-production/rate-limits.mdx
@@ -27,9 +27,4 @@ Cohere offers two kinds of API keys: evaluation keys (free but limited in usage)
 
 In addition, all endpoints are limited to 1,000 calls **per month** with a **trial** key.
 
-Organizational evaluation key limitations:
-- Organizations can have unlimited evaluation keys.
-- Organization evaluation keys share the rate limits enumerated above.
-- Playground and Chat UI usage counts toward the evaluation key rate limit.
-
 If you have any questions or want to speak about getting a rate limit increase, reach out to support@cohere.com.

--- a/fern/pages/going-to-production/rate-limits.mdx
+++ b/fern/pages/going-to-production/rate-limits.mdx
@@ -15,15 +15,15 @@ Cohere offers two kinds of API keys: evaluation keys (free but limited in usage)
 
 | Endpoint                                   | Evaluation rate limit | Production rate limit |
 | ------------------------------------------ | --------------------- | --------------------- |
-| [Chat](/reference/chat)                    | 20/min                | 500/min               |
-| [Embed](/reference/embed)                  | 100,000/min           | 2,000/min             |
-| [EmbedJob](/reference/embed-jobs)          | 5/min                 | no limit              |
-| [Classify](/reference/classify)            | ?/min                 | 1,000/min             |
+| [Embed](/reference/embed)                  | 100/min               | 2,000/min             |
+| [Tokenize](/reference/tokenize)            | 100/min               | 2,000/min             |
+| [Classify](/reference/classify)            | 100/min               | 1000/min              |
 | [Rerank](/reference/rerank)                | 10/min                | 1,000/min             |
+| [Summarize (legacy)](/reference/summarize) | 5/min                 | 500/min               |
+| [Chat](/reference/chat)                    | 20/min                | 500/min               |
 | [Generate (legacy)](/reference/generate)   | 5/min                 | 500/min               |
-| [Summarize (legacy)](/reference/summarize) | 5/min                 | no limit              |
-| Default                                    | 500/min               | 500/min               |
-
+| [EmbedJob](/reference/embed-jobs)          | 5/min                 | 50/min                |
+| Default (anything not covered above)       | 500/min               | 500/min               |
 
 All endpoints are limited to 1,000 calls per month with an evaluation key. 
 

--- a/fern/pages/going-to-production/rate-limits.mdx
+++ b/fern/pages/going-to-production/rate-limits.mdx
@@ -11,9 +11,9 @@ keywords: "Cohere, large language model API"
 createdAt: "Thu Feb 29 2024 18:20:04 GMT+0000 (Coordinated Universal Time)"
 updatedAt: "Wed Jun 05 2024 20:23:51 GMT+0000 (Coordinated Universal Time)"
 ---
-Cohere offers two kinds of API keys: evaluation keys (free but limited in usage), and production keys (paid and much less limited in usage). You can create an evaluation or production key on [the API keys page](https://dashboard.cohere.com/api-keys). For more details on pricing please see our [pricing docs](https://docs.cohere.com/v2/docs/how-does-cohere-pricing-work).
+Cohere offers two kinds of API keys: evaluation keys (free but limited in usage), and production keys (paid and much less limited in usage). You can create a trial or production key on [the API keys page](https://dashboard.cohere.com/api-keys). For more details on pricing please see our [pricing docs](https://docs.cohere.com/v2/docs/how-does-cohere-pricing-work).
 
-| Endpoint                                   | Evaluation rate limit | Production rate limit |
+| Endpoint                                   | Trial rate limit      | Production rate limit |
 | ------------------------------------------ | --------------------- | --------------------- |
 | [Embed](/reference/embed)                  | 100/min               | 2,000/min             |
 | [Tokenize](/reference/tokenize)            | 100/min               | 2,000/min             |
@@ -25,9 +25,11 @@ Cohere offers two kinds of API keys: evaluation keys (free but limited in usage)
 | [EmbedJob](/reference/embed-jobs)          | 5/min                 | 50/min                |
 | Default (anything not covered above)       | 500/min               | 500/min               |
 
-All endpoints are limited to 1,000 calls per month with an evaluation key. 
+In addition, all endpoints are limited to 1,000 calls **per month** with a **trial** key.
 
 Organizational evaluation key limitations:
 - Organizations can have unlimited evaluation keys.
 - Organization evaluation keys share the rate limits enumerated above.
 - Playground and Chat UI usage counts toward the evaluation key rate limit.
+
+If you have any questions or want to speak about getting a rate limit increase, reach out to support@cohere.com.


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR introduces changes to the rate limits for Cohere's API keys, specifically the trial and production keys. The modifications include:

- Renaming the 'Evaluation rate limit' to 'Trial rate limit' to align with the new terminology.
- Updating the rate limits for various endpoints, such as reducing the rate limit for the 'Embed' endpoint from 100,000/min to 100/min for trial keys and introducing a limit of 2,000/min for production keys.
- Adding new endpoints like 'Tokenize' and 'Classify' with specific rate limits.
- Implementing a monthly limit of 1,000 calls for all endpoints with a trial key.
- Providing contact information for rate limit increase inquiries.

## Changes:
- The 'Evaluation' key is now referred to as a 'Trial' key, reflecting a change in terminology.
- Rate limits for specific endpoints have been adjusted, with notable changes including the 'Embed' endpoint's limit reduction from 100,000/min to 100/min for trial keys and the introduction of a 2,000/min limit for production keys.
- New endpoints, 'Tokenize' and 'Classify', have been added with their respective rate limits.
- A monthly limit of 1,000 calls has been set for all endpoints when using a trial key.
- Contact information (support@cohere.com) is provided for users seeking rate limit increases.

<!-- end-generated-description -->