### PR TITLE
Adding information about the refreshed models on Azure.

### DIFF
--- a/fern/pages/deployment-options/cohere-on-microsoft-azure.mdx
+++ b/fern/pages/deployment-options/cohere-on-microsoft-azure.mdx
@@ -17,8 +17,8 @@ In this article, you learn how to use [Azure AI Studio](https://ai.azure.com/) t
 
 The following six models are available through Azure AI Studio with pay-as-you-go, token-based billing:
 
-- Command R
-- Command R+
+- Command R (and the [refreshed Command R model](https://docs.cohere.com/docs/command-r#:~:text=Command%20R%20August%202024%20Release))
+- Command R+ (and the [refreshed Command R+ model](https://docs.cohere.com/docs/command-r-plus#:~:text=Command%20R%2B%20August%202024%20Release))
 - Embed v3 - English
 - Embed v3 - Multilingual
 - Cohere Rerank V3 (English)
@@ -93,6 +93,8 @@ except urllib.error.HTTPError as error:
 You can find more code snippets, including examples of how to stream responses, in this [notebook](https://github.com/Azure/azureml-examples/blob/main/sdk/python/foundation-models/cohere/webrequests.ipynb).
 
 Though this section is called "Text Generation", it's worth pointing out that these models are capable of much more. Specifically, you can use Azure-hosted Cohere models for both retrieval augmented generation and [multi-step tool use](/docs/multi-step-tool-use). Check the linked pages for much more information.
+
+Finally, we released refreshed versions of Command R and Command R+ in August 2024, both of which are now available on Azure. Check [these Microsoft docs](https://learn.microsoft.com/en-us/azure/ai-studio/how-to/deploy-models-cohere-command?tabs=cohere-command-r-08-2024&pivots=programming-language-python#:~:text=the%20model%20catalog.-,Cohere%20Command%20chat%20models,-The%20Cohere%20Command) for more information (select the Cohere Command R 08-2024 or Cohere Command R+ 08-2024 tabs).
 
 ## Embeddings
 

--- a/fern/pages/v2/deployment-options/cohere-on-microsoft-azure.mdx
+++ b/fern/pages/v2/deployment-options/cohere-on-microsoft-azure.mdx
@@ -21,8 +21,8 @@ In this article, you learn how to use [Azure AI Studio](https://ai.azure.com/) t
 
 The following six models are available through Azure AI Studio with pay-as-you-go, token-based billing:
 
-- Command R
-- Command R+
+- Command R (and the [refreshed Command R model](https://docs.cohere.com/docs/command-r#:~:text=Command%20R%20August%202024%20Release))
+- Command R+ (and the [refreshed Command R+ model](https://docs.cohere.com/docs/command-r-plus#:~:text=Command%20R%2B%20August%202024%20Release))
 - Embed v3 - English
 - Embed v3 - Multilingual
 - Cohere Rerank V3 (English)
@@ -97,6 +97,8 @@ except urllib.error.HTTPError as error:
 You can find more code snippets, including examples of how to stream responses, in this [notebook](https://github.com/Azure/azureml-examples/blob/main/sdk/python/foundation-models/cohere/webrequests.ipynb).
 
 Though this section is called "Text Generation", it's worth pointing out that these models are capable of much more. Specifically, you can use Azure-hosted Cohere models for both retrieval augmented generation and [multi-step tool use](/docs/multi-step-tool-use). Check the linked pages for much more information.
+
+Finally, we released refreshed versions of Command R and Command R+ in August 2024, both of which are now available on Azure. Check [these Microsoft docs](https://learn.microsoft.com/en-us/azure/ai-studio/how-to/deploy-models-cohere-command?tabs=cohere-command-r-08-2024&pivots=programming-language-python#:~:text=the%20model%20catalog.-,Cohere%20Command%20chat%20models,-The%20Cohere%20Command) for more information (select the Cohere Command R 08-2024 or Cohere Command R+ 08-2024 tabs).
 
 ## Embeddings
 


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the list of available models through Azure AI Studio with pay-as-you-go, token-based billing. It adds refreshed versions of Command R and Command R+ that were released in August 2024 and are now available on Azure.

- Adds refreshed versions of Command R and Command R+ to the list of available models.
- Includes links to the refreshed models' documentation.
- Mentions the release date of the refreshed models and their availability on Azure.

<!-- end-generated-description -->