### PR TITLE
Fix redirect to old rerank overview page

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -156,7 +156,7 @@ redirects:
     destination: "/docs/overview-rag-connectors"
     permanent: true
   - source: "/docs/reranking"
-    destination: "/docs/overview"
+    destination: "/docs/rerank-overview"
     permanent: true
   - source: "/reference/rerank-1"
     destination: "/reference/rerank"


### PR DESCRIPTION
Since we migrated rerank overview from `docs/overview` to `docs/rerank-oveview` we should fix all urls to resolve SEO issues