### PR TITLE
Fix image links for Aya Vision cookbook

### DIFF
--- a/fern/pages/cookbooks/aya_vision_intro.mdx
+++ b/fern/pages/cookbooks/aya_vision_intro.mdx
@@ -15,7 +15,7 @@ import { CookbookHeader } from "../../components/cookbook-header";
 Introducing Aya Vision - a state-of-the-art open-weights multimodal multilingual model.
 
 <img
-  src="https://github.com/cohere-ai/cohere-developer-experience/tree/main/notebooks/images/aya-vision/Aya-Vision.jpg"
+  src="https://github.com/cohere-ai/cohere-developer-experience/raw/main/notebooks/images/aya-vision/Aya-Vision.jpg"
 />
 
 In this notebook, we will explore the capabilities of Aya Vision, which can take text and image inputs to generates text responses.
@@ -130,7 +130,7 @@ render_image(image_path)
 ```
 
 <img
-  src="https://github.com/cohere-ai/cohere-developer-experience/tree/main/notebooks/images/aya-vision/image1.jpg"
+  src="https://github.com/cohere-ai/cohere-developer-experience/raw/main/notebooks/images/aya-vision/image1.jpg"
 />
 
 ```python PYTHON
@@ -158,7 +158,7 @@ render_image(image_path)
 ```
 
 <img
-  src="https://github.com/cohere-ai/cohere-developer-experience/tree/main/notebooks/images/aya-vision/image2.jpg"
+  src="https://github.com/cohere-ai/cohere-developer-experience/raw/main/notebooks/images/aya-vision/image2.jpg"
 />
 
 
@@ -179,7 +179,7 @@ render_image(image_path)
 ```
 
 <img
-  src="https://github.com/cohere-ai/cohere-developer-experience/tree/main/notebooks/images/aya-vision/image3.jpg"
+  src="https://github.com/cohere-ai/cohere-developer-experience/raw/main/notebooks/images/aya-vision/image3.jpg"
 />
 
 
@@ -204,7 +204,7 @@ render_image(image_path)
 ```
     
 <img
-  src="https://github.com/cohere-ai/cohere-developer-experience/tree/main/notebooks/images/aya-vision/image4.jpg"
+  src="https://github.com/cohere-ai/cohere-developer-experience/raw/main/notebooks/images/aya-vision/image4.jpg"
 />
 
 ```python PYTHON
@@ -227,7 +227,7 @@ render_image(image_path)
 ```
 
 <img
-  src="https://github.com/cohere-ai/cohere-developer-experience/tree/main/notebooks/images/aya-vision/image5.jpg"
+  src="https://github.com/cohere-ai/cohere-developer-experience/raw/main/notebooks/images/aya-vision/image5.jpg"
 />
 
 
@@ -254,11 +254,11 @@ render_image(image_path2)
 
 
 <img
-  src="https://github.com/cohere-ai/cohere-developer-experience/tree/main/notebooks/images/aya-vision/image6.jpg"
+  src="https://github.com/cohere-ai/cohere-developer-experience/raw/main/notebooks/images/aya-vision/image6.jpg"
 />
 
 <img
-  src="https://github.com/cohere-ai/cohere-developer-experience/tree/main/notebooks/images/aya-vision/image7.jpg"
+  src="https://github.com/cohere-ai/cohere-developer-experience/raw/main/notebooks/images/aya-vision/image7.jpg"
 />
 
 
@@ -295,11 +295,11 @@ render_image(image_path2)
 
 
 <img
-  src="https://github.com/cohere-ai/cohere-developer-experience/tree/main/notebooks/images/aya-vision/image6.jpg"
+  src="https://github.com/cohere-ai/cohere-developer-experience/raw/main/notebooks/images/aya-vision/image6.jpg"
 />
 
 <img
-  src="https://github.com/cohere-ai/cohere-developer-experience/tree/main/notebooks/images/aya-vision/image7.jpg"
+  src="https://github.com/cohere-ai/cohere-developer-experience/raw/main/notebooks/images/aya-vision/image7.jpg"
 />
 
 


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request updates the image source paths in the `fern/pages/cookbooks/aya_vision_intro.mdx` file.

- The image source paths are changed from `tree/main/notebooks/images/aya-vision/` to `raw/main/notebooks/images/aya-vision/`.
- This ensures that the images are directly accessible from the raw file path, rather than being nested within the main directory.
- The change affects all image sources in the file, including the Aya Vision logo and other images used in the notebook.

<!-- end-generated-description -->