### PR TITLE
Updaing api reference and cookbooks urls

### DIFF
--- a/fern/pages/index.mdx
+++ b/fern/pages/index.mdx
@@ -99,7 +99,7 @@ export const cards = [
       "Understand how to use our API on a deeper level. Train and customize the model to work for you.",
   },
   {
-    href: "/reference/about",
+    href: "/v1/reference/cohere-api/about",
     imgSrc: "https://fern-image-hosting.s3.amazonaws.com/cohere/8ff146a-Group_138977.png",
     title: "API reference",
     description:
@@ -113,7 +113,7 @@ export const cards = [
       "Keep up with the latest releases and platform updates from Cohere.",
   },
   {
-    href: "/page/cookbooks",
+    href: "/v1/page/cookbooks",
     imgSrc: "https://fern-image-hosting.s3.amazonaws.com/cohere/7fca92c-Group_138977_2.png",
     title: "Cookbooks",
     description:


### PR DESCRIPTION
Fixing temporarly urls for `api reference` and `cookbooks` due to the issue with extra `v1` chunk has been added to the URL.

Once issue is resolved - we need to rollback this PR.