### PR TITLE
Fixing the title.

### DIFF
--- a/fern/pages/changelog/2025-01-24-multimodal-on-bedrock.mdx
+++ b/fern/pages/changelog/2025-01-24-multimodal-on-bedrock.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Cohere's Multimodal Embedding Models are on SageMaker!"
+title: "Cohere's Multimodal Embedding Models are on Bedrock!"
 slug: "changelog/multimodal-models-on-bedrock"
 createdAt: "Thu Jan 23 2025 12:51:00 (MST)"
 hidden: false


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request updates the title of the changelog to reflect the availability of Cohere's Multimodal Embedding Models on Bedrock.

- The title is changed from "Cohere's Multimodal Embedding Models are on SageMaker!" to "Cohere's Multimodal Embedding Models are on Bedrock!".

<!-- end-generated-description -->