### PR TITLE
Announcing multimodal models on Bedrock, plus docs changes.

### DIFF
--- a/fern/pages/changelog/2025-01-24-multimodal-on-bedrock.mdx
+++ b/fern/pages/changelog/2025-01-24-multimodal-on-bedrock.mdx
@@ -1,0 +1,14 @@
+---
+title: "Cohere's Multimodal Embedding Models are on SageMaker!"
+slug: "changelog/multimodal-models-on-bedrock"
+createdAt: "Thu Jan 23 2025 12:51:00 (MST)"
+hidden: false
+description: >-
+  Release announcement for the ability to work with multimodal image models on the Amazon Bedrock platform.
+---
+
+In October, Cohere updated our embeddings models to be able to [process images](https://docs.cohere.com/v1/docs/embeddings#image-embeddings) in addition to text.
+
+These enhanced models have been available through the Cohere API, but today we’re pleased to announce that they can also be utilized through the powerful Amazon Bedrock cloud computing platform!
+
+You can find more information about using Cohere’s embedding models on Bedrock [here](https://docs.cohere.com/v1/docs/amazon-bedrock).

--- a/fern/pages/deployment-options/cohere-on-aws/amazon-bedrock.mdx
+++ b/fern/pages/deployment-options/cohere-on-aws/amazon-bedrock.mdx
@@ -72,6 +72,8 @@ result = co.embed(
 print(result)
 ```
 
+Note that we've released multimodal embeddings models that are able to handle images in addition to text. Find [more information here](https://docs.cohere.com/docs/multimodal-embeddings).
+
 ## Text Generation
 
 You can use this code to invoke either Command R (`cohere.command-r-v1:0`), Command R+ (`cohere.command-r-plus-v1:0`), Command (`cohere.command-text-v14`), or Command light (`cohere.command-light-text-v14`) on Amazon Bedrock:

--- a/fern/pages/v2/deployment-options/cohere-on-aws/amazon-bedrock.mdx
+++ b/fern/pages/v2/deployment-options/cohere-on-aws/amazon-bedrock.mdx
@@ -74,6 +74,8 @@ result = co.embed(
 print(result)
 ```
 
+Note that we've released multimodal embeddings models that are able to handle images in addition to text. Find [more information here](https://docs.cohere.com/docs/multimodal-embeddings).
+
 ## Text Generation
 
 You can use this code to invoke either Command R (`cohere.command-r-v1:0`), Command R+ (`cohere.command-r-plus-v1:0`) on Amazon Bedrock:


### PR DESCRIPTION
<!-- begin-generated-description -->

## Summary
This pull request announces the release of Cohere's multimodal embedding models, which can now process images in addition to text. The models are available through the Cohere API and the Amazon Bedrock cloud computing platform.

## Changes
- Added a new file `fern/pages/changelog/2025-01-24-multimodal-on-bedrock.mdx` with a release announcement for the ability to work with multimodal image models on the Amazon Bedrock platform.
- Updated the `fern/pages/deployment-options/cohere-on-aws/amazon-bedrock.mdx` and `fern/pages/v2/deployment-options/cohere-on-aws/amazon-bedrock.mdx` files to include a note about the release of multimodal embedding models and a link to more information.

<!-- end-generated-description -->