### PR TITLE
Added necessary space between `--name multilingual` and `--gpus=1`

### DIFF
--- a/fern/pages/v2/deployment-options/private-deployment/single-container-on-private-clouds.mdx
+++ b/fern/pages/v2/deployment-options/private-deployment/single-container-on-private-clouds.mdx
@@ -105,7 +105,7 @@ curl --header "Content-Type: application/json" --request POST http://localhost:8
 docker stop embed-english
 ```
 ```Text Embed Multilingual
-docker run -d --rm --name multilingual--gpus=1 --net=host $IMAGE_TAG
+docker run -d --rm --name multilingual --gpus=1 --net=host $IMAGE_TAG
 
 curl --header "Content-Type: application/json" --request POST http://localhost:8080/embed --data-raw '{"texts": ["testing multilingual embeddings"], "input_type": "classification"}'
 


### PR DESCRIPTION
For the Embed Multilingual example, there should be a space between `--name multilingual` and `--gpus=1`