### PR TITLE
fixed broken link to blog post "clustering-with-embeddings"

### DIFF
--- a/notebooks/llmu/Introduction_Text_Embeddings.ipynb
+++ b/notebooks/llmu/Introduction_Text_Embeddings.ipynb
@@ -959,7 +959,7 @@
     "\n",
     "In this section, you will learn how to use embeddings to group similar documents into clusters, to discover emerging patterns in the documents. We'll work with the same 9 data points as before.\n",
     "\n",
-    "_Read the accompanying [blog post here](https://docs.cohere.com/docs/clustering-with-embeddings)._"
+    "_Read the accompanying [blog post here](https://cohere.com/llmu/clustering-with-embeddings)._"
    ]
   },
   {


### PR DESCRIPTION
the current linked pointed to https://docs.cohere.com/docs/clustering-with-embeddings which doesnt exist. 

Link is now pointing to https://cohere.com/llmu/clustering-with-embeddings - which works just fine