### PR TITLE
I included a link in the v1 and v2 doc pointing to the page where we …

### DIFF
--- a/fern/pages/deployment-options/cohere-on-aws/amazon-bedrock.mdx
+++ b/fern/pages/deployment-options/cohere-on-aws/amazon-bedrock.mdx
@@ -20,6 +20,8 @@ Here, you'll learn how to use Amazon Bedrock to deploy both the Cohere Command a
 - Embed - English
 - Embed - Multilingual
 
+Note that the code snippets below are in Python, but you can find the equivalent code for other languages (if they're supported) [here](https://docs.cohere.com/docs/cohere-works-everywhere)
+
 ## Prerequisites
 
 Here are the steps you'll need to get set up in advance of running Cohere models on Amazon Bedrock.

--- a/fern/pages/v2/deployment-options/cohere-on-aws/amazon-bedrock.mdx
+++ b/fern/pages/v2/deployment-options/cohere-on-aws/amazon-bedrock.mdx
@@ -22,6 +22,8 @@ Here, you'll learn how to use Amazon Bedrock to deploy both the Cohere Command a
 - Embed - Multilingual
 - Rerank v3.5
 
+Note that the code snippets below are in Python, but you can find the equivalent code for other languages (if they're supported) [here](https://docs.cohere.com/docs/cohere-works-everywhere)
+
 ## Prerequisites
 
 Here are the steps you'll need to get set up in advance of running Cohere models on Amazon Bedrock.


### PR DESCRIPTION
…have code snippets in other languages, rather than copying and pasting them in directly.