### PR TITLE
Tool use - fix broken redirect link

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -590,7 +590,7 @@ redirects:
     destination: /v2/docs/tool-use-usage-patterns/multi-step-tool-use
     permanent: true
   - source: /v2/docs/implementing-a-multi-step-agent-with-langchain
-    destination: /v2/docs/tool-use-usage-patterns/multi-step-tool-use
+    destination: /v2/docs/tool-use-usage-patterns#multi-step-tool-use
     permanent: true
   - source: /v2/docs/parameter-types-in-tool-use
     destination: /v2/docs/tool-use-parameter-types

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -587,13 +587,25 @@ redirects:
     destination: /v2/docs/tool-use-overview
     permanent: true
   - source: /v2/docs/multi-step-tool-use
-    destination: /v2/docs/tool-use-usage-patterns/multi-step-tool-use
+    destination: /v2/docs/tool-use-usage-patterns#multi-step-tool-use
     permanent: true
   - source: /v2/docs/implementing-a-multi-step-agent-with-langchain
     destination: /v2/docs/tool-use-usage-patterns#multi-step-tool-use
     permanent: true
   - source: /v2/docs/parameter-types-in-tool-use
     destination: /v2/docs/tool-use-parameter-types
+    permanent: true
+  - source: /docs/tool-use
+    destination: /docs/tool-use-overview
+    permanent: true
+  - source: /docs/multi-step-tool-use
+    destination: /docs/tool-use-usage-patterns#multi-step-tool-use
+    permanent: true
+  - source: /docs/implementing-a-multi-step-agent-with-langchain
+    destination: /docs/tool-use-usage-patterns#multi-step-tool-use
+    permanent: true
+  - source: /docs/parameter-types-in-tool-use
+    destination: /docs/tool-use-parameter-types
     permanent: true
 
 analytics:


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the destination of a redirect in the `docs.yml` file.

- The destination of the redirect with the source `/v2/docs/implementing-a-multi-step-agent-with-langchain` is changed from `/v2/docs/tool-use-usage-patterns/multi-step-tool-use` to `/v2/docs/tool-use-usage-patterns#multi-step-tool-use`.

<!-- end-generated-description -->