### PR TITLE
Fix going live page

### DIFF
--- a/fern/pages/going-to-production/going-live.mdx
+++ b/fern/pages/going-to-production/going-live.mdx
@@ -1,12 +1,15 @@
 ---
 title: Going Live with a Cohere Model
 slug: docs/going-live
+
 hidden: false
+
 description: >-
   Learn to upgrade from a Trial to a Production key; understand the limitations
   and benefits of each and go live with Cohere.
 image: ../../assets/images/4f186df-cohere_docs_preview_image_1200x630_copy.jpg
 keywords: 'Cohere API, large language models, generative AI'
+
 createdAt: 'Thu Sep 01 2022 20:13:15 GMT+0000 (Coordinated Universal Time)'
 updatedAt: 'Thu May 23 2024 15:57:38 GMT+0000 (Coordinated Universal Time)'
 ---


### PR DESCRIPTION
At the moment [going-live page](https://docs.cohere.com/v2/docs/going-live) doesn't rendered properly so this PR should fix that.
