### PR TITLE
Fix chaines of redirects issue

### DIFF
--- a/fern/pages/v2/fine-tuning/fine-tuning-with-the-python-sdk.mdx
+++ b/fern/pages/v2/fine-tuning/fine-tuning-with-the-python-sdk.mdx
@@ -56,5 +56,5 @@ finetuned_model = co.finetuning.create_finetuned_model(
 
 ## Fine-tuning results
 
-When the fine-tune model is ready you will receive an email notification. You can explore the evaluation metrics using the Dashboard and try out your model using one of our APIs on the [Playground](https://dashboard.cohere.com/playground/).
+When the fine-tune model is ready you will receive an email notification. You can explore the evaluation metrics using the Dashboard and try out your model using one of our APIs on the [Playground](https://dashboard.cohere.com/welcome/login?redirect_uri=/playground/chat).
 


### PR DESCRIPTION
It was reported that on v2 Programmatic Fine-tuning pages ([page1](https://docs.cohere.com/v2/docs/fine-tuning-with-the-python-sdk) [page2](https://docs.cohere.com/docs/fine-tuning-with-the-python-sdk)) we have chains of redicts that is recognized as an error in seo tools.

This PRs should fix the issue. I've used the [same approach](https://github.com/cohere-ai/cohere-developer-experience/blob/main/fern/pages/fine-tuning/fine-tuning-with-the-python-sdk.mdx?plain=1#L57) we used in other places which seems to resolve similar issues.
