### PR TITLE
Add snippets for using langchain on private deployments

### DIFF
--- a/fern/pages/integrations/cohere-and-langchain/chat-on-langchain.mdx
+++ b/fern/pages/integrations/cohere-and-langchain/chat-on-langchain.mdx
@@ -284,3 +284,13 @@ chain = load_summarize_chain(llm, chain_type="stuff")
 
 chain.invoke({"input_documents": docs})
 ```
+
+### Using LangChain on Private Deployments
+
+You can use LangChain with privately deployed Cohere models. To use it, specify your model deployment URL in the `base_url` parameter.
+
+```python PYTHON
+llm = ChatCohere(base_url=<YOUR_DEPLOYMENT_URL>,
+                 cohere_api_key="COHERE_API_KEY",              
+                 model="MODEL_NAME")
+```

--- a/fern/pages/integrations/cohere-and-langchain/embed-on-langchain.mdx
+++ b/fern/pages/integrations/cohere-and-langchain/embed-on-langchain.mdx
@@ -111,3 +111,12 @@ embeddings = BedrockEmbeddings(
 
 embeddings.embed_query("This is a content of the document")
 ```
+### Using LangChain on Private Deployments
+
+You can use LangChain with privately deployed Cohere models. To use it, specify your model deployment URL in the `base_url` parameter.
+
+```python PYTHON
+llm = CohereEmbeddings(base_url=<YOUR_DEPLOYMENT_URL>,
+                 cohere_api_key="COHERE_API_KEY",              
+                 model="MODEL_NAME")
+```

--- a/fern/pages/integrations/cohere-and-langchain/rerank-on-langchain.mdx
+++ b/fern/pages/integrations/cohere-and-langchain/rerank-on-langchain.mdx
@@ -84,3 +84,13 @@ citations = docs[-1].metadata['citations']
 print("Citations:")
 print(citations)
 ```
+
+### Using LangChain on Private Deployments
+
+You can use LangChain with privately deployed Cohere models. To use it, specify your model deployment URL in the `base_url` parameter.
+
+```python PYTHON
+llm = CohereRerank(base_url=<YOUR_DEPLOYMENT_URL>,
+                 cohere_api_key="COHERE_API_KEY",              
+                 model="MODEL_NAME")
+```


### PR DESCRIPTION
This PR introduces the ability to use LangChain with privately deployed Cohere models across various integrations. The updates include instructions and code examples for specifying a model deployment URL using the base_url parameter in the following files:
- chat-on-langchain.mdx
- embed-on-langchain.mdx
- rerank-on-langchain.mdx