### PR TITLE
Bad slug, missing link.

### DIFF
--- a/fern/pages/models/aya.mdx
+++ b/fern/pages/models/aya.mdx
@@ -1,6 +1,6 @@
 ---
 title: Aya Family of Models
-slug: aya/tools
+slug: "docs/aya"
 hidden: false
 description: >-
   Understand Cohere for AI's groundbreaking multilingual Aya models, which aim to bring many more languages into generative AI.
@@ -66,7 +66,7 @@ Espero que esta historia te sea útil para ilustrar vocabulario sencillo en espa
 Finally, you can directly download the raw models for research purposes because Cohere For AI has released [Aya Expanse 8B](https://huggingface.co/CohereForAI/aya-expanse-8b) and [Aya Expanse 32B](https://huggingface.co/CohereForAI/aya-expanse-32b) as open-weight models, through HuggingFace. What’s more, the massively multilingual instruction data used for development of these models has been [made available](https://huggingface.co/datasets/CohereForAI/aya_collection) for download as well.
 
 ## Find More
-We hope you’ve found this as fascinating as we do! If you want to see more substantial projects you can check out these notebooks (source):
+We hope you’ve found this as fascinating as we do! If you want to see more substantial projects you can check out these notebooks ([source](https://huggingface.co/CohereForAI/aya-expanse-32b)):
 
 - [Multilingual Writing Assistant](https://colab.research.google.com/drive/1SRLWQ0HdYN_NbRMVVUHTDXb-LSMZWF60)
 - [AyaMCooking](https://colab.research.google.com/drive/1-cnn4LXYoZ4ARBpnsjQM3sU7egOL_fLB?usp=sharing)


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the slug for the Aya Family of Models page, changing it from `aya/tools` to `docs/aya`. This change ensures that the page is accessible at the correct URL.

## Changes
- The slug for the Aya Family of Models page is updated to `docs/aya`.

<!-- end-generated-description -->