### PR TITLE
Explaining billed tokens and why they're different.

### DIFF
--- a/fern/pages/going-to-production/how-does-cohere-pricing-work.mdx
+++ b/fern/pages/going-to-production/how-does-cohere-pricing-work.mdx
@@ -21,7 +21,7 @@ You can find up-to-date prices on our [dedicated pricing page](https://cohere.co
 
 ### What's the Difference Between "billed" Tokens and Generic Tokens?
 
-In certain workflows you'll see an output like this:
+When using the [Chat API endpoint](https://docs.cohere.com/reference/chat), the response will contain the total count of input and output tokens, as well as the count of billed tokens. Here's an example:
 
 ```json JSON
 {
@@ -36,7 +36,7 @@ In certain workflows you'll see an output like this:
 }
 ```
 
-And it may not be obvious why there are separate input and output values under `billed_units`. As its name suggests, the _billed_ input and output tokens are the tokens that you're actually _billed_ for. The reason these values can be different from the overall `"tokens"` value is that there are situations in which Cohere adds tokens under the hood, and there are others in which a particular model has been trained to do so (i.e. when outputting special tokens). Since these are tokens *you don't have control over, you are not charged for them.* 
+The rerank and embed models have their own, slightly different versions, and it may not be obvious why there are separate input and output values under `billed_units`. As its name suggests, the _billed_ input and output tokens are the tokens that you're actually _billed_ for. The reason these values can be different from the overall `"tokens"` value is that there are situations in which Cohere adds tokens under the hood, and there are others in which a particular model has been trained to do so (i.e. when outputting special tokens). Since these are tokens *you don't have control over, you are not charged for them.* 
 
 ## Trial Usage and Production Usage
 

--- a/fern/pages/going-to-production/how-does-cohere-pricing-work.mdx
+++ b/fern/pages/going-to-production/how-does-cohere-pricing-work.mdx
@@ -21,7 +21,7 @@ You can find up-to-date prices on our [dedicated pricing page](https://cohere.co
 
 ### What's the Difference Between "billed" Tokens and Generic Tokens?
 
-When using the [Chat API endpoint](https://docs.cohere.com/reference/chat), the response will contain the total count of input and output tokens, as well as the count of billed tokens. Here's an example:
+When using the [Chat API endpoint](https://docs.cohere.com/reference/chat), the response will contain the total count of input and output tokens, as well as the count of _billed_ tokens. Here's an example:
 
 ```json JSON
 {
@@ -36,7 +36,7 @@ When using the [Chat API endpoint](https://docs.cohere.com/reference/chat), the 
 }
 ```
 
-The rerank and embed models have their own, slightly different versions, and it may not be obvious why there are separate input and output values under `billed_units`. As its name suggests, the _billed_ input and output tokens are the tokens that you're actually _billed_ for. The reason these values can be different from the overall `"tokens"` value is that there are situations in which Cohere adds tokens under the hood, and there are others in which a particular model has been trained to do so (i.e. when outputting special tokens). Since these are tokens *you don't have control over, you are not charged for them.* 
+The rerank and embed models have their own, slightly different versions, and it may not be obvious why there are separate input and output values under `billed_units`. To clarify, the _billed_ input and output tokens are the tokens that you're actually _billed_ for. The reason these values can be different from the overall `"tokens"` value is that there are situations in which Cohere adds tokens under the hood, and there are others in which a particular model has been trained to do so (i.e. when outputting special tokens). Since these are tokens *you don't have control over, you are not charged for them.* 
 
 ## Trial Usage and Production Usage
 

--- a/fern/pages/going-to-production/how-does-cohere-pricing-work.mdx
+++ b/fern/pages/going-to-production/how-does-cohere-pricing-work.mdx
@@ -19,6 +19,25 @@ Our Rerank models are priced based on the quantity of searches, and our Embeddin
 
 You can find up-to-date prices on our [dedicated pricing page](https://cohere.com/pricing).
 
+### What's the Difference Between "billed" Tokens and Generic Tokens?
+
+In certain workflows you'll see an output like this:
+
+```json JSON
+{
+  "billed_units": {
+    "input_tokens": 6772,
+    "output_tokens": 248
+  },
+  "tokens": {
+    "input_tokens": 7596,
+    "output_tokens": 645
+  }
+}
+```
+
+And it may not be obvious why there are separate input and output values under `billed_units`. As its name suggests, the _billed_ input and output tokens are the tokens that you're actually _billed_ for. The reason these values can be different from the overall `"tokens"` value is that there are situations in which Cohere adds tokens under the hood, and there are others in which a particular model has been trained to do so (i.e. when outputting special tokens). Since these are tokens *you don't have control over, you are not charged for them.* 
+
 ## Trial Usage and Production Usage
 
 Cohere makes a distinction between "trial" and "production" usage of an API key.  


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR introduces a new section titled "What's the Difference Between 'billed' Tokens and Generic Tokens?" to clarify the distinction between billed and generic tokens in the JSON output.

## Changes:
- Added a new section to explain the difference between billed and generic tokens.
- Included a JSON example to illustrate the difference in input and output values under `billed_units` and `tokens`.
- Clarified that billed tokens are the ones users are charged for, while generic tokens may include additional tokens added by Cohere or the model, which users are not charged for.

<!-- end-generated-description -->