### PR TITLE
Add language env variable

### DIFF
--- a/.github/workflows/create-sdk-releases.yml
+++ b/.github/workflows/create-sdk-releases.yml
@@ -42,4 +42,5 @@ jobs:
           GITHUB_OWNER: ${{ github.repository_owner }}
           GITHUB_REPO: ${{ github.event.repository.name }}
           BUMP_TYPE: ${{ github.event.inputs.bump_type }}
+          LANGUAGE: ${{ github.event.inputs.language }}
         run: pnpm run --filter autorelease release


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request introduces a new variable, `LANGUAGE`, to the `create-sdk-releases.yml` file. The variable is set to `${{ github.event.inputs.language }}`, indicating that it will be populated with the language input provided during the GitHub event.

## Summary of Changes:
- Adds the `LANGUAGE` variable to the job configuration.
- The `run` command now includes the `LANGUAGE` variable, ensuring that the language input is considered during the release process.

<!-- end-generated-description -->