### PR TITLE
Update Rerank docs to clarify how tokens from the query and document are combined for each document

### DIFF
--- a/fern/pages/models/rerank-2.mdx
+++ b/fern/pages/models/rerank-2.mdx
@@ -21,5 +21,5 @@ Rerank models sort text inputs by semantic relevance to a specified query. They 
 | `rerank-multilingual-v2.0` | A model for documents that are not in English. Supports the same languages as `embed-multilingual-v3.0`. This model has a context length of 512 tokens.                                | Text     | N/A        | [Rerank](/reference/rerank) |
 
 <Note> 
-Rerank accepts full strings and than tokens, so the token limit works a little differently. Rerank will automatically chunk documents longer than 4096 tokens, and there is therefore no explicit limit to how long a document can be when using rerank. See our [best practice guide](/docs/reranking-best-practices) for more info about formatting documents for the Rerank endpoint.
+For each document included in a request, Rerank combines the tokens from the query with the tokens from the document and the combined total counts toward the context limit for a single document.  If the combined number of tokens from the query and a document exceeds the model’s context length for a single document, the document will automatically get chunked and processed in multiple inferences. See our [best practice guide](/docs/reranking-best-practices) for more info about formatting documents for the Rerank endpoint.
 </Note>


### PR DESCRIPTION
...and the process for handling documents in cases where the combined tokens from the query + document exceed the context limit.