### PR TITLE
Update OCI model availability

### DIFF
--- a/fern/pages/deployment-options/oracle-cloud-infrastructure-oci.mdx
+++ b/fern/pages/deployment-options/oracle-cloud-infrastructure-oci.mdx
@@ -15,8 +15,6 @@ In an effort to make our language-model capabilities more widely available, we'v
 
 Here, you'll learn how to use Oracle Cloud Infrastructure (OCI) to deploy both the Cohere Command and the Cohere Embed models on the AWS cloud computing platform. The following models are available on OCI:
 
-- Command
-- Command light
 - Command R+
 - Command R
 - Embed English v3
@@ -24,7 +22,9 @@ Here, you'll learn how to use Oracle Cloud Infrastructure (OCI) to deploy both t
 - Embed Multilingual v3
 - Embed Multilingual v3 light
 
-We also support fine-tuning for Command R, Command and Command light on OCI.
+We also support fine-tuning for Command R (`command-r-04-2024` and `command-r-08-2024`) on OCI. 
+
+For the most updated list of available models, see the [OCI documentation](https://docs.oracle.com/en-us/iaas/Content/generative-ai/pretrained-models.htm).
 
 ## Working With Cohere Models on OCI
 


### PR DESCRIPTION
- Removes Command and Command light from available models list
- Updates fine-tuning support information to specify Command R versions (command-r-04-2024 and command-r-08-2024)
- Adds reference link to OCI documentation for up-to-date model listings