### PR TITLE
Update colab links

### DIFF
--- a/fern/pages/v2/tutorials/build-things-with-cohere/building-a-chatbot-with-cohere.mdx
+++ b/fern/pages/v2/tutorials/build-things-with-cohere/building-a-chatbot-with-cohere.mdx
@@ -7,7 +7,7 @@ image: "../../../../assets/images/f1cc130-cohere_meta_image.jpg"
 keywords: "Cohere, chatbot"
 ---
 
-<a target="_blank" href="https://colab.research.google.com/github/cohere-ai/cohere-developer-experience/blob/main/notebooks/guides/getting-started/v2/tutorial_pt3.ipynb">Open in Colab</a>
+<a target="_blank" href="https://colab.research.google.com/github/cohere-ai/cohere-developer-experience/blob/main/notebooks/guides/getting-started/v2/tutorial_pt3_v2.ipynb">Open in Colab</a>
 
 As its name implies, the Chat endpoint enables developers to build chatbots that can handle conversations. At the core of a conversation is a multi-turn dialog between the user and the chatbot. This requires the chatbot to have the state (or “memory”) of all the previous turns to maintain the state of the conversation.
 

--- a/fern/pages/v2/tutorials/build-things-with-cohere/building-an-agent-with-cohere.mdx
+++ b/fern/pages/v2/tutorials/build-things-with-cohere/building-an-agent-with-cohere.mdx
@@ -7,7 +7,7 @@ image: "../../../../assets/images/f1cc130-cohere_meta_image.jpg"
 keywords: "Cohere, agents"
 ---
 
-<a target="_blank" href="https://colab.research.google.com/github/cohere-ai/cohere-developer-experience/blob/main/notebooks/guides/getting-started/v2/tutorial_pt7.ipynb">Open in Colab</a>
+<a target="_blank" href="https://colab.research.google.com/github/cohere-ai/cohere-developer-experience/blob/main/notebooks/guides/getting-started/v2/tutorial_pt7_v2.ipynb">Open in Colab</a>
 
 Tool use extends the ideas from [RAG](/v2/docs/rag-with-cohere), where external systems are used to guide the response of an LLM, but by leveraging a much bigger set of tools than what’s possible with RAG. The concept of tool use leverages LLMs' useful feature of being able to act as a reasoning and decision-making engine.
 

--- a/fern/pages/v2/tutorials/build-things-with-cohere/rag-with-cohere.mdx
+++ b/fern/pages/v2/tutorials/build-things-with-cohere/rag-with-cohere.mdx
@@ -7,7 +7,7 @@ image: "../../../../assets/images/f1cc130-cohere_meta_image.jpg"
 keywords: "Cohere, retrieval-augmented generation, RAG"
 ---
 
-<a target="_blank" href="https://colab.research.google.com/github/cohere-ai/cohere-developer-experience/blob/main/notebooks/guides/getting-started/v2/tutorial_pt6.ipynb">Open in Colab</a>
+<a target="_blank" href="https://colab.research.google.com/github/cohere-ai/cohere-developer-experience/blob/main/notebooks/guides/getting-started/v2/tutorial_pt6_v2.ipynb">Open in Colab</a>
 
 The Chat endpoint provides comprehensive support for various text generation use cases, including retrieval-augmented generation (RAG). 
 

--- a/fern/pages/v2/tutorials/build-things-with-cohere/reranking-with-cohere.mdx
+++ b/fern/pages/v2/tutorials/build-things-with-cohere/reranking-with-cohere.mdx
@@ -7,7 +7,7 @@ image: "../../../../assets/images/f1cc130-cohere_meta_image.jpg"
 keywords: "Cohere, language models, ReRank models"
 ---
 
-<a target="_blank" href="https://colab.research.google.com/github/cohere-ai/cohere-developer-experience/blob/main/notebooks/guides/getting-started/v2/tutorial_pt5.ipynb">Open in Colab</a>
+<a target="_blank" href="https://colab.research.google.com/github/cohere-ai/cohere-developer-experience/blob/main/notebooks/guides/getting-started/v2/tutorial_pt5_v2.ipynb">Open in Colab</a>
 
 Reranking is a technique that leverages [embeddings](/v2/docs/embeddings) as the last stage of a retrieval process, and is especially useful in [RAG systems](/v2/docs/retrieval-augmented-generation-rag).
 

--- a/fern/pages/v2/tutorials/build-things-with-cohere/semantic-search-with-cohere.mdx
+++ b/fern/pages/v2/tutorials/build-things-with-cohere/semantic-search-with-cohere.mdx
@@ -7,7 +7,7 @@ image: "../../../../assets/images/f1cc130-cohere_meta_image.jpg"
 keywords: "Cohere, language models, "
 ---
 
-<a target="_blank" href="https://colab.research.google.com/github/cohere-ai/cohere-developer-experience/blob/main/notebooks/guides/getting-started/v2/tutorial_pt4.ipynb">Open in Colab</a>
+<a target="_blank" href="https://colab.research.google.com/github/cohere-ai/cohere-developer-experience/blob/main/notebooks/guides/getting-started/v2/tutorial_pt4_v2.ipynb">Open in Colab</a>
 
 [Text embeddings](/v2/docs/embeddings) are lists of numbers that represent the context or meaning inside a piece of text. This is particularly useful in search or information retrieval applications. With text embeddings, this is called semantic search.
 

--- a/fern/pages/v2/tutorials/build-things-with-cohere/text-generation-tutorial.mdx
+++ b/fern/pages/v2/tutorials/build-things-with-cohere/text-generation-tutorial.mdx
@@ -7,7 +7,7 @@ image: "../../../../assets/images/f1cc130-cohere_meta_image.jpg"
 keywords: "Cohere, how do LLMs generate text"
 ---
 
-<a target="_blank" href="https://colab.research.google.com/github/cohere-ai/cohere-developer-experience/blob/main/notebooks/guides/getting-started/v2/tutorial_pt2.ipynb">Open in Colab</a>
+<a target="_blank" href="https://colab.research.google.com/github/cohere-ai/cohere-developer-experience/blob/main/notebooks/guides/getting-started/v2/tutorial_pt2_v2.ipynb">Open in Colab</a>
 
 Command is Cohere’s flagship LLM. It generates a response based on a user message or prompt. It is trained to follow user commands and to be instantly useful in practical business applications, like summarization, copywriting, extraction, and question-answering.
 


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request updates the links to the Colab notebooks for several tutorials.

- The link to the notebook for the tutorial on building a chatbot with Cohere has been updated to `https://colab.research.google.com/github/cohere-ai/cohere-developer-experience/blob/main/notebooks/guides/getting-started/v2/tutorial_pt3_v2.ipynb`.
- The link to the notebook for the tutorial on building an agent with Cohere has been updated to `https://colab.research.google.com/github/cohere-ai/cohere-developer-experience/blob/main/notebooks/guides/getting-started/v2/tutorial_pt7_v2.ipynb`.
- The link to the notebook for the tutorial on RAG with Cohere has been updated to `https://colab.research.google.com/github/cohere-ai/cohere-developer-experience/blob/main/notebooks/guides/getting-started/v2/tutorial_pt6_v2.ipynb`.
- The link to the notebook for the tutorial on reranking with Cohere has been updated to `https://colab.research.google.com/github/cohere-ai/cohere-developer-experience/blob/main/notebooks/guides/getting-started/v2/tutorial_pt5_v2.ipynb`.
- The link to the notebook for the tutorial on semantic search with Cohere has been updated to `https://colab.research.google.com/github/cohere-ai/cohere-developer-experience/blob/main/notebooks/guides/getting-started/v2/tutorial_pt4_v2.ipynb`.
- The link to the notebook for the tutorial on text generation with Cohere has been updated to `https://colab.research.google.com/github/cohere-ai/cohere-developer-experience/blob/main/notebooks/guides/getting-started/v2/tutorial_pt2_v2.ipynb`.

<!-- end-generated-description -->