### PR TITLE
Fix issue with learn more color

### DIFF
--- a/fern/assets/input.css
+++ b/fern/assets/input.css
@@ -38,8 +38,8 @@ h2 {
   font-weight: 400 !important;
 }
 
-.fern-announcement .fern-mdx-link, .fern-announcement svg {
-    color: #fff;
+.fern-announcement .fern-mdx-link, .fern-announcement svg.external-link-icon {
+    color: #fff !important;
 }
 
 

--- a/fern/assets/input.css
+++ b/fern/assets/input.css
@@ -38,6 +38,11 @@ h2 {
   font-weight: 400 !important;
 }
 
+.fern-announcement .fern-mdx-link, .fern-announcement svg {
+    color: #fff;
+}
+
+
 .font-semibold {
   font-weight: 500 !important;
 }

--- a/fern/assets/input.css
+++ b/fern/assets/input.css
@@ -42,7 +42,6 @@ h2 {
     color: #fff !important;
 }
 
-
 .font-semibold {
   font-weight: 500 !important;
 }


### PR DESCRIPTION
Update color for "Learn more" text in annoucements section
Previous [PR](https://github.com/cohere-ai/cohere-developer-experience/pull/439) didn't use such precise selector and caused issue with links on the pages