### PR TITLE
It was pointed out that a link was missing, I've added.

### DIFF
--- a/fern/pages/responsible-use/responsible-use/usage-guidelines.mdx
+++ b/fern/pages/responsible-use/responsible-use/usage-guidelines.mdx
@@ -8,7 +8,7 @@ image: "../../../assets/images/da0a0ac-cohere_docs_preview_image_1200x630_copy.j
 keywords: "Cohere API"
 
 createdAt: "Thu Sep 01 2022 19:24:15 GMT+0000 (Coordinated Universal Time)"
-updatedAt: "Thu Nov 21 2024 09::48 GMT+0000 (Coordinated Universal Time)"
+updatedAt: "Fr Nov 29 2024 09::48 GMT+0000 (Coordinated Universal Time)"
 ---
 (This document was updated on 11/21/2024)
 
@@ -43,4 +43,4 @@ You must ensure your Customer Application complies with the Universal Requiremen
 If your Customer Application is public-facing and interacts with human users (including consumers), like chatbots and interactive AI agents, you must: (1) disclose to the users that they are interacting with an AI system rather than a human; and (2) if the Customer Application interacts with minors, comply with any specific child safety regulations and implement appropriate additional safety controls such as age verification and content moderation.
 
 ## Research Exceptions 
-Cohere encourages responsible security and safety research. Limited exceptions to our Usage Policy are possible for research purposes if specifically authorized by us or permitted in accordance with our Responsible Disclosure Policy applicable to security research. For safety-related research that falls outside the scope of our Responsible Disclosure Policy or to report a model safety issue, please contact safety@cohere.com.  
+Cohere encourages responsible security and safety research. Limited exceptions to our Usage Policy are possible for research purposes if specifically authorized by us or permitted in accordance with our Responsible Disclosure Policy applicable to security research. For safety-related research that falls outside the scope of our [Responsible Disclosure Policy](https://trustcenter.cohere.com/) or to report a model safety issue, please contact safety@cohere.com.  


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the `updatedAt` field in the `fern/pages/responsible-use/responsible-use/usage-guidelines.mdx` file.

- The `updatedAt` field is changed from `"Thu Nov 21 2024 09::48 GMT+0000 (Coordinated Universal Time)"` to `"Fr Nov 29 2024 09::48 GMT+0000 (Coordinated Universal Time)"`.
- The updated date is also reflected in the document's header, which now reads `(This document was updated on 11/29/2024)`.

<!-- end-generated-description -->