### PR TITLE
Update north-eap-private-deployment.mdx

### DIFF
--- a/fern/pages/deployment-options/north-eap-private-deployment.mdx
+++ b/fern/pages/deployment-options/north-eap-private-deployment.mdx
@@ -104,7 +104,7 @@ The defaults are set up to expect a secret named `credentials` in your installat
     apiVersion: v1
     kind: Secret
     metadata:
-      name: persistence-credentials
+      name: credentials
       namespace: cohere
     type: Opaque
     stringData:


### PR DESCRIPTION
step 4 updated to reflect 'credentials' instead of 'persistence-credentials'