### PR TITLE
Update getting started tutorial on reranking - removed rank fields

### DIFF
--- a/fern/pages/tutorials/build-things-with-cohere/reranking-with-cohere.mdx
+++ b/fern/pages/tutorials/build-things-with-cohere/reranking-with-cohere.mdx
@@ -9,7 +9,7 @@ keywords: "Cohere, language models, ReRank models"
 
 <a target="_blank" href="https://colab.research.google.com/github/cohere-ai/cohere-developer-experience/blob/main/notebooks/guides/getting-started/tutorial_pt5.ipynb">Open in Colab</a>
 
-Reranking is a technique that leverages [embeddings](/docs/embeddings) as the last stage of a retrieval process, and is especially useful in [RAG systems](/docs/retrieval-augmented-generation-rag).
+Reranking is a technique that provides a semantic boost to the search quality of any keyword or vector search system, and is especially useful in [RAG systems](/v2/docs/retrieval-augmented-generation-rag).
 
 We can rerank results from semantic search as well as any other search systems such as lexical search. This means that companies can retain an existing keyword-based (also called “lexical”) or semantic search system for the first-stage retrieval and integrate the [Rerank endpoint](/docs/rerank-2) in the second-stage reranking.
 
@@ -50,7 +50,7 @@ This is where Rerank can help. We call the endpoint using `co.rerank()` and pass
 
 ```python PYTHON
 # Define the documents
-faqs_short = [
+faqs = [
     {"text": "Reimbursing Travel Expenses: Easily manage your travel expenses by submitting them through our finance tool. Approvals are prompt and straightforward."},
     {"text": "Working from Abroad: Working remotely from another country is possible. Simply coordinate with your manager and ensure your availability during core hours."},
     {"text": "Health and Wellness Benefits: We care about your well-being and offer gym memberships, on-site yoga classes, and comprehensive health insurance."},
@@ -63,10 +63,12 @@ faqs_short = [
 query = "Are there fitness-related perks?"
 
 # Rerank the documents
-results = co.rerank(query=query,
-                    documents=faqs_short,
-                    top_n=2,
-                    model='rerank-english-v3.0')
+results = co.rerank(
+    model='rerank-v3.5',
+    query=query,
+    documents=faqs,
+    top_n=1,
+)
 
 print(results)
 ```
@@ -108,13 +110,11 @@ Further reading:
 
 The Rerank 3 model supports multi-aspect and semi-structured data like emails, invoices, JSON documents, code, and tables. By setting the rank fields, you can select which fields the model should consider for reranking.
 
-In the following example, we'll use an email data example. It is a semi-stuctured data that contains a number of fields – `from`, `to`, `date`, `subject`, and `text`. 
+In the following example, we'll use an email data example. It is a semi-stuctured data that contains a number of fields – `from`, `to`, `date`, `subject`, and `text`. 
 
-Suppose the new hire now wants to search for any emails about check-in sessions. Let's pretend we have a list of five emails retrieved from the email provider's API.
+Suppose the new hire now wants to search for any emails about check-in sessions. Let's pretend we have a list of 5 emails retrieved from the email provider's API.
 
-To perform reranking over semi-structured data, we add an additional parameter, `rank_fields`, which contains the list of available fields.
-
-The model will rerank based on order of the fields passed in. For example, given `rank_fields=['title','author','text']`, the model will rerank using the values in title, author, and text sequentially. 
+To perform reranking over semi-structured data, we convert the documents to YAML format, which prepares the data in the format required for reranking. Then, we pass the YAML formatted documents to the Rerank endpoint.
 
 ```python PYTHON
 # Define the documents
@@ -126,15 +126,19 @@ emails = [
 ```
 
 ```python PYTHON
+# Convert the documents to YAML format
+yaml_docs = [yaml.dump(doc, sort_keys=False) for doc in emails]
+
 # Add the user query
 query = "Any email about check ins?"
 
 # Rerank the documents
-results = co.rerank(query=query,
-                    documents=emails,
-                    top_n=2,
-                    model='rerank-english-v3.0',
-                    rank_fields=["from", "to", "date", "subject", "body"])
+results = co.rerank(
+    model='rerank-v3.5',
+    query=query,
+    documents=yaml_docs,
+    top_n=2,
+)
 
 return_results(results, emails)
 ```
@@ -151,7 +155,7 @@ Document: {'from': 'hr@co1t.com', 'to': 'david@co1t.com', 'date': '2024-06-24', 
 
 ## Reranking tabular data
 
-Many enterprises rely on tabular data, such as relational databases, CSVs, and Excel. To perform reranking, you can transform a dataframe into a list of JSON records and use Rerank 3's JSON capabilities to rank them.
+Many enterprises rely on tabular data, such as relational databases, CSVs, and Excel. To perform reranking, you can transform a dataframe into a list of JSON records and use Rerank 3's JSON capabilities to rank them. We follow the same steps in the previous example, where we convert the data into YAML format before passing it to the Rerank endpoint.
 
 Here's an example of reranking a CSV file that contains employee information.
 
@@ -182,22 +186,23 @@ Here's what the table looks like:
 Below, we'll get results from the Rerank endpoint:
 
 ```python PYTHON
-# Define the documents and rank fields
+# Define the documents
 employees = df.to_dict('records')
-rank_fields = df.columns.tolist()
+
+# Convert the documents to YAML format
+yaml_docs = [yaml.dump(doc, sort_keys=False) for doc in employees]
 
 # Add the user query
 query = "Any full-time product designers who joined recently?"
 
 # Rerank the documents
-results = co.rerank(query=query,
-                    documents=employees,
-                    top_n=1,
-                    model='rerank-english-v3.0',
-                    rank_fields=rank_fields)
-
+results = co.rerank(
+    model='rerank-v3.5',
+    query=query,
+    documents=yaml_docs,
+    top_n=1,
+)
 return_results(results, employees)
-
 ```
 
 ```
@@ -208,21 +213,23 @@ Document: {'name': 'Emma Williams', 'role': 'Product Designer', 'join_date': '20
 
 ## Multilingual reranking
 
-The Rerank endpoint also supports multilingual semantic search via the `rerank-multilingual-...` models. This means you can perform semantic search on texts in different languages.
+The Rerank models (`rerank-v3.5` and `rerank-multilingual-v3.0`) support 100+ languages. This means you can perform semantic search on texts in different languages.
 
-In the example below, we repeat the steps of performing reranking with one difference – changing the model type to a multilingual one. Here, we use the `rerank-multilingual-v3.0` model. Here, we are reranking the FAQ list using an Arabic query.
+In the example below, we repeat the steps of performing reranking with one difference – changing the model type to a multilingual one. Here, we use the `rerank-v3.5` model. Here, we are reranking the FAQ list using an Arabic query.
 
 ```python PYTHON
 # Define the query
 query = "هل هناك مزايا تتعلق باللياقة البدنية؟" # Are there fitness benefits?
 
 # Rerank the documents
-results = co.rerank(query=query,
-                    documents=faqs_short,
-                    top_n=2,
-                    model='rerank-multilingual-v3.0')
+results = co.rerank(
+    model='rerank-v3.5',
+    query=query,
+    documents=faqs,
+    top_n=1,
+)
 
-return_results(results, faqs_short)
+return_results(results, faqs)
 ```
 
 ```
@@ -242,7 +249,7 @@ In this tutorial, you learned about:
 - How to rerank lexical/semantic search results
 - How to rerank semi-structured data
 - How to rerank tabular data
-- How to perform Multilingual reranking
+- How to perform multilingual reranking
 
 We have now seen two critical components of a powerful search system - [semantic search](/docs/semantic-search-with-cohere), or dense retrieval (Part 4) and reranking (Part 5). These building blocks are essential for implementing RAG solutions.
 

--- a/fern/pages/v2/tutorials/build-things-with-cohere/reranking-with-cohere.mdx
+++ b/fern/pages/v2/tutorials/build-things-with-cohere/reranking-with-cohere.mdx
@@ -9,7 +9,7 @@ keywords: "Cohere, language models, ReRank models"
 
 <a target="_blank" href="https://colab.research.google.com/github/cohere-ai/cohere-developer-experience/blob/main/notebooks/guides/getting-started/v2/tutorial_pt5.ipynb">Open in Colab</a>
 
-Reranking is a technique that leverages [embeddings](/v2/docs/embeddings) as the last stage of a retrieval process, and is especially useful in [RAG systems](/v2/docs/retrieval-augmented-generation-rag).
+Reranking is a technique that provides a semantic boost to the search quality of any keyword or vector search system, and is especially useful in [RAG systems](/v2/docs/retrieval-augmented-generation-rag).
 
 We can rerank results from semantic search as well as any other search systems such as lexical search. This means that companies can retain an existing keyword-based (also called “lexical”) or semantic search system for the first-stage retrieval and integrate the [Rerank endpoint](/v2/docs/rerank-2) in the second-stage reranking.
 
@@ -49,7 +49,7 @@ This is where Rerank can help. We call the endpoint using `co.rerank()` and pass
 
 ```python PYTHON
 # Define the documents
-faqs_short = [
+faqs = [
     {"text": "Reimbursing Travel Expenses: Easily manage your travel expenses by submitting them through our finance tool. Approvals are prompt and straightforward."},
     {"text": "Working from Abroad: Working remotely from another country is possible. Simply coordinate with your manager and ensure your availability during core hours."},
     {"text": "Health and Wellness Benefits: We care about your well-being and offer gym memberships, on-site yoga classes, and comprehensive health insurance."},
@@ -63,10 +63,12 @@ faqs_short = [
 query = "Are there fitness-related perks?"
 
 # Rerank the documents
-results = co.rerank(query=query,
-                    documents=faqs_short,
-                    top_n=2,
-                    model='rerank-english-v3.0')
+results = co.rerank(
+    model='rerank-v3.5',
+    query=query,
+    documents=faqs,
+    top_n=1,
+)
 
 print(results)
 ```
@@ -111,10 +113,7 @@ In the following example, we'll use an email data example. It is a semi-stucture
 
 Suppose the new hire now wants to search for any emails about check-in sessions. Let's pretend we have a list of 5 emails retrieved from the email provider's API.
 
-To perform reranking over semi-structured data, we add an additional parameter, `rank_fields`, which contains the list of available fields.
-
-The model will rerank based on order of the fields passed in. For example, given rank_fields=['title','author','text'], the model will rerank using the values in title, author, and text sequentially. 
-
+To perform reranking over semi-structured data, we convert the documents to YAML format, which prepares the data in the format required for reranking. Then, we pass the YAML formatted documents to the Rerank endpoint.
 
 ```python PYTHON
 # Define the documents
@@ -127,15 +126,19 @@ emails = [
 
 
 ```python PYTHON
+# Convert the documents to YAML format
+yaml_docs = [yaml.dump(doc, sort_keys=False) for doc in emails]
+
 # Add the user query
 query = "Any email about check ins?"
 
 # Rerank the documents
-results = co.rerank(query=query,
-                    documents=emails,
-                    top_n=2,
-                    model='rerank-english-v3.0',
-                    rank_fields=["from", "to", "date", "subject", "body"])
+results = co.rerank(
+    model='rerank-v3.5',
+    query=query,
+    documents=yaml_docs,
+    top_n=2,
+)
 
 return_results(results, emails)
 ```
@@ -152,10 +155,9 @@ Document: {'from': 'hr@co1t.com', 'to': 'david@co1t.com', 'date': '2024-06-24', 
 
 ## Reranking tabular data
 
-Many enterprises rely on tabular data, such as relational databases, CSVs, and Excel. To perform reranking, you can transform a dataframe into a list of JSON records and use Rerank 3's JSON capabilities to rank them.
+Many enterprises rely on tabular data, such as relational databases, CSVs, and Excel. To perform reranking, you can transform a dataframe into a list of JSON records and use Rerank 3's JSON capabilities to rank them. We follow the same steps in the previous example, where we convert the data into YAML format before passing it to the Rerank endpoint.
 
 Here's an example of reranking a CSV file that contains employee information.
-
 
 ```python PYTHON
 import pandas as pd
@@ -185,20 +187,22 @@ Below, we'll get results from the Rerank endpoint:
 
 
 ```python PYTHON
-# Define the documents and rank fields
+# Define the documents
 employees = df.to_dict('records')
-rank_fields = df.columns.tolist()
+
+# Convert the documents to YAML format
+yaml_docs = [yaml.dump(doc, sort_keys=False) for doc in employees]
 
 # Add the user query
 query = "Any full-time product designers who joined recently?"
 
 # Rerank the documents
-results = co.rerank(query=query,
-                    documents=employees,
-                    top_n=1,
-                    model='rerank-english-v3.0',
-                    rank_fields=rank_fields)
-
+results = co.rerank(
+    model='rerank-v3.5',
+    query=query,
+    documents=yaml_docs,
+    top_n=1,
+)
 return_results(results, employees)
 
 ```
@@ -211,22 +215,23 @@ Document: {'name': 'Emma Williams', 'role': 'Product Designer', 'join_date': '20
 
 ## Multilingual reranking
 
-The Rerank endpoint also supports multilingual semantic search via the `rerank-multilingual-...` models. This means you can perform semantic search on texts in different languages.
+The Rerank models (`rerank-v3.5` and `rerank-multilingual-v3.0`) support 100+ languages. This means you can perform semantic search on texts in different languages.
 
-In the example below, we repeat the steps of performing reranking with one difference – changing the model type to a multilingual one. Here, we use the `rerank-multilingual-v3.0` model. Here, we are reranking the FAQ list using an Arabic query.
-
+In the example below, we repeat the steps of performing reranking with one difference – changing the model type to a multilingual one. Here, we use the `rerank-v3.5` model. Here, we are reranking the FAQ list using an Arabic query.
 
 ```python PYTHON
 # Define the query
 query = "هل هناك مزايا تتعلق باللياقة البدنية؟" # Are there fitness benefits?
 
 # Rerank the documents
-results = co.rerank(query=query,
-                    documents=faqs_short,
-                    top_n=2,
-                    model='rerank-multilingual-v3.0')
+results = co.rerank(
+    model='rerank-v3.5',
+    query=query,
+    documents=faqs,
+    top_n=1,
+)
 
-return_results(results, faqs_short)
+return_results(results, faqs)
 ```
 ```
 Rank: 1
@@ -245,7 +250,7 @@ In this tutorial, you learned about:
 - How to rerank lexical/semantic search results
 - How to rerank semi-structured data
 - How to rerank tabular data
-- How to perform Multilingual reranking
+- How to perform multilingual reranking
 
 We have now seen two critical components of a powerful search system - [semantic search](/v2/docs/semantic-search-with-cohere), or dense retrieval (Part 4) and reranking (Part 5). These building blocks are essential for implementing RAG solutions.
 

--- a/fern/pages/v2/tutorials/build-things-with-cohere/reranking-with-cohere.mdx
+++ b/fern/pages/v2/tutorials/build-things-with-cohere/reranking-with-cohere.mdx
@@ -113,7 +113,7 @@ In the following example, we'll use an email data example. It is a semi-stucture
 
 Suppose the new hire now wants to search for any emails about check-in sessions. Let's pretend we have a list of 5 emails retrieved from the email provider's API.
 
-To perform reranking over semi-structured data, we convert the documents to YAML format, which prepares the data in the format required for reranking. Then, we pass the YAML formatted documents to the Rerank endpoint.
+To perform reranking over semi-structured data, we serialize the documents to YAML format, which prepares the data in the format required for reranking. Then, we pass the YAML formatted documents to the Rerank endpoint.
 
 ```python PYTHON
 # Define the documents

--- a/notebooks/guides/getting-started/tutorial_pt5.ipynb
+++ b/notebooks/guides/getting-started/tutorial_pt5.ipynb
@@ -20,7 +20,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Reranking is a technique that leverages embeddings as the last stage of a retrieval process, and is especially useful in RAG systems.\n",
+    "Reranking is a technique that provides a semantic boost to the search quality of any keyword or vector search system, and is especially useful in RAG systems.\n",
     "\n",
     "We can rerank results from semantic search as well as any other search systems such as lexical search. This means that companies can retain an existing keyword-based (also called “lexical”) or semantic search system for the first-stage retrieval and integrate the Rerank endpoint in the second-stage reranking.\n",
     "\n",
@@ -85,7 +85,7 @@
    "outputs": [],
    "source": [
     "# Define the documents\n",
-    "faqs_short = [\n",
+    "faqs = [\n",
     "    {\"text\": \"Reimbursing Travel Expenses: Easily manage your travel expenses by submitting them through our finance tool. Approvals are prompt and straightforward.\"},\n",
     "    {\"text\": \"Working from Abroad: Working remotely from another country is possible. Simply coordinate with your manager and ensure your availability during core hours.\"},\n",
     "    {\"text\": \"Health and Wellness Benefits: We care about your well-being and offer gym memberships, on-site yoga classes, and comprehensive health insurance.\"},\n",
@@ -111,10 +111,12 @@
     "query = \"Are there fitness-related perks?\"\n",
     "\n",
     "# Rerank the documents\n",
-    "results = co.rerank(query=query,\n",
-    "                    documents=faqs_short,\n",
-    "                    top_n=2,\n",
-    "                    model='rerank-english-v3.0')\n",
+    "results = co.rerank(\n",
+    "    model='rerank-v3.5',\n",
+    "    query=query,\n",
+    "    documents=faqs,\n",
+    "    top_n=1,\n",
+    ")\n",
     "\n",
     "print(results)"
    ]
@@ -179,9 +181,7 @@
     "\n",
     "Suppose the new hire now wants to search for any emails about check-in sessions. Let's pretend we have a list of 5 emails retrieved from the email provider's API.\n",
     "\n",
-    "To perform reranking over semi-structured data, we add an additional parameter, `rank_fields`, which contains the list of available fields.\n",
-    "\n",
-    "The model will rerank based on order of the fields passed in. For example, given rank_fields=['title','author','text'], the model will rerank using the values in title, author, and text sequentially. "
+    "To perform reranking over semi-structured data, we serialize the documents to YAML format, which prepares the data in the format required for reranking. Then, we pass the YAML formatted documents to the Rerank endpoint."
    ]
   },
   {
@@ -219,15 +219,19 @@
     }
    ],
    "source": [
+    "# Convert the documents to YAML format\n",
+    "yaml_docs = [yaml.dump(doc, sort_keys=False) for doc in emails]\n",
+    "\n",
     "# Add the user query\n",
     "query = \"Any email about check ins?\"\n",
     "\n",
     "# Rerank the documents\n",
-    "results = co.rerank(query=query,\n",
-    "                    documents=emails,\n",
-    "                    top_n=2,\n",
-    "                    model='rerank-english-v3.0',\n",
-    "                    rank_fields=[\"from\", \"to\", \"date\", \"subject\", \"body\"])\n",
+    "results = co.rerank(\n",
+    "    model='rerank-v3.5',\n",
+    "    query=query,\n",
+    "    documents=yaml_docs,\n",
+    "    top_n=2,\n",
+    ")\n",
     "\n",
     "return_results(results, emails)"
    ]
@@ -243,7 +247,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Many enterprises rely on tabular data, such as relational databases, CSVs, and Excel. To perform reranking, you can transform a dataframe into a list of JSON records and use Rerank 3's JSON capabilities to rank them.\n",
+    "Many enterprises rely on tabular data, such as relational databases, CSVs, and Excel. To perform reranking, you can transform a dataframe into a list of JSON records and use Rerank 3's JSON capabilities to rank them. We follow the same steps in the previous example, where we convert the data into YAML format before passing it to the Rerank endpoint.\n",
     "\n",
     "Here's an example of reranking a CSV file that contains employee information."
    ]
@@ -382,21 +386,23 @@
     }
    ],
    "source": [
-    "# Define the documents and rank fields\n",
+    "# Define the documents\n",
     "employees = df.to_dict('records')\n",
-    "rank_fields = df.columns.tolist()\n",
+    "\n",
+    "# Convert the documents to YAML format\n",
+    "yaml_docs = [yaml.dump(doc, sort_keys=False) for doc in employees]\n",
     "\n",
     "# Add the user query\n",
     "query = \"Any full-time product designers who joined recently?\"\n",
     "\n",
     "# Rerank the documents\n",
-    "results = co.rerank(query=query,\n",
-    "                    documents=employees,\n",
-    "                    top_n=1,\n",
-    "                    model='rerank-english-v3.0',\n",
-    "                    rank_fields=rank_fields)\n",
-    "\n",
-    "return_results(results, employees)\n"
+    "results = co.rerank(\n",
+    "    model='rerank-v3.5',\n",
+    "    query=query,\n",
+    "    documents=yaml_docs,\n",
+    "    top_n=1,\n",
+    ")\n",
+    "return_results(results, employees)"
    ]
   },
   {
@@ -440,12 +446,14 @@
     "query = \"هل هناك مزايا تتعلق باللياقة البدنية؟\" # Are there fitness benefits?\n",
     "\n",
     "# Rerank the documents\n",
-    "results = co.rerank(query=query,\n",
-    "                    documents=faqs_short,\n",
-    "                    top_n=2,\n",
-    "                    model='rerank-multilingual-v3.0')\n",
+    "results = co.rerank(\n",
+    "    model='rerank-v3.5',\n",
+    "    query=query,\n",
+    "    documents=faqs,\n",
+    "    top_n=1,\n",
+    ")\n",
     "\n",
-    "return_results(results, faqs_short)"
+    "return_results(results, faqs)"
    ]
   },
   {

--- a/notebooks/guides/getting-started/v2/tutorial_pt5_v2.ipynb
+++ b/notebooks/guides/getting-started/v2/tutorial_pt5_v2.ipynb
@@ -20,7 +20,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Reranking is a technique that leverages embeddings as the last stage of a retrieval process, and is especially useful in RAG systems.\n",
+    "Reranking is a technique that provides a semantic boost to the search quality of any keyword or vector search system, and is especially useful in RAG systems.\n",
     "\n",
     "We can rerank results from semantic search as well as any other search systems such as lexical search. This means that companies can retain an existing keyword-based (also called “lexical”) or semantic search system for the first-stage retrieval and integrate the Rerank endpoint in the second-stage reranking.\n",
     "\n",
@@ -84,7 +84,7 @@
    "outputs": [],
    "source": [
     "# Define the documents\n",
-    "faqs_short = [\n",
+    "faqs = [\n",
     "    \"Reimbursing Travel Expenses: Easily manage your travel expenses by submitting them through our finance tool. Approvals are prompt and straightforward.\",\n",
     "    \"Working from Abroad: Working remotely from another country is possible. Simply coordinate with your manager and ensure your availability during core hours.\",\n",
     "    \"Health and Wellness Benefits: We care about your well-being and offer gym memberships, on-site yoga classes, and comprehensive health insurance.\",\n",
@@ -110,10 +110,12 @@
     "query = \"Are there fitness-related perks?\"\n",
     "\n",
     "# Rerank the documents\n",
-    "results = co.rerank(query=query,\n",
-    "                    documents=faqs_short,\n",
-    "                    top_n=2,\n",
-    "                    model='rerank-3.5')\n",
+    "results = co.rerank(\n",
+    "    model='rerank-v3.5',\n",
+    "    query=query,\n",
+    "    documents=faqs,\n",
+    "    top_n=1,\n",
+    ")\n",
     "\n",
     "print(results)"
    ]
@@ -178,7 +180,7 @@
     "\n",
     "Suppose the new hire now wants to search for any emails about check-in sessions. Let's pretend we have a list of 5 emails retrieved from the email provider's API.\n",
     "\n",
-    "To perform reranking over semi-structured data, we serialize the data into a list of yaml strings."
+    "To perform reranking over semi-structured data, we serialize the documents to YAML format, which prepares the data in the format required for reranking. Then, we pass the YAML formatted documents to the Rerank endpoint."
    ]
   },
   {
@@ -220,14 +222,19 @@
     }
    ],
    "source": [
+    "# Convert the documents to YAML format\n",
+    "yaml_docs = [yaml.dump(doc, sort_keys=False) for doc in emails]\n",
+    "\n",
     "# Add the user query\n",
     "query = \"Any email about check ins?\"\n",
     "\n",
     "# Rerank the documents\n",
-    "results = co.rerank(query=query,\n",
-    "                    documents=yaml_emails,\n",
-    "                    top_n=2,\n",
-    "                    model='rerank-v3.5')\n",
+    "results = co.rerank(\n",
+    "    model='rerank-v3.5',\n",
+    "    query=query,\n",
+    "    documents=yaml_docs,\n",
+    "    top_n=2,\n",
+    ")\n",
     "\n",
     "return_results(results, emails)"
    ]
@@ -243,7 +250,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Many enterprises rely on tabular data, such as relational databases, CSVs, and Excel. To perform reranking, you can transform a dataframe into a list of JSON records and use Rerank 3's JSON capabilities to rank them.\n",
+    "Many enterprises rely on tabular data, such as relational databases, CSVs, and Excel. To perform reranking, you can transform a dataframe into a list of JSON records and use Rerank 3's JSON capabilities to rank them. We follow the same steps in the previous example, where we convert the data into YAML format before passing it to the Rerank endpoint.\n",
     "\n",
     "Here's an example of reranking a CSV file that contains employee information."
    ]
@@ -390,21 +397,23 @@
     }
    ],
    "source": [
-    "# Define the documents and rank fields\n",
+    "# Define the documents\n",
     "employees = df.to_dict('records')\n",
-    "employees_yaml = [yaml.dump(employee, sort_keys=False) for employee in employees]\n",
     "\n",
+    "# Convert the documents to YAML format\n",
+    "yaml_docs = [yaml.dump(doc, sort_keys=False) for doc in employees]\n",
     "\n",
     "# Add the user query\n",
     "query = \"Any full-time product designers who joined recently?\"\n",
     "\n",
     "# Rerank the documents\n",
-    "results = co.rerank(query=query,\n",
-    "                    documents=employees,\n",
-    "                    top_n=1,\n",
-    "                    model='rerank-v3.5')\n",
-    "\n",
-    "return_results(results, employees)\n"
+    "results = co.rerank(\n",
+    "    model='rerank-v3.5',\n",
+    "    query=query,\n",
+    "    documents=yaml_docs,\n",
+    "    top_n=1,\n",
+    ")\n",
+    "return_results(results, employees)"
    ]
   },
   {
@@ -448,12 +457,14 @@
     "query = \"هل هناك مزايا تتعلق باللياقة البدنية؟\" # Are there fitness benefits?\n",
     "\n",
     "# Rerank the documents\n",
-    "results = co.rerank(query=query,\n",
-    "                    documents=faqs_short,\n",
-    "                    top_n=2,\n",
-    "                    model='rerank-v3.5')\n",
+    "results = co.rerank(\n",
+    "    model='rerank-v3.5',\n",
+    "    query=query,\n",
+    "    documents=faqs,\n",
+    "    top_n=1,\n",
+    ")\n",
     "\n",
-    "return_results(results, faqs_short)"
+    "return_results(results, faqs)"
    ]
   },
   {


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR introduces changes to the reranking tutorial, focusing on improving search quality and supporting multilingual search.

## Changes:
- **Reranking Definition:** The definition of reranking has been updated to emphasize its role in providing a semantic boost to search quality for keyword and vector search systems.
- **Model Version:** The model version used for reranking has been updated from `'rerank-english-v3.0' to `'rerank-v3.5'` in various code blocks.
- **Data Conversion:** The process of performing reranking over semi-structured data has been modified. Instead of using the `rank_fields` parameter, the documents are now converted to YAML format before being passed to the Rerank endpoint.
- **Top Results:** The `top_n` parameter has been adjusted to return a single top result (`top_n=1`) for some reranking operations.
- **Multilingual Support:** The tutorial now highlights that the Rerank models (`rerank-v3.5` and `rerank-multilingual-v3.0`) support over 100 languages, enabling multilingual semantic search.

<!-- end-generated-description -->