### PR TITLE
refactor: Remove all references to prompt tuner

### DIFF
--- a/fern/pages/get-started/frequently-asked-questions.mdx
+++ b/fern/pages/get-started/frequently-asked-questions.mdx
@@ -261,8 +261,6 @@ For general recommendations on prompt engineering check the following resources:
 - Tips on [Crafting Effective Prompts](https://docs.cohere.com/v1/docs/crafting-effective-prompts)
 - Techniques of [Advanced Prompt Engineering](https://docs.cohere.com/v1/docs/advanced-prompt-engineering-techniques).
 
-Make sure to try our [Prompt Tuner](https://dashboard.cohere.com/prompt-tuner). It was developed to streamline the process of defining a robust prompt for your use case. Check [Prompt Tuner documentation](https://docs.cohere.com/docs/prompt-tuner) to learn how it works.
-
 For the most reliable results when working with external document sources, we recommend using a technique called Retrieval-Augmented Generation (RAG). You can learn about it here:
 - [Getting Started With Retrieval-Augmented Generation](https://cohere.com/llmu/rag-start)
 - [Cohere documentation](https://docs.cohere.com/v1/docs/retrieval-augmented-generation-rag) on RAG

--- a/fern/pages/integrations/llamaindex.mdx
+++ b/fern/pages/integrations/llamaindex.mdx
@@ -73,7 +73,7 @@ from llama_index.readers.web import (
 
 # create index (we are using an example page from Cohere's docs)
 documents = SimpleWebPageReader(html_to_text=True).load_data(
-    ["https://docs.cohere.com/v2/docs/prompt-tuner"]
+    ["https://docs.cohere.com/v2/docs/cohere-embed"]
 )  # you can replace this with any other reader or documents
 index = VectorStoreIndex.from_documents(documents=documents)
 
@@ -92,7 +92,7 @@ print(query_engine)
 
 # generate a response
 response = query_engine.query(
-    "What is Cohere Prompt Tuner?",
+    "What is Cohere's Embed Model?",
 )
 
 print(response)
@@ -132,7 +132,7 @@ Settings.embed_model = embed_model
 
 # create index (we are using an example page from Cohere's docs)
 documents = SimpleWebPageReader(html_to_text=True).load_data(
-    ["https://docs.cohere.com/v2/docs/prompt-tuner"]
+    ["https://docs.cohere.com/v2/docs/cohere-embed"]
 )  # you can replace this with any other reader or documents
 index = VectorStoreIndex.from_documents(documents=documents)
 
@@ -147,7 +147,7 @@ query_engine = index.as_query_engine(
 )
 
 # Generate the response
-response = query_engine.query("What is Cohere Prompt Tuner?")
+response = query_engine.query("What is Cohere's Embed model?")
 print(response)
 ```
 

--- a/fern/v1.yml
+++ b/fern/v1.yml
@@ -120,8 +120,6 @@ navigation:
                 path: pages/text-generation/prompt-engineering/prompt-truncation.mdx
               - page: Preambles
                 path: pages/text-generation/prompt-engineering/preambles.mdx
-              - page: Prompt Tuner (beta)
-                path: pages/text-generation/prompt-engineering/prompt-tuner.mdx
               - section: Prompt Library
                 contents:
                   - page: Create CSV data from JSON data

--- a/fern/v2.yml
+++ b/fern/v2.yml
@@ -111,8 +111,6 @@ navigation:
                 path: pages/v2/text-generation/prompt-engineering/advanced-prompt-engineering-techniques.mdx
               - page: System Messages
                 path: pages/v2/text-generation/prompt-engineering/preambles.mdx
-              - page: Prompt Tuner (beta)
-                path: pages/text-generation/prompt-engineering/prompt-tuner.mdx
               - section: Prompt Library
                 contents:
                   - page: Create CSV data from JSON data


### PR DESCRIPTION
This PR removes references to the Automatic Prompt Tuner, which is being deprecated. Removes page references in the v1 and v2 API, references in the FAQs, and in the Llama index examples. 