### PR TITLE
Add info about private deployment in quickstart

### DIFF
--- a/fern/pages/v2/get-started/quickstart/text-gen-quickstart.mdx
+++ b/fern/pages/v2/get-started/quickstart/text-gen-quickstart.mdx
@@ -93,6 +93,10 @@ co = cohere.ClientV2(
 ### Basic Text Generation
 To perform a basic text generation, call the Chat endpoint by passing the `messages` parameter containing the `user` message.
 
+<Info>
+The `model` parameter definition for private deployments is the same as the Cohere platform, as shown below. Find more details on private deployments usage [here](https://docs.cohere.com/docs/private-deployment-usage#getting-started).
+</Info>
+
 <Tabs>
 <Tab title="Cohere Platform">
 ```python PYTHON
@@ -169,6 +173,8 @@ response = co.chat(
         }
     ],
 )
+
+print(response.message.content[0].text)
 ```
 </Tab>
 
@@ -252,6 +258,8 @@ response = co.chat(
         },
     ],
 )
+
+print(response.message.content[0].text)
 ```
 </Tab>
 
@@ -275,6 +283,8 @@ response = co.chat(
         },
     ],
 )
+
+print(response.message.content[0].text)
 ```
 </Tab>
 
@@ -298,6 +308,8 @@ response = co.chat(
         },
     ],
 )
+
+print(response.message.content[0].text)
 ```
 </Tab>
 


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request adds a new section to the documentation, providing information about the `model` parameter definition for private deployments. The section includes a code snippet demonstrating how to use the `model` parameter with the Cohere platform.

## Changes:
- Added a new section with an `<Info>` tag, containing details about the `model` parameter definition for private deployments.
- Included a code snippet under the Cohere Platform tab, showing the usage of the `model` parameter.
- The code snippet prints the response message content's text using `print(response.message.content[0].text)`.

<!-- end-generated-description -->