### PR TITLE
Compatibility api clarification

### DIFF
--- a/fern/pages/v2/text-generation/compatibility-api.mdx
+++ b/fern/pages/v2/text-generation/compatibility-api.mdx
@@ -14,6 +14,13 @@ The Compatibility API allows developers to use Cohere’s models through OpenAI�
 
 It makes it easy to switch existing OpenAI-based applications to use Cohere’s models while still maintaining the use of OpenAI SDK — no big refactors needed.
 
+The supported libraries are:
+- TypeScript / JavaScript	
+- Python
+- .NET
+- Java (beta)
+- Go (beta)
+
 This is a quickstart guide to help you get started with the Compatibility API.
 
 ## Installation
@@ -836,3 +843,20 @@ The following parameters are not supported in the Compatibility API:
 
 - `dimensions`
 - `user`
+
+### Cohere-specific parameters
+
+Parameters that are uniquely available on the Cohere API but not on the OpenAI SDK are not supported.
+
+Chat endpoint:
+
+- `connectors`
+- `documents`
+- `citation_options`
+- ...[more here](https://docs.cohere.com/reference/chat)
+
+Embed endpoint:
+- `input_type`
+- `images`
+- `truncate`
+- ...[more here](https://docs.cohere.com/reference/embed)


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request updates the documentation for the Compatibility API, which allows developers to use Cohere's models through OpenAI. The changes include:

- Adding a list of supported libraries: TypeScript / JavaScript, Python, .NET, Java (beta), and Go (beta).
- Removing the `user` parameter from the unsupported parameters list.
- Adding a new section for Cohere-specific parameters, which are not supported on the OpenAI SDK. This section includes parameters for the chat and embed endpoints, with links to the Cohere documentation for more information.

<!-- end-generated-description -->