### PR TITLE
Add Image Embeddings rate limits

### DIFF
--- a/fern/pages/going-to-production/rate-limits.mdx
+++ b/fern/pages/going-to-production/rate-limits.mdx
@@ -15,14 +15,15 @@ Cohere offers two kinds of API keys: evaluation keys (free but limited in usage)
 
 | Endpoint                                   | Trial rate limit      | Production rate limit |
 | ------------------------------------------ | --------------------- | --------------------- |
+| [Chat](/reference/chat)                    | 20/min                | 500/min               |
 | [Embed](/reference/embed)                  | 100/min               | 2,000/min             |
+| [Embed (Images)](/reference/embed)         | 40/min                | 40/min                |
+| [Rerank](/reference/rerank)                | 10/min                | 1,000/min             |
 | [Tokenize](/reference/tokenize)            | 100/min               | 2,000/min             |
 | [Classify](/reference/classify)            | 100/min               | 1000/min              |
-| [Rerank](/reference/rerank)                | 10/min                | 1,000/min             |
-| [Summarize (legacy)](/reference/summarize) | 5/min                 | 500/min               |
-| [Chat](/reference/chat)                    | 20/min                | 500/min               |
-| [Generate (legacy)](/reference/generate)   | 5/min                 | 500/min               |
 | [EmbedJob](/reference/embed-jobs)          | 5/min                 | 50/min                |
+| [Summarize (legacy)](/reference/summarize) | 5/min                 | 500/min               |
+| [Generate (legacy)](/reference/generate)   | 5/min                 | 500/min               |
 | Default (anything not covered above)       | 500/min               | 500/min               |
 
 In addition, all endpoints are limited to 1,000 calls **per month** with a **trial** key.

--- a/fern/pages/going-to-production/rate-limits.mdx
+++ b/fern/pages/going-to-production/rate-limits.mdx
@@ -17,7 +17,7 @@ Cohere offers two kinds of API keys: evaluation keys (free but limited in usage)
 | ------------------------------------------ | --------------------- | --------------------- |
 | [Chat](/reference/chat)                    | 20/min                | 500/min               |
 | [Embed](/reference/embed)                  | 100/min               | 2,000/min             |
-| [Embed (Images)](/reference/embed)         | 40/min                | 40/min                |
+| [Embed (Images)](/reference/embed)         | 5/min                 | 40/min                |
 | [Rerank](/reference/rerank)                | 10/min                | 1,000/min             |
 | [Tokenize](/reference/tokenize)            | 100/min               | 2,000/min             |
 | [Classify](/reference/classify)            | 100/min               | 1000/min              |


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the rate limits for various Cohere API endpoints, ensuring accurate and up-to-date information for users. The changes include:

- Adding a new row for the `/reference/chat` endpoint, specifying a trial rate limit of 20/min and a production rate limit of 500/min.
- Introducing a new row for the `/reference/embed-images` endpoint, with a trial rate limit of 5/min and a production rate limit of 40/min.
- Adjusting the order of rows to maintain consistency and clarity.
- Removing the duplicate row for the `/reference/rerank` endpoint, ensuring a single entry with the correct rate limits.
- Removing the duplicate row for the `/reference/embed-jobs` endpoint, leaving only one entry with the appropriate rate limits.
- Moving the row for the `/reference/chat` endpoint to a more appropriate position, aligning with the alphabetical order of endpoints.

<!-- end-generated-description -->