### PR TITLE
Remove Multilingual warning for Cmd-R+

### DIFF
--- a/fern/pages/models/the-command-family-of-models/command-r-plus.mdx
+++ b/fern/pages/models/the-command-family-of-models/command-r-plus.mdx
@@ -44,8 +44,6 @@ Finally, these refreshed models were trained with data through February 2023, wh
 
 Command R+ has been trained on a massive corpus of diverse texts in multiple languages, and can perform a wide array of text-generation tasks. Moreover, Command R+ has been trained with a particular focus on excelling in some of the most critical business use-cases.
 
-Note, however, that RAG and multi-step tool use (agents) are currently only available in English.
-
 ### Multilingual Capabilities
 
 The model is optimized to perform well in the following languages: English, French, Spanish, Italian, German, Brazilian Portuguese, Japanese, Korean, Simplified Chinese, and Arabic. 

--- a/fern/pages/v2/models/the-command-family-of-models/command-r-plus.mdx
+++ b/fern/pages/v2/models/the-command-family-of-models/command-r-plus.mdx
@@ -45,8 +45,6 @@ Finally, these refreshed models were trained with data through February 2023, wh
 
 Command R+ has been trained on a massive corpus of diverse texts in multiple languages, and can perform a wide array of text-generation tasks. Moreover, Command R+ has been trained with a particular focus on excelling in some of the most critical business use-cases.
 
-Note, however, that RAG and multi-step tool use (agents) are currently only available in English.
-
 ### Multilingual Capabilities
 
 The model is optimized to perform well in the following languages: English, French, Spanish, Italian, German, Brazilian Portuguese, Japanese, Korean, Simplified Chinese, and Arabic. 


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request removes the following text from the Command R+ model description:

> Note, however, that RAG and multi-step tool use (agents) are currently only available in English.

This change is made to both the `fern/pages/models/the-command-family-of-models/command-r-plus.mdx` and `fern/pages/v2/models/the-command-family-of-models/command-r-plus.mdx` files.

- **Reasoning:** The removed text is no longer accurate or relevant to the model's capabilities. It may have been included in the original description to highlight a limitation of the model, but this limitation has since been addressed or is no longer a significant factor in the model's performance.

<!-- end-generated-description -->