### PR TITLE
Add warning about client version for Rerank on Bedrock

### DIFF
--- a/fern/pages/v2/deployment-options/cohere-works-everywhere.mdx
+++ b/fern/pages/v2/deployment-options/cohere-works-everywhere.mdx
@@ -167,6 +167,10 @@ public class ChatPost {
 
 #### Bedrock
 
+<Warning title="Rerank API Compatibility">
+Rerank 3.5 on bedrock is only supported with Rerank API v2, via `BedrockClientV2()`
+</Warning>
+
 <CodeBlocks>
 ```typescript TS 
 const { BedrockClient } = require('cohere-ai');

--- a/fern/pages/v2/deployment-options/cohere-works-everywhere.mdx
+++ b/fern/pages/v2/deployment-options/cohere-works-everywhere.mdx
@@ -168,7 +168,7 @@ public class ChatPost {
 #### Bedrock
 
 <Warning title="Rerank API Compatibility">
-Rerank 3.5 on bedrock is only supported with Rerank API v2, via `BedrockClientV2()`
+Rerank 3.5 on Bedrock is only supported with Rerank API v2, via `BedrockClientV2()`
 </Warning>
 
 <CodeBlocks>

--- a/fern/pages/v2/deployment-options/cohere-works-everywhere.mdx
+++ b/fern/pages/v2/deployment-options/cohere-works-everywhere.mdx
@@ -168,7 +168,7 @@ public class ChatPost {
 #### Bedrock
 
 <Warning title="Rerank API Compatibility">
-Rerank 3.5 on Bedrock is only supported with Rerank API v2, via `BedrockClientV2()`
+Rerank v3.5 on Bedrock is only supported with Rerank API v2, via `BedrockClientV2()`
 </Warning>
 
 <CodeBlocks>


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR adds a warning about the compatibility of the Rerank API with Bedrock.

- A new warning is added to the page, stating that Rerank 3.5 on Bedrock is only supported with Rerank API v2, via `BedrockClientV2()`.

<!-- end-generated-description -->