### PR TITLE
Multi modal image types

### DIFF
--- a/fern/pages/text-embeddings/embeddings.mdx
+++ b/fern/pages/text-embeddings/embeddings.mdx
@@ -91,7 +91,7 @@ print(embeddings[0][:5])  # Print embeddings for the first text
 
 ## Image Embeddings
 
-The Cohere embedding platform supports image embeddings for the entire of `embed-v3.0` family. This functionality can be utilized with the following steps:
+The Cohere embedding platform supports image embeddings for the entire `embed-v3.0` family. This functionality can be utilized with the following steps:
 
 - Pass `image` to the `input_type` parameter (as discussed above). 
 - Pass your image URL to the new `images` parameter.

--- a/fern/pages/text-embeddings/embeddings.mdx
+++ b/fern/pages/text-embeddings/embeddings.mdx
@@ -99,7 +99,7 @@ The Cohere embedding platform supports image embeddings for the entire of `embed
 Be aware that image embedding has the following restrictions:
 
 - If `input_type='image'`, the `texts` field must be empty.
-- The original image file type must be `png` or `jpeg`.
+- The original image file type must be in a `png`, `jpeg`, `webp`, or `gif` format and can be up to 5 MB in size.
 - The image must be base64 encoded and sent as a Data URL to the `images` parameter. 
 - Our API currently does not support batch image embeddings.
 

--- a/fern/pages/v2/text-embeddings/embeddings.mdx
+++ b/fern/pages/v2/text-embeddings/embeddings.mdx
@@ -101,7 +101,7 @@ The Cohere embedding platform supports image embeddings for the entire of `embed
 Be aware that image embedding has the following restrictions:
 
 - If `input_type='image'`, the `texts` field must be empty.
-- The original image file type must be `png` or `jpeg`.
+- The original image file type must be in a `png`, `jpeg`, `webp`, or `gif` format and can be up to 5 MB in size.
 - The image must be base64 encoded and sent as a Data URL to the `images` parameter. 
 - Our API currently does not support batch image embeddings.
 

--- a/fern/pages/v2/text-embeddings/embeddings.mdx
+++ b/fern/pages/v2/text-embeddings/embeddings.mdx
@@ -93,7 +93,7 @@ print(embeddings[0][:5])  # Print embeddings for the first text
 
 ## Image Embeddings
 
-The Cohere embedding platform supports image embeddings for the entire of `embed-v3.0` family. This functionality can be utilized with the following steps:
+The Cohere embedding platform supports image embeddings for the entire `embed-v3.0` family. This functionality can be utilized with the following steps:
 
 - Pass `image` to the `input_type` parameter (as discussed above). 
 - Pass your image URL to the new `images` parameter.


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request updates the documentation for the Cohere embedding platform's support for image embeddings in the `embed-v3.0` family. The changes include:

- Expanding the supported image file types to include `png`, `jpeg`, `webp`, and `gif`, with a maximum file size of 5 MB.
- Clarifying that the image must be base64 encoded and sent as a Data URL to the `images` parameter.
- Emphasizing that the `texts` field must be empty when `input_type` is set to `image`.

<!-- end-generated-description -->