### PR TITLE
Fixing slugs for quickstart pages

### DIFF
--- a/fern/pages/v2/get-started/quickstart/rag-quickstart.mdx
+++ b/fern/pages/v2/get-started/quickstart/rag-quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 title: Retrieval augmented generation (RAG) - quickstart
-slug: /docs/v2/rag-quickstart
+slug: v2/docs/rag-quickstart
 
 description: "A quickstart guide for performing retrieval augmented generation (RAG) with Cohere's Command models (v2 API)."
 image: "../../../../assets/images/f1cc130-cohere_meta_image.jpg"  

--- a/fern/pages/v2/get-started/quickstart/reranking-quickstart.mdx
+++ b/fern/pages/v2/get-started/quickstart/reranking-quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 title: Reranking - quickstart
-slug: /docs/v2/reranking-quickstart
+slug: v2/docs/reranking-quickstart
 
 description: "A quickstart guide for performing reranking with Cohere's Reranking models (v2 API)."
 image: "../../../../assets/images/f1cc130-cohere_meta_image.jpg"  

--- a/fern/pages/v2/get-started/quickstart/sem-search-quickstart.mdx
+++ b/fern/pages/v2/get-started/quickstart/sem-search-quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 title: Semantic search - quickstart
-slug: /docs/v2/sem-search-quickstart
+slug: v2/docs/sem-search-quickstart
 
 description: "A quickstart guide for performing text semantic search with Cohere's Embed models (v2 API)."
 image: "../../../../assets/images/f1cc130-cohere_meta_image.jpg"  

--- a/fern/pages/v2/get-started/quickstart/text-gen-quickstart.mdx
+++ b/fern/pages/v2/get-started/quickstart/text-gen-quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 title: Text generation - quickstart
-slug: /docs/v2/text-gen-quickstart
+slug: v2/docs/text-gen-quickstart
 
 description: "A quickstart guide for performing text generation with Cohere's Command models (v2 API)."
 image: "../../../../assets/images/f1cc130-cohere_meta_image.jpg"  

--- a/fern/pages/v2/get-started/quickstart/tool-use-quickstart.mdx
+++ b/fern/pages/v2/get-started/quickstart/tool-use-quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 title: Tool use & agents - quickstart
-slug: /docs/v2/tool-use-quickstart
+slug: v2/docs/tool-use-quickstart
 
 description: "A quickstart guide for using tool use and building agents with Cohere's Command models (v2 API)."
 image: "../../../../assets/images/f1cc130-cohere_meta_image.jpg"  


### PR DESCRIPTION
I found that according to our standart `v2` path entry should goes before `docs`.