### PR TITLE
chore(docs): bump fern cli to 0.51.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   },
   "dependencies": {
     "cohere-ai": "^7.14.0",
-    "fern-api": "^0.41.16",
     "gray-matter": "^4.0.3",
+    "fern-api": "^0.51.36",
     "react": "^18.3.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^7.14.0
         version: 7.14.0(@aws-sdk/client-sso-oidc@3.679.0(@aws-sdk/client-sts@3.679.0))
       fern-api:
-        specifier: ^0.41.16
-        version: 0.41.16
+        specifier: ^0.51.36
+        version: 0.51.36
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
@@ -1881,8 +1881,8 @@ packages:
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
 
-  fern-api@0.41.16:
-    resolution: {integrity: sha512-LykhNvMl0NjTnCu6kHiYV9a2Y3iX5HMFlD6dO1A6J1WfvH8mcKYzcz/R/Md9/h6QygSeuuFGAo/K3JJ9e3j4QQ==}
+  fern-api@0.51.36:
+    resolution: {integrity: sha512-C1gHkb2e+aRLmuxbD6Y2WDlJhQdsYLR6svFhUit1WLft5mlcWgjJfrBoPAWDh+tSwfqcSICpoWJqkhJ4rSAc3g==}
     hasBin: true
 
   fill-range@7.1.1:
@@ -5427,7 +5427,7 @@ snapshots:
     dependencies:
       bser: 2.1.1
 
-  fern-api@0.41.16: {}
+  fern-api@0.51.36: {}
 
   fill-range@7.1.1:
     dependencies:


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the `fern-api` package to version `0.51.36` in both the `package.json` and `pnpm-lock.yaml` files.

- In `package.json`, the `fern-api` dependency is updated from `^0.41.16` to `^0.51.36`.
- In `pnpm-lock.yaml`, the `fern-api` specifier and version are updated from `^0.41.16` to `^0.51.36`, and the `fern-api@0.41.16` resolution is replaced with `fern-api@0.51.36`.

<!-- end-generated-description -->