### PR TITLE
Fix duplicates titles on fine-tuning reference and fine tuning page

### DIFF
--- a/fern/pages/v2/fine-tuning/classify-fine-tuning/classify-starting-the-training.mdx
+++ b/fern/pages/v2/fine-tuning/classify-fine-tuning/classify-starting-the-training.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Trains and deploys a fine-tuned model."
+title: "Train and deploy a fine-tuned model."
 slug: "v2/docs/classify-starting-the-training"
 
 hidden: false

--- a/fern/v2.yml
+++ b/fern/v2.yml
@@ -156,7 +156,7 @@ navigation:
             contents:
               - page: Preparing the Classify Fine-tuning data
                 path: pages/v2/fine-tuning/classify-fine-tuning/classify-preparing-the-data.mdx
-              - page: Trains and deploys a fine-tuned model
+              - page: Train and deploy a fine-tuned model
                 path: pages/v2/fine-tuning/classify-fine-tuning/classify-starting-the-training.mdx
               - page: Understanding the Classify Fine-tuning Results
                 path: pages/fine-tuning/classify-fine-tuning/classify-understanding-the-results.mdx


### PR DESCRIPTION
It was reported by site audit that we have duplicated titles on a couple pages so this change has to resove that issue

Pages with duplicated titles:

https://docs.cohere.com/v2/reference/createfinetunedmodel
https://docs.cohere.com/v2/docs/classify-starting-the-training