### PR TITLE
Adding warning to AWS SM setup guide for version compatibility issue.

### DIFF
--- a/fern/pages/deployment-options/cohere-on-aws/amazon-sagemaker-setup-guide.mdx
+++ b/fern/pages/deployment-options/cohere-on-aws/amazon-sagemaker-setup-guide.mdx
@@ -40,6 +40,8 @@ Next, explore the tools on the **Product Detail** page to evaluate how you want 
 - Subscribing: This section will once again present you with both the pricing details and the EULA for final review before you accept the offer. This information is identical to the information on Product Detail page.
 - Configuration: The primary goal of this section is to retrieve the [Amazon Resource Name (ARN)](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html) for the product you have subscribed to.
 
+<Warning>For any Cohere _software_ version after 1.0.5 (or _model_ version after 3.0.5), the parameter `InferenceAmiVersion=al2-ami-sagemaker-inference-gpu-2` must be specified on the endpoint-configuration (as a variant option) to avoid deployment errors.</Warning>
+
 ## Embeddings
 
 You can use this code to invoke Cohere's embed model on Amazon SageMaker:

--- a/fern/pages/deployment-options/cohere-on-aws/amazon-sagemaker-setup-guide.mdx
+++ b/fern/pages/deployment-options/cohere-on-aws/amazon-sagemaker-setup-guide.mdx
@@ -40,7 +40,7 @@ Next, explore the tools on the **Product Detail** page to evaluate how you want 
 - Subscribing: This section will once again present you with both the pricing details and the EULA for final review before you accept the offer. This information is identical to the information on Product Detail page.
 - Configuration: The primary goal of this section is to retrieve the [Amazon Resource Name (ARN)](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html) for the product you have subscribed to.
 
-<Warning>For any Cohere _software_ version after 1.0.5 (or _model_ version after 3.0.5), the parameter `InferenceAmiVersion=al2-ami-sagemaker-inference-gpu-2` must be specified on the endpoint-configuration (as a variant option) to avoid deployment errors.</Warning>
+<Warning>For any Cohere _software_ version after 1.0.5 (or _model_ version after 3.0.5), the parameter `InferenceAmiVersion=al2-ami-sagemaker-inference-gpu-2` must be specified during endpoint configuration (as a variant option) to avoid deployment errors.</Warning>
 
 ## Embeddings
 

--- a/fern/pages/deployment-options/deployment-options/aws-sagemaker.mdx
+++ b/fern/pages/deployment-options/deployment-options/aws-sagemaker.mdx
@@ -28,7 +28,7 @@ These permissions allow a user to manage your organization’s SageMaker subscri
 
 First, navigate to [Cohere’s Sagemaker Marketplace](https://aws.amazon.com/marketplace/seller-profile?id=87af0c85-6cf9-4ed8-bee0-b40ce65167e0) to view the product offerings available to you. Select the product offering to which you are interested in subscribing.
 
-Next, explore the tools on the **Product Detail** page to evaluate how you want to configure your subscription. Some of the key sections to consider are detailed below:
+Next, explore the tools on the **Product Detail** page to evaluate how you want to configure your subscription. Some of the key sections to consider are detailed below.
 
 #### Pricing
 

--- a/fern/pages/v2/deployment-options/cohere-on-aws/amazon-sagemaker-setup-guide.mdx
+++ b/fern/pages/v2/deployment-options/cohere-on-aws/amazon-sagemaker-setup-guide.mdx
@@ -43,6 +43,9 @@ Next, explore the tools on the **Product Detail** page to evaluate how you want 
 - Subscribing: This section will once again present you with both the pricing details and the EULA for final review before you accept the offer. This information is identical to the information on Product Detail page.
 - Configuration: The primary goal of this section is to retrieve the [Amazon Resource Name (ARN)](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html) for the product you have subscribed to.
 
+<Warning>For any Cohere _software_ version after 1.0.5 (or _model_ version after 3.0.5), the parameter `InferenceAmiVersion=al2-ami-sagemaker-inference-gpu-2` must be specified on the endpoint-configuration (as a variant option) to avoid deployment errors.</Warning>
+
+
 ## Embeddings
 
 You can use this code to invoke Cohere's embed model on Amazon SageMaker:

--- a/fern/pages/v2/deployment-options/cohere-on-aws/amazon-sagemaker-setup-guide.mdx
+++ b/fern/pages/v2/deployment-options/cohere-on-aws/amazon-sagemaker-setup-guide.mdx
@@ -45,7 +45,6 @@ Next, explore the tools on the **Product Detail** page to evaluate how you want 
 
 <Warning>For any Cohere _software_ version after 1.0.5 (or _model_ version after 3.0.5), the parameter `InferenceAmiVersion=al2-ami-sagemaker-inference-gpu-2` must be specified on the endpoint-configuration (as a variant option) to avoid deployment errors.</Warning>
 
-
 ## Embeddings
 
 You can use this code to invoke Cohere's embed model on Amazon SageMaker:

--- a/fern/pages/v2/deployment-options/cohere-on-aws/amazon-sagemaker-setup-guide.mdx
+++ b/fern/pages/v2/deployment-options/cohere-on-aws/amazon-sagemaker-setup-guide.mdx
@@ -43,7 +43,7 @@ Next, explore the tools on the **Product Detail** page to evaluate how you want 
 - Subscribing: This section will once again present you with both the pricing details and the EULA for final review before you accept the offer. This information is identical to the information on Product Detail page.
 - Configuration: The primary goal of this section is to retrieve the [Amazon Resource Name (ARN)](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html) for the product you have subscribed to.
 
-<Warning>For any Cohere _software_ version after 1.0.5 (or _model_ version after 3.0.5), the parameter `InferenceAmiVersion=al2-ami-sagemaker-inference-gpu-2` must be specified on the endpoint-configuration (as a variant option) to avoid deployment errors.</Warning>
+<Warning>For any Cohere _software_ version after 1.0.5 (or _model_ version after 3.0.5), the parameter `InferenceAmiVersion=al2-ami-sagemaker-inference-gpu-2` must be specified during endpoint configuration (as a variant option) to avoid deployment errors.</Warning>
 
 ## Embeddings
 


### PR DESCRIPTION
<!-- begin-generated-description -->

## Summary
This PR introduces a new warning message for users working with Cohere software or model versions beyond 1.0.5 and 3.0.5, respectively. It highlights the need to specify the `InferenceAmiVersion=al2-ami-sagemaker-inference-gpu-2` parameter on the endpoint configuration to prevent deployment errors.

## Changes
- **New Warning:** A warning is added to inform users about a specific configuration requirement for Cohere software and model versions above 1.0.5 and 3.0.5, respectively.
- **Configuration Requirement:** The warning emphasizes the need to set the `InferenceAmiVersion` parameter to `al2-ami-sagemaker-inference-gpu-2` on the endpoint configuration to ensure successful deployments.

<!-- end-generated-description -->