### PR TITLE
Fixing some links.

### DIFF
--- a/fern/pages/llm-university/intro-large-language-models/semantic-search-temp.mdx
+++ b/fern/pages/llm-university/intro-large-language-models/semantic-search-temp.mdx
@@ -60,11 +60,11 @@ In short, semantic search works as follows:
 - It uses a text embedding to turn words into vectors (lists of numbers).  
   Uses similarity to find the vector among the responses which is the most similar to the vector corresponding to the query.
 - Outputs the response corresponding to this most similar vector.  
-  In this chapter, we’ll learn all these steps in detail. First, let’s look at text embeddings. If you need to brush up on these, check out the previous chapter on <a target="_blank" href="/docs/text-embeddings">text embeddings</a>.
+  In this chapter, we’ll learn all these steps in detail. First, let’s look at text embeddings. If you need to brush up on these, check out the previous chapter on [text embeddings](https://docs.cohere.com/docs/embeddings).
 
 ### How to Search Using Text Embeddings?
 
-As you learned in a previous chapter, an <a target="_blank" href="/docs/text-embeddings">embedding</a> is a way to assign to each sentence (or more generally, to each text fragment, which can be as short as a word or as long as a full article), a vector, which is a list of numbers. The Cohere embedding model used in the codelab for this chapter returns a vector of length 4096. This is a list of 4096 numbers (other Cohere embeddings, such as the multilingual one, return smaller vectors, for example, of length 768). A very important property of embeddings is that similar pieces of text get assigned to similar lists of numbers. For example, the sentence “Hello, how are you?” and the sentence “Hi, what’s up?” will be assigned lists of similar numbers, whereas the sentence “Tomorrow is Friday” will be assigned a list of numbers that are quite different from the two previous ones.
+As you learned in a previous chapter, [an embedding](https://docs.cohere.com/docs/embeddings) is a way to assign to each sentence (or more generally, to each text fragment, which can be as short as a word or as long as a full article), a vector, which is a list of numbers. The Cohere embedding model used in the codelab for this chapter returns a vector of length 4096. This is a list of 4096 numbers (other Cohere embeddings, such as the multilingual one, return smaller vectors, for example, of length 768). A very important property of embeddings is that similar pieces of text get assigned to similar lists of numbers. For example, the sentence “Hello, how are you?” and the sentence “Hi, what’s up?” will be assigned lists of similar numbers, whereas the sentence “Tomorrow is Friday” will be assigned a list of numbers that are quite different from the two previous ones.
 
 In the next image, there is an example of an embedding. For visual simplicity, this embedding assigns to each sentence, a vector of length 2 (a list of two numbers). These numbers are plotted in the graph in the right, as coordinates. For example, the sentence “The world cup is in Qatar” gets assigned to the vector (4, 2), so it gets plotted in the point with coordinates 4 (horizontal) and 2 (vertical).
 
@@ -98,7 +98,7 @@ However, here’s a caveat. In the above example, we used Euclidean distance, wh
 
 ### Using Similarity to Find the Best Document
 
-In a previous chapter, you learned that <a target="_blank" href="/docs/similarity-between-words-and-sentences">similarity</a> is a way to tell if two pieces of text are similar or different. This uses text embeddings. In particular, you learned about two types of similarity:
+Elsewhere, we've [discussed how embeddings](https://cohere.com/llmu/what-is-semantic-search#:~:text=Using%20Similarity%20to%20Find%20the%20Best%20Document) allow you to tell if two pieces of text are similar or different. This uses text embeddings. In particular, you learned about two types of similarity:
 
 - Dot product similarity
 - Cosine similarity

--- a/fern/pages/llm-university/intro-large-language-models/semantic-search-temp.mdx
+++ b/fern/pages/llm-university/intro-large-language-models/semantic-search-temp.mdx
@@ -21,7 +21,7 @@ updatedAt: "Mon Oct 23 2023 14:40:59 GMT+0000 (Coordinated Universal Time)"
 
 ### Colab Notebook
 
-This chapter comes with a [Colab notebook](https://colab.research.google.com/github/cohere-ai/notebooks/blob/main/notebooks/What_is_Semantic_Search.ipynb) where you get to build a simple semantic search model to answer queries from a small dataset. And if you'd like a more advanced semantic search Colab, check this one <a target="_blank" href="https://colab.research.google.com/github/cohere-ai/notebooks/blob/main/notebooks/Basic_Semantic_Search.ipynb">here</a>!
+This chapter comes with a [Colab notebook](https://github.com/cohere-ai/notebooks/blob/main/notebooks/llmu/What_is_Semantic_Search.ipynb) where you get to build a simple semantic search model to answer queries from a small dataset. And if you'd like a more advanced semantic search Colab, check this one <a target="_blank" href="https://github.com/cohere-ai/notebooks/blob/main/notebooks/guides/Basic_Semantic_Search.ipynb">here</a>!
 
 For the setup, please refer to the [Setting Up](/docs/setting-up) chapter.
 
@@ -60,7 +60,7 @@ In short, semantic search works as follows:
 - It uses a text embedding to turn words into vectors (lists of numbers).  
   Uses similarity to find the vector among the responses which is the most similar to the vector corresponding to the query.
 - Outputs the response corresponding to this most similar vector.  
-  In this chapter, we’ll learn all these steps in detail. First, let’s look at text embeddings. If you need to brush up on these, check out the previous chapter on [text embeddings](https://docs.cohere.com/docs/embeddings).
+  In this chapter, we’ll learn all these steps in detail. First, let’s look at text embeddings. If you need to brush up on these, check out this resource on [text embeddings](https://docs.cohere.com/docs/embeddings).
 
 ### How to Search Using Text Embeddings?
 

--- a/fern/pages/llm-university/intro-semantic-search/multilingual-movie-search.mdx
+++ b/fern/pages/llm-university/intro-semantic-search/multilingual-movie-search.mdx
@@ -225,7 +225,3 @@ Now, use DeepL to translate the movie description to Korean or a different langu
 ### Conclusion
 
 By following the steps in this article, you’ve created a movie recommendation app that recommends movies based on a description written in any language. To accomplish this, you used Cohere’s multilingual model, which embeds movie descriptions into a language-invariant embedding space, capturing similarities between movies regardless of language.
-
-### Original Source
-
-This material comes from the post <a target="_blank" href="/page/multilingual-movie-search">Multilingual Movie Search</a>

--- a/fern/pages/llm-university/intro-semantic-search/multilingual-movie-search.mdx
+++ b/fern/pages/llm-university/intro-semantic-search/multilingual-movie-search.mdx
@@ -86,7 +86,7 @@ Running this function should give the following output: “Movie database ready!
 
 ### Step 2: Build a User Interface to Get Movie Descriptions
 
-In this step, we'll use the Streamlit Python library to build an interactive and user-friendly interface in your browser. (If you'd like to learn more about deploying in Streamlit, please check <a target="_blank" href="https://dash.readme.com/project/cohere-ai/v1.0/docs/deploying-with-streamlit">this chapter</a> in the deployment module, where you can learn all the details).
+In this step, we'll use the Streamlit Python library to build an interactive and user-friendly interface in your browser. (If you'd like to learn more about deploying in Streamlit, please check <a target="_blank" href="https://cohere.com/llmu/deploy-streamlit">this chapter</a> in the deployment module, where you can learn all the details).
 
 To improve the interface design, use the `streamlit_header_and_footer_setup` function implemented in the utils.py file. This will set up a header and footer for your app, apply custom CSS to style both, and incorporate the Cohere brand logo into the header.
 


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR makes changes to the semantic search documentation.

- The text embedding section has been updated to include a link to the Cohere documentation.
- The section on using similarity to find the best document has been updated to include a link to the Cohere documentation.
- The 'Original Source' section has been removed.

<!-- end-generated-description -->