### PR TITLE
Adding a 'contact support' message.

### DIFF
--- a/fern/pages/deployment-options/cohere-on-aws/amazon-sagemaker-setup-guide.mdx
+++ b/fern/pages/deployment-options/cohere-on-aws/amazon-sagemaker-setup-guide.mdx
@@ -113,6 +113,8 @@ To access Cohere's models on SageMaker Jumpstart, follow these steps:
 - Select any Cohere model and you will find details about the model and links to further resources.
 - You can try out the model by going to the `Notebooks` tab, where you can launch the notebook in JupyterLab.
 
+If you have any questions about this process, reach out to support@cohere.com.
+
 ## Next Steps
 
 With your selected configuration and Product ARN available, you now have everything you need to integrate with Cohere’s model offerings on SageMaker. 


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR adds a support email address to the Amazon SageMaker setup guide. The email address is provided to help users with any questions they may have about the process.

- A new line is added to the guide: `If you have any questions about this process, reach out to support@cohere.com.`

<!-- end-generated-description -->