### PR TITLE
Update json schema type for number and link to the spec page

### DIFF
--- a/fern/pages/v2/text-generation/structured-outputs.mdx
+++ b/fern/pages/v2/text-generation/structured-outputs.mdx
@@ -290,10 +290,10 @@ Structured Outputs supports a subset of the JSON Schema specification, detailed 
 
 | Parameter | [Structured Outputs (JSON)](#) | [Structured Outputs (Tools)](https://docs.cohere.com/v2/docs/tool-use#structured-outputs-tools) | [Tool Use](https://docs.cohere.com/v2/docs/tool-use) |
 | --- | --- | --- | --- |
-| String |  Yes | Yes | Yes |
-| Integer | Yes | Yes | Yes |
-| Float |  Yes | Yes | Yes |
-| Boolean | Yes | Yes | Yes |
+| [String](https://json-schema.org/understanding-json-schema/reference/string) |  Yes | Yes | Yes |
+| [Integer](https://json-schema.org/understanding-json-schema/reference/numeric#integer) | Yes | Yes | Yes |
+| [Number](https://json-schema.org/understanding-json-schema/reference/numeric#number) |  Yes | Yes | Yes |
+| [Boolean](https://json-schema.org/understanding-json-schema/reference/boolean) | Yes | Yes | Yes |
 
 See usage examples for [JSON](https://docs.cohere.com/v2/docs/parameter-types-in-json#basic-types) and [Tools](https://docs.cohere.com/v2/docs/parameter-types-in-tool-use#basic-types).
 


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the parameter types in the Structured Outputs table to include links to the relevant JSON Schema documentation.

- The `String` parameter now links to the JSON Schema reference for strings.
- The `Integer` parameter now links to the JSON Schema reference for integers.
- The `Float` parameter has been replaced with `Number`, which links to the JSON Schema reference for numbers.
- The `Boolean` parameter now links to the JSON Schema reference for booleans.

<!-- end-generated-description -->