### PR TITLE
Update note on cloud deployments for v2 API

### DIFF
--- a/fern/pages/v2/deployment-options/cohere-on-aws/amazon-bedrock.mdx
+++ b/fern/pages/v2/deployment-options/cohere-on-aws/amazon-bedrock.mdx
@@ -9,9 +9,9 @@ keywords: 'Cohere on AWS, language models on AWS, Amazon Bedrock, Amazon SageMak
 createdAt: 'Thu Feb 01 2024 18:08:37 GMT+0000 (Coordinated Universal Time)'
 updatedAt: 'Thu May 30 2024 16:00:53 GMT+0000 (Coordinated Universal Time)'
 ---
-<Info title="Note"> 
+<Note title="Note"> 
 The code examples in this section use the Cohere v1 API. The v2 API is not yet supported for cloud deployments and will be coming soon.
-</Info>
+</Note>
 In an effort to make our language-model capabilities more widely available, we've partnered with a few major platforms to create hosted versions of our offerings. 
 
 Here, you'll learn how to use Amazon Bedrock to deploy both the Cohere Command and the Cohere Embed models on the AWS cloud computing platform. The following models are available on Bedrock:

--- a/fern/pages/v2/deployment-options/cohere-on-aws/amazon-sagemaker-setup-guide.mdx
+++ b/fern/pages/v2/deployment-options/cohere-on-aws/amazon-sagemaker-setup-guide.mdx
@@ -10,9 +10,9 @@ keywords: "Amazon SageMaker, Generative AI on AWS"
 createdAt: "Wed Jun 28 2023 14:29:11 GMT+0000 (Coordinated Universal Time)"
 updatedAt: "Thu May 30 2024 16:01:40 GMT+0000 (Coordinated Universal Time)"
 ---
-<Info title="Note"> 
+<Note title="Note"> 
 The code examples in this section use the Cohere v1 API. The v2 API is not yet supported for cloud deployments and will be coming soon.
-</Info>
+</Note>
 In an effort to make our language-model capabilities more widely available, we've partnered with a few major platforms to create hosted versions of our offerings.
 
 This document will guide you through enabling development teams to access [Cohere’s offerings on Amazon SageMaker](https://aws.amazon.com/marketplace/seller-profile?id=87af0c85-6cf9-4ed8-bee0-b40ce65167e0). 

--- a/fern/pages/v2/deployment-options/cohere-on-microsoft-azure.mdx
+++ b/fern/pages/v2/deployment-options/cohere-on-microsoft-azure.mdx
@@ -11,9 +11,9 @@ keywords: "generative AI, large language models, Microsoft Azure"
 createdAt: "Mon Apr 08 2024 14:53:59 GMT+0000 (Coordinated Universal Time)"
 updatedAt: "Wed May 01 2024 16:11:36 GMT+0000 (Coordinated Universal Time)"
 ---
-<Info title="Note"> 
+<Note title="Note"> 
 The code examples in this section use the Cohere v1 API. The v2 API is not yet supported for cloud deployments and will be coming soon.
-</Info>
+</Note>
 
 In an effort to make our language-model capabilities more widely available, we've partnered with a few major platforms to create hosted versions of our offerings. 
 

--- a/fern/pages/v2/deployment-options/cohere-works-everywhere.mdx
+++ b/fern/pages/v2/deployment-options/cohere-works-everywhere.mdx
@@ -12,9 +12,9 @@ createdAt: "Thu Jun 06 2024 10:53:49 GMT+0000 (Coordinated Universal Time)"
 updatedAt: "Tue Jun 18 2024 16:38:28 GMT+0000 (Coordinated Universal Time)"
 ---
 
-<Info title="Note"> 
+<Note title="Note"> 
 The code examples in this section use the Cohere v1 API. The v2 API is not yet supported for cloud deployments and will be coming soon.
-</Info>
+</Note>
 
 To maximize convenience in building on and switching between Cohere-supported environments, we have developed SDKs that seamlessly support whichever backend you choose. This allows you to start developing your project with one backend while maintaining the flexibility to switch, should the need arise.
 

--- a/fern/v2.yml
+++ b/fern/v2.yml
@@ -235,7 +235,7 @@ navigation:
               - page: Amazon Bedrock
                 path: pages/v2/deployment-options/cohere-on-aws/amazon-bedrock.mdx
               - section: Amazon SageMaker
-                path: pages/deployment-options/cohere-on-aws/amazon-sagemaker-setup-guide.mdx
+                path: pages/v2/deployment-options/cohere-on-aws/amazon-sagemaker-setup-guide.mdx
                 contents:
                   - page: Deploy Your Own Finetuned Command-R-0824 Model from AWS Marketplace
                     path: pages/deployment-options/cohere-on-aws/amazon-sagemaker-setup-guide/byo-finetuning-sm.mdx


### PR DESCRIPTION
This PR updates the note on cloud deployments for v2 API. Also corrects one link in the yml to point to v2.