### PR TITLE
Docs: make code block comment color more contrast

### DIFF
--- a/fern/assets/input.css
+++ b/fern/assets/input.css
@@ -634,3 +634,10 @@ button[class^="Sidebar-link-buttonWrapper"] {
 .extra-green {
   color: #38761d !important;
 }
+
+/*
+    This is hacky fix for the code block comment color
+*/
+.code-block-line-content span[style*="color: rgb(194, 195, 197)"] {
+    color: rgb(155, 156, 158) !important;
+}


### PR DESCRIPTION
In scope of this PR we introduce change to make comment in code block section more contrast.
Change affects only light theme.

Before the change:
![image](https://github.com/user-attachments/assets/74cd3678-9101-4c79-9274-df96f65f5a07)

After the change:
![image](https://github.com/user-attachments/assets/308442e9-d6e7-4c48-9380-4428621218ee)
