### PR TITLE
Change rerank overview page slug

### DIFF
--- a/fern/pages/text-embeddings/reranking/overview.mdx
+++ b/fern/pages/text-embeddings/reranking/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Rerank Overview"
-slug: "docs/overview"
+slug: "docs/rerank-overview"
 
 hidden: false
 

--- a/fern/pages/tutorials/build-things-with-cohere/rag-with-cohere.mdx
+++ b/fern/pages/tutorials/build-things-with-cohere/rag-with-cohere.mdx
@@ -314,7 +314,7 @@ Document: {'text': 'Team-Building Activities: We foster team spirit with monthly
 Further reading:
 
 - [Rerank endpoint API reference](/reference/rerank)
-- [Documentation on Rerank](/docs/overview)
+- [Documentation on Rerank](/docs/rerank-overview)
 - [Documentation on Rerank fine-tuning](/docs/rerank-fine-tuning)
 - [Documentation on Rerank best practices](/docs/reranking-best-practices)
 

--- a/fern/pages/tutorials/build-things-with-cohere/reranking-with-cohere.mdx
+++ b/fern/pages/tutorials/build-things-with-cohere/reranking-with-cohere.mdx
@@ -99,7 +99,7 @@ Document: {'text': 'Performance Reviews Frequency: We conduct informal check-ins
 Further reading:
 
 - [Rerank endpoint API reference](/reference/rerank)
-- [Documentation on Rerank](/docs/overview)
+- [Documentation on Rerank](/docs/rerank-overview)
 - [Documentation on Rerank fine-tuning](/docs/rerank-fine-tuning)
 - [Documentation on Rerank best practices](/docs/reranking-best-practices)
 - [LLM University module on Text Representation](https://cohere.com/llmu#text-representation)

--- a/fern/pages/v2/tutorials/build-things-with-cohere/reranking-with-cohere.mdx
+++ b/fern/pages/v2/tutorials/build-things-with-cohere/reranking-with-cohere.mdx
@@ -98,7 +98,7 @@ Document: {'text': 'Performance Reviews Frequency: We conduct informal check-ins
 
 Further reading:
 - [Rerank endpoint API reference](https://docs.cohere.com/reference/rerank)
-- [Documentation on Rerank](https://docs.cohere.com/docs/overview)
+- [Documentation on Rerank](https://docs.cohere.com/docs/rerank-overview)
 - [Documentation on Rerank fine-tuning](https://docs.cohere.com/docs/rerank-fine-tuning)
 - [Documentation on Rerank best practices](https://docs.cohere.com/docs/reranking-best-practices)
 - [LLM University module on Text Representation](https://cohere.com/llmu#text-representation)


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request updates the slug for the "Rerank Overview" page from `docs/overview` to `docs/rerank-overview`. It also updates the links to the documentation on Rerank in several tutorial pages to reflect this change.

- The `slug` field in the `fern/pages/text-embeddings/reranking/overview.mdx` file is updated to `docs/rerank-overview`.
- The links to the documentation on Rerank in the following files are updated to `/docs/rerank-overview`:
  - `fern/pages/tutorials/build-things-with-cohere/rag-with-cohere.mdx`
  - `fern/pages/tutorials/build-things-with-cohere/reranking-with-cohere.mdx`
  - `fern/pages/v2/tutorials/build-things-with-cohere/reranking-with-cohere.mdx`

<!-- end-generated-description -->