### PR TITLE
update token limit in document chunking example

### DIFF
--- a/fern/pages/text-embeddings/reranking/reranking-best-practices.mdx
+++ b/fern/pages/text-embeddings/reranking/reranking-best-practices.mdx
@@ -33,11 +33,11 @@ In the following two tables, you'll find recommendations for getting the best Re
 
 ## Document Chunking
 
-For `rerank-v3.0`, the model breaks documents into 4094 token chunks. For example, if your query is 100 tokens and your document is 10,000 tokens, your document will be broken into the following chunks:
+For `rerank-v3.0`, the model breaks documents into 4096 token chunks. For example, if your query is 100 tokens and your document is 10,000 tokens, your document will be broken into the following chunks:
 
-1. `relevance_score_1 = <query[0,99], document[0,3994]>`
-2. `relevance_score_2 = <query[0,99], document[3995,7989]>`
-3. `relevance_score_3 = <query[0,99],document[7990,9999]>`
+1. `relevance_score_1 = <query[0,99], document[0,3995]>`
+2. `relevance_score_2 = <query[0,99], document[3996,7991]>`
+3. `relevance_score_3 = <query[0,99],document[7992,9999]>`
 4. `relevance_score = max(relevance_score_1, relevance_score_2, relevance_score_3)`
 
 If you would like more control over how chunking is done, we recommend that you chunk your documents yourself.


### PR DESCRIPTION
update token limit in document chunking example to reflect the 4096 query + document token limit for rerank-english-v3.0 and rerank-multilingual-v3.0