### PR TITLE
Image embed limit

### DIFF
--- a/fern/pages/going-to-production/rate-limits.mdx
+++ b/fern/pages/going-to-production/rate-limits.mdx
@@ -17,7 +17,7 @@ Cohere offers two kinds of API keys: evaluation keys (free but limited in usage)
 | ------------------------------------------ | --------------------- | --------------------- |
 | [Chat](/reference/chat)                    | 20/min                | 500/min               |
 | [Embed](/reference/embed)                  | 100/min               | 2,000/min             |
-| [Embed (Images)](/reference/embed)         | 5/min                 | 40/min                |
+| [Embed (Images)](/reference/embed)         | 200/min               | 400/min               |
 | [Rerank](/reference/rerank)                | 10/min                | 1,000/min             |
 | [Tokenize](/reference/tokenize)            | 100/min               | 2,000/min             |
 | [Classify](/reference/classify)            | 100/min               | 1000/min              |

--- a/fern/pages/going-to-production/rate-limits.mdx
+++ b/fern/pages/going-to-production/rate-limits.mdx
@@ -17,7 +17,7 @@ Cohere offers two kinds of API keys: evaluation keys (free but limited in usage)
 | ------------------------------------------ | --------------------- | --------------------- |
 | [Chat](/reference/chat)                    | 20/min                | 500/min               |
 | [Embed](/reference/embed)                  | 100/min               | 2,000/min             |
-| [Embed (Images)](/reference/embed)         | 200/min               | 400/min               |
+| [Embed (Images)](/reference/embed)         | 5/min                 | 400/min               |
 | [Rerank](/reference/rerank)                | 10/min                | 1,000/min             |
 | [Tokenize](/reference/tokenize)            | 100/min               | 2,000/min             |
 | [Classify](/reference/classify)            | 100/min               | 1000/min              |


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request updates the rate limits for the Cohere API keys. The changes are as follows:

- The rate limit for the **Embed (Images)** API key has been increased from **40/min** to **400/min**.

<!-- end-generated-description -->