### PR TITLE
Changing on-page teams and roles copy.

### DIFF
--- a/fern/pages/cohere-api/teams-and-roles.mdx
+++ b/fern/pages/cohere-api/teams-and-roles.mdx
@@ -37,7 +37,8 @@ Users have permissions to:
 - View all other Team members
 - Create and delete custom models
 - View, create, copy, and rename Trial API keys
-- View Production API keys (NOTE: you can see which keys exist, but production keys are only viewable in their entirety when they're created)
+- Make Production API keys (NOTE: Production API keys can only be created after an owner has completed the "Go to Production" form)
+- View Production API keys (NOTE: you can *always* see which keys exist, but production keys are only viewable in their entirety when they’re created)
 - View Usage history
 
 ### Owner
@@ -46,8 +47,6 @@ In addition to the above, Owners have permissions to:
 
 - Invite, remove, and change role type of other Team members
 - Generate, rename, and delete production API keys
-- Complete the “Go to Production” form for your team to receive a production API key. After your team has been approved, you can create any number of production keys
+- Complete the “Go to Production” form for your team to receive a production API key. After your team has been approved, you (or users on your team) can create any number of production keys
 - View and download invoices
 - View and update payment information
-
-Crucially, users are prevented from accessing production API key details to ensure security.


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request introduces changes to the permissions and capabilities of users and owners within the system. The modifications aim to enhance security and streamline the process of managing API keys, particularly production API keys.

## Changes:
- **Users**:
  - Can now `make` and `view` production API keys, with a note that production keys are only viewable in their entirety when they're created.
  - The note regarding viewing production API keys has been updated to clarify that users can always see which keys exist.
- **Owners**:
  - After completing the "Go to Production" form and receiving approval, owners or users on their team can create any number of production keys.

<!-- end-generated-description -->