### PR TITLE
Fix rate limit documentation

### DIFF
--- a/fern/pages/going-to-production/rate-limits.mdx
+++ b/fern/pages/going-to-production/rate-limits.mdx
@@ -13,14 +13,14 @@ updatedAt: "Wed Jun 05 2024 20:23:51 GMT+0000 (Coordinated Universal Time)"
 ---
 Cohere offers two kinds of API keys: evaluation keys (free but limited in usage), and production keys (paid and not limited in usage). You can create an evaluation or production key on [the API keys page](https://dashboard.cohere.com/api-keys). For more details on pricing please see our [pricing docs](https://docs.cohere.com/v2/docs/how-does-cohere-pricing-work).
 
-| Endpoint                                   | Evaluation rate limit | Production rate limit |
-| ------------------------------------------ | --------------------- | --------------------- |
-| [Chat](/reference/chat)                    | 20/min                | no limit              |
-| [Embed](/reference/embed)                  | 100,000/min           | no limit              |
-| [EmbedJob](/reference/embed-jobs)          | 5/min                 | no limit              |
-| [Rerank](/reference/rerank)                | 10/min                | no limit              |
-| [Generate (legacy)](/reference/generate)   | 5/min                 | no limit              |
-| [Summarize (legacy)](/reference/summarize) | 5/min                 | no limit              |
+| Endpoint                                   | Evaluation RPM limit | Production RPM limit |
+| ------------------------------------------ | -------------------- | -------------------- |
+| [Chat](/reference/chat)                    | 20                   | 500                  |
+| [Embed](/reference/embed)                  | 100                  | 2,000                |
+| [EmbedJob](/reference/embed-jobs)          | 5                    | 50                   |
+| [Rerank](/reference/rerank)                | 10                   | 1,000                |
+| [Generate (legacy)](/reference/generate)   | 5                    | 500                  |
+| [Summarize (legacy)](/reference/summarize) | 5                    | 500                  |
 
 
 All endpoints are limited to 1,000 calls per month with a evaluation key. 


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request updates the rate limits for Cohere's API keys, specifically the evaluation and production keys. The changes are as follows:

- The rate limit column has been renamed from `Evaluation rate limit` and `Production rate limit` to `Evaluation RPM limit` and `Production RPM limit` respectively.
- The rate limit values for each endpoint have been updated. For example, the `Chat` endpoint's evaluation rate limit has been changed from `20/min` to `20` and the production rate limit has been changed from `no limit` to `500`.
- The rate limit values for the `Embed`, `EmbedJob`, `Rerank`, `Generate (legacy)`, and `Summarize (legacy)` endpoints have also been updated, with the evaluation rate limits now expressed as a single number and the production rate limits adjusted.

<!-- end-generated-description -->