### PR TITLE
Updating the SM page with batch transform information.

### DIFF
--- a/fern/pages/deployment-options/cohere-on-aws/amazon-sagemaker-setup-guide.mdx
+++ b/fern/pages/deployment-options/cohere-on-aws/amazon-sagemaker-setup-guide.mdx
@@ -81,6 +81,7 @@ result = co.embed(
 
 print(result)
 ```
+<Warning>Cohere's embed models don't support batch transform operations.</Warning>
 
 Note that we've released multimodal embeddings models that are able to handle images in addition to text. Find [more information here](https://docs.cohere.com/docs/multimodal-embeddings).
 

--- a/fern/pages/v2/deployment-options/cohere-on-aws/amazon-sagemaker-setup-guide.mdx
+++ b/fern/pages/v2/deployment-options/cohere-on-aws/amazon-sagemaker-setup-guide.mdx
@@ -85,6 +85,8 @@ result = co.embed(
 print(result)
 ```
 
+<Warning>Cohere's embed models don't support batch transform operations.</Warning>
+
 Note that we've released multimodal embeddings models that are able to handle images in addition to text. Find [more information here](https://docs.cohere.com/docs/multimodal-embeddings).
 
 ## Text Generation


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR adds a warning to the Amazon Sagemaker Setup Guide in the Deployment Options section.

- Adds a warning that Cohere's embed models don't support batch transform operations.

<!-- end-generated-description -->