### PR TITLE
Update tools-on-langchain.mdx

### DIFF
--- a/fern/pages/integrations/cohere-and-langchain/tools-on-langchain.mdx
+++ b/fern/pages/integrations/cohere-and-langchain/tools-on-langchain.mdx
@@ -70,7 +70,7 @@ print(response['output'])
 
 ## Single-Step Tool Use
 
-In order to utilize single-step mode, you have to set `force_single_step=False`. Here's an example of using it to answer a few questions:
+In order to utilize single-step mode, you have to set `force_single_step=True`. Here's an example of using it to answer a few questions:
 
 ```python PYTHON
 from langchain_cohere import ChatCohere


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the code for using single-step mode in the `langchain_cohere` module.

- The `force_single_step` flag has been changed from `False` to `True`.
- This change ensures that single-step mode is enabled when using the `ChatCohere` class.

<!-- end-generated-description -->