### PR TITLE
Adding image embedding formats.

### DIFF
--- a/cohere-openapi.yaml
+++ b/cohere-openapi.yaml
@@ -15442,7 +15442,7 @@ paths:
                   description: |-
                     An array of image data URIs for the model to embed. Maximum number of images per call is `1`.
 
-                    The image must be a valid [data URI](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data). The image must be in either `image/jpeg`, `image/png`, `image/webp`, or `image/gif` format, and has a maximum size of 5MB.
+                    The image must be a valid [data URI](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data). The image must be in either `image/jpeg`, `image/png`, `image/webp`, or `image/gif` format, and can be up to 5MB in size.
                   items:
                     type: string
                     x-fern-audiences:

--- a/cohere-openapi.yaml
+++ b/cohere-openapi.yaml
@@ -11852,7 +11852,7 @@ paths:
                   description: |-
                     An array of image data URIs for the model to embed. Maximum number of images per call is `1`.
 
-                    The image must be a valid [data URI](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data). The image must be in either `image/jpeg`, `image/png`, `image/webp`, or `image/gif` format, and can be up to 5MB in size.
+                    The image must be a valid [data URI](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data). The image must be in either `image/jpeg`, `image/png`, `image/webp`, or `image/gif` format, and can be up to 5MB (or 178956970 pixels in size.
                   items:
                     type: string
                     x-fern-audiences:
@@ -15442,7 +15442,7 @@ paths:
                   description: |-
                     An array of image data URIs for the model to embed. Maximum number of images per call is `1`.
 
-                    The image must be a valid [data URI](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data). The image must be in either `image/jpeg`, `image/png`, `image/webp`, or `image/gif` format, and can be up to 5MB in size.
+                    The image must be a valid [data URI](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data). The image must be in either `image/jpeg`, `image/png`, `image/webp`, or `image/gif` format, and can be up to 5MB (or 178956970 pixels in size.
                   items:
                     type: string
                     x-fern-audiences:

--- a/cohere-openapi.yaml
+++ b/cohere-openapi.yaml
@@ -11852,7 +11852,7 @@ paths:
                   description: |-
                     An array of image data URIs for the model to embed. Maximum number of images per call is `1`.
 
-                    The image must be a valid [data URI](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data). The image must be in either `image/jpeg` or `image/png` format and has a maximum size of 5MB.
+                    The image must be a valid [data URI](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data). The image must be in either `image/jpeg`, `image/png`, `image/webp`, or `image/gif` format, and can be up to 5MB in size.
                   items:
                     type: string
                     x-fern-audiences:
@@ -15442,7 +15442,7 @@ paths:
                   description: |-
                     An array of image data URIs for the model to embed. Maximum number of images per call is `1`.
 
-                    The image must be a valid [data URI](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data). The image must be in either `image/jpeg` or `image/png` format and has a maximum size of 5MB.
+                    The image must be a valid [data URI](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data). The image must be in either `image/jpeg`, `image/png`, `image/webp`, or `image/gif` format, and has a maximum size of 5MB.
                   items:
                     type: string
                     x-fern-audiences:


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR introduces a change to the image format requirements for embedding.

- The image format options have been expanded to include `image/webp` and `image/gif` in addition to the existing `image/jpeg` and `image/png` formats.
- The maximum size of the image remains at 5MB.

<!-- end-generated-description -->