### PR TITLE
Aya Vision - update cookbook links

### DIFF
--- a/fern/pages/cookbooks/aya_vision_intro.mdx
+++ b/fern/pages/cookbooks/aya_vision_intro.mdx
@@ -1,5 +1,5 @@
 ---
-title: Introduction to Aya Vision - A state-of-the-art open-weights vision model
+title: Introduction to Aya Vision
 slug: /page/aya-vision-intro
 
 description: "In this notebook, we will explore the capabilities of Aya Vision, which can take text and image inputs to generates text responses."
@@ -9,7 +9,7 @@ keywords: "Aya, Cohere for AI, multimodal model, multilingual model"
 import { CookbookHeader } from "../../components/cookbook-header";
 
 
-<CookbookHeader href="https://github.com/cohere-ai/cohere-developer-experience/blob/main/notebooks/guide/aya_vision_intro.ipynb" />
+<CookbookHeader href="https://github.com/cohere-ai/cohere-developer-experience/blob/main/notebooks/guides/aya_vision_intro.ipynb" />
 
 
 Introducing Aya Vision - a state-of-the-art open-weights multimodal multilingual model.
@@ -22,7 +22,7 @@ In this notebook, we will explore the capabilities of Aya Vision, which can take
 
 The following links provide further details about the Aya Vision model:
 - [The launch blog](https://cohere.com/blog/aya-vision)
-- [Cohere's documentation](https://docs.cohere.com/docs/aya-multimodal)
+- [Documentation](https://docs.cohere.com/docs/aya-multimodal)
 - HuggingFace model page for the [32B](https://huggingface.co/CohereForAI/aya-vision-32b) and [8B](https://huggingface.co/CohereForAI/aya-vision-8b) models.
 
 This tutorial will provide a walkthrough of the various use cases that you can build with Aya Vision. By the end of this notebook, you will have a solid understanding of how to use Aya Vision for a wide range of applications.


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the Aya Vision documentation to reflect the new location of the Aya Vision introduction notebook.

## Changes
- The `href` attribute in the `CookbookHeader` component is updated to point to the new location of the notebook.
- The markdown link to the notebook in the `.ipynb` file is also updated to reflect the new location.

<!-- end-generated-description -->