### PR TITLE
Fix duplicate code in RAG page

### DIFF
--- a/fern/pages/v2/text-generation/retrieval-augmented-generation-rag.mdx
+++ b/fern/pages/v2/text-generation/retrieval-augmented-generation-rag.mdx
@@ -359,15 +359,6 @@ response = co.chat_stream(
     model="command-r-plus-08-2024",
     messages=messages,
     documents=documents,
-    citation_options={"mode":"accurate"}
-)
-
-messages = [{"role": "user", "content": "Where do the tallest penguins live?"}]
-
-response = co.chat_stream(
-    model="command-r-plus-08-2024",
-    messages=messages,
-    documents=documents,
     citation_options={"mode":"fast"}
 )
 


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR removes the following lines of code:

```
response = co.chat_stream(
    model="command-r-plus-08-2024",
    messages=messages,
    documents=documents,
    citation_options={"mode":"accurate"}
)

messages = [{"role": "user", "content": "Where do the tallest penguins live?"}]
```

## Summary
The PR removes the code that sets the `response` variable to the result of the `co.chat_stream` function. This function is used to generate a response to a user's message, and the removed code sets the model, messages, documents, and citation options for the function.

## Changes
- The `response` variable is no longer set to the result of the `co.chat_stream` function.
- The `messages` variable is no longer set to a list containing a user message.

<!-- end-generated-description -->