### PR TITLE
Add sagemaker jumpstart guide

### DIFF
--- a/fern/pages/deployment-options/cohere-on-aws/amazon-sagemaker-setup-guide.mdx
+++ b/fern/pages/deployment-options/cohere-on-aws/amazon-sagemaker-setup-guide.mdx
@@ -100,6 +100,19 @@ result = co.chat(message="Write a LinkedIn post about starting a career in tech:
 print(result)
 ```
 
+## Access Via Amazon SageMaker Jumpstart
+
+Cohere's models are also available on Amazon SageMaker Jumpstart, which makes it easy to access the models with just a few clicks.
+
+To access Cohere's models on SageMaker Jumpstart, follow these steps:
+
+- In the AWS Console, go to Amazon SageMaker and click `Studio`.
+- Then, click `Open Studio`. If you don't see this option, you first need to create a user profile.
+- This will bring you to the SageMaker Studio page. Look for `Prebuilt and automated solutions` and select `JumpStart`.
+- A list of models will appear. To look for Cohere models, type "cohere" in the search bar.
+- Select any Cohere model and you will find details about the model and links to further resources.
+- You can try out the model by going to the `Notebooks` tab, where you can launch the notebook in JupyterLab.
+
 ## Next Steps
 
 With your selected configuration and Product ARN available, you now have everything you need to integrate with Cohere’s model offerings on SageMaker. 


### PR DESCRIPTION
Adds documentation for accessing Cohere models through Amazon SageMaker Jumpstart, providing step-by-step instructions for users to easily find and use Cohere models in the SageMaker Studio interface.