### PR TITLE
added deprecation policy to docs site

### DIFF
--- a/fern/pages/going-to-production/deprecation.mdx
+++ b/fern/pages/going-to-production/deprecation.mdx
@@ -1,0 +1,44 @@
+---
+title: Deprecations
+slug: docs/deprecations
+hidden: false
+description: >-
+  Learn about Cohere's deprecation policies and recommended replacements
+image: ../../assets/images/4f186df-cohere_docs_preview_image_1200x630_copy.jpg
+keywords: 'Cohere API, large language models, generative AI'
+createdAt: 'Wed Nov 27 2024 00:00:00 GMT+0000 (Coordinated Universal Time)'
+updatedAt: 'Wed Nov 27 2024 00:00:00 GMT+0000 (Coordinated Universal Time)'
+---
+## Deprecations
+Find information around deprecated endpoints and models with their recommended replacements. 
+
+## Overview
+As Cohere launches safer and more capable models, we will regularly retire old models. Applications relying on Cohere's models may need occasional updates to keep working. Impacted customers will always be notified via email and in our documentation along with blog posts.
+This page lists all API deprecations, along with recommended replacements. 
+
+Cohere uses the following terms to describe the lifecycle of our models: 
+-*Active:*The model and endpoint are fully supported and recommended for use. 
+-*Legacy:*The model and endpoints will no longer receive updates and may be deprecated in the future.
+-*Deprecated:*The model and endpoints are no longer available for new customers but continue to be available for existing users until retirement (i.e. an existing user is anyone who has used the model or endpoint within 90 days of the deprecation announcement. We will assign a shut-down date at this point.
+-*Shutdown:*The model and endpoint are no longer available for users. Requests to shutdown models and endpoints will fail.
+
+## Migrating to replacements
+Once a model is deprecated, it is imperative to migrate all usage to a suitable replacement before the shutdown date. Requests to models and endpoints past the shutdown date will fail. 
+To ensure a smooth transition, we recommend thorough testing of your applications with the new models well before the shutdown date. If your team requires assistance, do not hesitate to reach out to support@cohere.ai.
+
+## Deprecation History
+All deprecations are listed below with the most recent announcements at the top.
+
+### 2024-12-02: Rerank v2.0
+On December 2nd, 2024, we announced the release of Rerank-v3.5 along with the deprecation of the rerank-v2.0 model family. 
+
+| Shutdown Date| Deprecated Model| Deprecated Model Price| Recommended Replacement|
+|--------------|-----------------|-----------------------|------------------------|
+| 2025-03-31 | `rerank-english-v2.0` | $1.00 / 1K searches | `rerank-v3.5`|
+| 2025-03-31 | `rerank-multilingual-v2.0` | $1.00 / 1K searches | `rerank-v3.5`|
+
+# Best Practices: 
+1.Regularly check our documentation for updates on announcements regarding the status of models.
+2.Test applications with newer models well before the shutdown date of your current model.
+3.Update any production code to use an active model as soon as possible.
+4.Contact support@cohere.ai if you need any assistance with migration or have any questions. 

--- a/fern/v1.yml
+++ b/fern/v1.yml
@@ -202,6 +202,8 @@ navigation:
             path: pages/going-to-production/rate-limits.mdx
           - page: Going Live
             path: pages/going-to-production/going-live.mdx
+          - page: Deprecations
+            path: pages/going-to-production/deprecation.mdx
           - page: How Does Cohere Pricing Work?
             path: pages/going-to-production/how-does-cohere-pricing-work.mdx
       - section: Integrations

--- a/fern/v2.yml
+++ b/fern/v2.yml
@@ -183,6 +183,8 @@ navigation:
             path: pages/going-to-production/rate-limits.mdx
           - page: Going Live
             path: pages/going-to-production/going-live.mdx
+          - page: Deprecations
+            path: pages/going-to-production/deprecation.mdx
           - page: How Does Cohere Pricing Work?
             path: pages/going-to-production/how-does-cohere-pricing-work.mdx
       - section: Integrations


### PR DESCRIPTION
I think we should also add a model status table but I don't know enough about the generative model statuses to reflect. For now, I think we omit and fast follow

![Screenshot 2024-11-27 at 9 43 40 PM](https://github.com/user-attachments/assets/45aca286-01d3-438a-8e34-16187acbf69a)
