### PR TITLE
Update meta description for structured-output

### DIFF
--- a/fern/pages/v2/text-generation/structured-outputs.mdx
+++ b/fern/pages/v2/text-generation/structured-outputs.mdx
@@ -4,7 +4,7 @@ slug: "v2/docs/structured-outputs"
 
 hidden: false
 
-description: "This page describes how to get Cohere models to create outputs in a certain format, such as JSON."
+description: "This page describes how to get Cohere models to create outputs in a certain format, such as JSON, TOOLS."
 image: "../../../assets/images/f1cc130-cohere_meta_image.jpg"  
 keywords: "Cohere, language models, structured outputs"
 


### PR DESCRIPTION
It was reported that structured-output pages for v1 and v2 have duplicated meta description.
This PR aims to change a bit description for v2 page to avoid duplicates.