### PR TITLE
Add rerank multilingual usage clarification

### DIFF
--- a/fern/pages/text-embeddings/reranking/overview.mdx
+++ b/fern/pages/text-embeddings/reranking/overview.mdx
@@ -203,7 +203,13 @@ In the `docs` parameter, we are passing in a list of objects which have the key 
 
 ## Multilingual Reranking
 
-Cohere's `rerank-v3.5` and `rerank-multilingual-v3.0` models have been trained for performance across a variety of languages. Please note that performance may vary across languages. The model is trained on the following languages:
+Cohere's Rerank models have been trained for performance across 100+ languages.
+
+When choosing the model, please note the following language support:
+- **Rerank 3.0**: Separate English-only and multilingual models (`rerank-english-v3.0` and `rerank-multilingual-v3.0`)
+- **Rerank 3.5**: A single multilingual model (`rerank-v3.5`)
+
+The following table provides the list of languages supported by the Rerank models. Please note that performance may vary across languages.
 
 | ISO Code | Language Name  |
 | -------- | -------------- |

--- a/fern/pages/v2/text-embeddings/reranking/overview.mdx
+++ b/fern/pages/v2/text-embeddings/reranking/overview.mdx
@@ -172,7 +172,13 @@ In the `documents` parameter, we are passing in a list YAML strings, representin
 
 ## Multilingual Reranking
 
-Cohere's `rerank-v3.5` and `rerank-multilingual-v3.0` models have been trained for performance across a variety of languages. Please note that performance may vary across languages. The model is trained on the following languages:
+Cohere's Rerank models have been trained for performance across 100+ languages.
+
+When choosing the model, please note the following language support:
+- **Rerank 3.0**: Separate English-only and multilingual models (`rerank-english-v3.0` and `rerank-multilingual-v3.0`)
+- **Rerank 3.5**: A single multilingual model (`rerank-v3.5`)
+
+The following table provides the list of languages supported by the Rerank models. Please note that performance may vary across languages.
 
 | ISO Code | Language Name  |
 | -------- | -------------- |


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the documentation for Cohere's Rerank models, specifically the `rerank-v3.5` and `rerank-multilingual-v3.0` models, to reflect their expanded language support.

## Changes
- The documentation now states that the Rerank models have been trained for performance across 100+ languages.
- It provides guidance on choosing the appropriate model, highlighting the availability of separate English-only and multilingual models for Rerank 3.0 and a single multilingual model for Rerank 3.5.
- A table is added to list the supported languages, with an ISO code and language name for each.

<!-- end-generated-description -->