### PR TITLE
Fix issue with duplicates titles on chat api reference endpoints

### DIFF
--- a/fern/v1.yml
+++ b/fern/v1.yml
@@ -623,9 +623,9 @@ navigation:
                 skip-slug: true
                 contents:
                   - endpoint: POST /v1/chat
-                    title: Chat
+                    title: Chat (API V1)
                   - endpoint: STREAM /v1/chat
-                    title: Chat with Streaming
+                    title: Chat with Streaming Outputs (API V1)
               - section: "v1/embed"
                 skip-slug: true
                 contents:

--- a/fern/v2.yml
+++ b/fern/v2.yml
@@ -626,10 +626,10 @@ navigation:
                 contents:
                   - endpoint: POST /v2/chat
                     slug: chat
-                    title: Chat
+                    title: Chat (API V2)
                   - endpoint: STREAM /v2/chat
                     slug: chat-stream
-                    title: Chat with Streaming
+                    title: Chat with Streaming Outputs (API V2)
               - section: "v2/rerank"
                 skip-slug: true
                 contents:
@@ -727,7 +727,7 @@ navigation:
                     title: Chat
                   - endpoint: STREAM /v1/chat
                     slug: chat-stream-v1
-                    title: Chat with Streaming
+                    title: Chat with Streaming Outputs (API V1)
               - section: "v1/generate"
                 hidden: true
                 skip-slug: true


### PR DESCRIPTION
There was issue reported by semrush that we have duplicated titles on a chat v1/v2 API Reference pages.
This PR aims to fix that issue