### PR TITLE
Fix issue with duplicates titles

### DIFF
--- a/fern/pages/tutorials/cohere-on-azure/azure-ai-rag.mdx
+++ b/fern/pages/tutorials/cohere-on-azure/azure-ai-rag.mdx
@@ -1,5 +1,5 @@
 ---
-title: Retrieval Augmented Generation (RAG)
+title: Retrieval Augmented Generation (RAG) on Azure
 slug: /docs/cohere-on-azure/azure-ai-rag
 
 description: "A guide for performing retrieval augmented generation (RAG) with Cohere's Command models on Azure AI Foundry (API v1)."

--- a/fern/pages/v2/tutorials/cohere-on-azure/azure-ai-rag.mdx
+++ b/fern/pages/v2/tutorials/cohere-on-azure/azure-ai-rag.mdx
@@ -1,5 +1,5 @@
 ---
-title: Retrieval Augmented Generation (RAG)
+title: Retrieval Augmented Generation (RAG) on Azure
 slug: /v2/docs/cohere-on-azure/azure-ai-rag
 
 description: "A guide for performing retrieval augmented generation (RAG) with Cohere's Command models on Azure AI Foundry (API v2)."


### PR DESCRIPTION
There was an issue reported related to duplicates titles.
`Retrieval Augmented Generation (RAG)` is already set for `docs/retrieval-augmented-generation-rag`