### PR TITLE
Undocument 498 errors

### DIFF
--- a/fern/pages/cohere-api/errors.mdx
+++ b/fern/pages/cohere-api/errors.mdx
@@ -141,17 +141,6 @@ To resolve this error, consult [the API spec](https://docs.cohere.com/reference/
     |trial token rate limit exceeded, limit is 100000 tokens per minute|
 </details>
 
-## 498 - Unsafe Request
-
-498 responses are sent when the request is blocked due to potential violations of the [Usage Guidelines](https://docs.cohere.com/docs/usage-guidelines). To resolve these errors, adjust your prompt and try again.
-
-<details>
-    <summary>Example error responses</summary>
-    |message|
-    |---|
-    |blocked input: please adjust your prompt and try again, as it may be a potential violation of our Usage Guidelines (https://docs.cohere.com/docs/usage-guidelines).|
-</details>
-
 ## 499 - Request Cancelled
 
 499 responses are sent when a user cancels the request. To resolve these errors, try the request again.


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request removes the section on the 498 response code, which is sent when a request is blocked due to potential violations of the Usage Guidelines. The section on the 499 response code, which is sent when a user cancels a request, remains unchanged.

## Changes
- The section on the 498 response code has been removed.

<!-- end-generated-description -->