### PR TITLE
use https urls instead of http

### DIFF
--- a/fern/pages/fine-tuning/chat-fine-tuning/chat-starting-the-training.mdx
+++ b/fern/pages/fine-tuning/chat-fine-tuning/chat-starting-the-training.mdx
@@ -18,7 +18,7 @@ Fine-tuning of the Command family of models for Chat with the Web UI consists of
 
 ### Choose the Chat Option
 
-Go to the [fine-tuning page](http://dashboard.cohere.com/fine-tuning) and click on 'Create a Chat model'.
+Go to the [fine-tuning page](https://dashboard.cohere.com/fine-tuning) and click on 'Create a Chat model'.
 
 <img src='../../../assets/images/465773a-image.png' />
 

--- a/fern/pages/fine-tuning/classify-fine-tuning/classify-starting-the-training.mdx
+++ b/fern/pages/fine-tuning/classify-fine-tuning/classify-starting-the-training.mdx
@@ -17,7 +17,7 @@ Creating a fine-tuned model for Classification with the Web UI consists of a few
 
 ### Choose the Classify Option
 
-Go to the [fine-tuning page](http://dashboard.cohere.com/fine-tuning) and click on 'Create a Classify model'.
+Go to the [fine-tuning page](https://dashboard.cohere.com/fine-tuning) and click on 'Create a Classify model'.
 
 <img src='../../../assets/images/465773a-image.png' />
 

--- a/fern/pages/fine-tuning/fine-tuning-with-the-cohere-dashboard.mdx
+++ b/fern/pages/fine-tuning/fine-tuning-with-the-cohere-dashboard.mdx
@@ -10,7 +10,7 @@ createdAt: 'Wed Nov 15 2023 21:36:22 GMT+0000 (Coordinated Universal Time)'
 updatedAt: 'Thu Jun 13 2024 00:39:00 GMT+0000 (Coordinated Universal Time)'
 ---
 ![](../../assets/images/be2ccc8-image.png)
-Customers can kick off fine-tuning jobs by completing the data preparation and validation steps through the [Cohere dashboard](http://dashboard.cohere.com/fine-tuning). This is useful for customers who don't need or don't want to create a fine-tuning job programmatically via the [Fine-tuning API](/reference/listfinetunedmodels) or via the Cohere [Python SDK](/docs/fine-tuning), instead preferring the ease and simplicity of a web interface.
+Customers can kick off fine-tuning jobs by completing the data preparation and validation steps through the [Cohere dashboard](https://dashboard.cohere.com/fine-tuning). This is useful for customers who don't need or don't want to create a fine-tuning job programmatically via the [Fine-tuning API](/reference/listfinetunedmodels) or via the Cohere [Python SDK](/docs/fine-tuning), instead preferring the ease and simplicity of a web interface.
 
 ## Datasets
 
@@ -24,7 +24,7 @@ After uploading the dataset and going through the validation and review data pha
 
 ## Fine-tuning results
 
-You will receive an email notification when the fine-tuned model is ready. You can explore the evaluation metrics using the [Dashboard](http://dashboard.cohere.com/fine-tuning) and try out your model using one of our APIs on the interactive [Playground](https://dashboard.cohere.com/welcome/login?redirect_uri=/playground/chat).
+You will receive an email notification when the fine-tuned model is ready. You can explore the evaluation metrics using the [Dashboard](https://dashboard.cohere.com/fine-tuning) and try out your model using one of our APIs on the interactive [Playground](https://dashboard.cohere.com/welcome/login?redirect_uri=/playground/chat).
 
 ## Fine-tuning job statuses
 

--- a/fern/pages/fine-tuning/rerank-fine-tuning/rerank-starting-the-training.mdx
+++ b/fern/pages/fine-tuning/rerank-fine-tuning/rerank-starting-the-training.mdx
@@ -17,7 +17,7 @@ Creating a fine-tuned model for Rerank via the Web UI consists of a few simple s
 
 ### Choose the Rerank Option
 
-Go to the [fine-tuning page](http://dashboard.cohere.com/fine-tuning) and click on 'Create a Rerank model'.
+Go to the [fine-tuning page](https://dashboard.cohere.com/fine-tuning) and click on 'Create a Rerank model'.
 
 <img src='../../../assets/images/465773a-image.png' />
 

--- a/fern/pages/v2/fine-tuning/chat-fine-tuning/chat-starting-the-training.mdx
+++ b/fern/pages/v2/fine-tuning/chat-fine-tuning/chat-starting-the-training.mdx
@@ -20,7 +20,7 @@ Fine-tuning of the Command family of models for Chat with the Web UI consists of
 
 ### Choose the Chat Option
 
-Go to the [fine-tuning page](http://dashboard.cohere.com/fine-tuning) and click on 'Create a Chat model'.
+Go to the [fine-tuning page](https://dashboard.cohere.com/fine-tuning) and click on 'Create a Chat model'.
 
 <img src='../../../../assets/images/465773a-image.png' />
 

--- a/fern/pages/v2/fine-tuning/classify-fine-tuning/classify-starting-the-training.mdx
+++ b/fern/pages/v2/fine-tuning/classify-fine-tuning/classify-starting-the-training.mdx
@@ -19,7 +19,7 @@ Creating a fine-tuned model for Classification with the Web UI consists of a few
 
 ### Choose the Classify Option
 
-Go to the [fine-tuning page](http://dashboard.cohere.com/fine-tuning) and click on 'Create a Classify model'.
+Go to the [fine-tuning page](https://dashboard.cohere.com/fine-tuning) and click on 'Create a Classify model'.
 
 <img src='../../../../assets/images/465773a-image.png' />
 

--- a/fern/pages/v2/fine-tuning/rerank-fine-tuning/rerank-starting-the-training.mdx
+++ b/fern/pages/v2/fine-tuning/rerank-fine-tuning/rerank-starting-the-training.mdx
@@ -19,7 +19,7 @@ Creating a fine-tuned model for Rerank via the Web UI consists of a few simple s
 
 ### Choose the Rerank Option
 
-Go to the [fine-tuning page](http://dashboard.cohere.com/fine-tuning) and click on 'Create a Rerank model'.
+Go to the [fine-tuning page](https://dashboard.cohere.com/fine-tuning) and click on 'Create a Rerank model'.
 
 <img src='../../../../assets/images/465773a-image.png' />
 


### PR DESCRIPTION
We have warnings reported that we use http urls on the https pages.
This PR aims to fix that warnings and replace `http` with `https`