### PR TITLE
The v2 summarization doc was missed in the updates.

### DIFF
--- a/fern/pages/v2/text-generation/summarizing-text.mdx
+++ b/fern/pages/v2/text-generation/summarizing-text.mdx
@@ -40,7 +40,7 @@ Rental companies are still seeing growth, but at a more moderate level."""
 message = f"Generate a concise summary of this text\n{document}"
 
 response = co.chat(
-    model="command-r-plus-08-2024",
+    model="command-a-03-2025",
     messages=[{"role": "user", "content": message}],
 )
 
@@ -68,7 +68,7 @@ You can further control the output by defining the length of the summary in your
 message = f"Summarize this text in one sentence\n{document}"
 
 response = co.chat(
-    model="command-r-plus-08-2024",
+    model="command-a-03-2025",
     messages=[{"role": "user", "content": message}],
 )
 
@@ -89,7 +89,7 @@ You can also specify the length in terms of word count.
 message = f"Summarize this text in less than 10 words\n{document}"
 
 response = co.chat(
-    model="command-r-plus-08-2024",
+    model="command-a-03-2025",
     messages=[{"role": "user", "content": message}],
 )
 
@@ -110,7 +110,7 @@ Instead of generating summaries as paragraphs, you can also prompt the model to 
 message = f"Generate a concise summary of this text as bullet points\n{document}"
 
 response = co.chat(
-    model="command-r-plus-08-2024",
+    model="command-a-03-2025",
     messages=[{"role": "user", "content": message}],
 )
 
@@ -171,7 +171,7 @@ Aside from displaying the actual summary, we can display the citations as as wel
 message = f"Summarize this text in one sentence."
 
 response = co.chat(
-    model="command-r-plus-08-2024",
+    model="command-a-03-2025",
     documents=document_chunked,
     messages=[
         {"role": "system", "content": system_message},
@@ -250,6 +250,6 @@ message = """Write a short summary from the following text in bullet point forma
 
 co.chat(
     messages=[{"role": "user", "content": message}],
-    model="command-r-plus-08-2024",
+    model="command-a-03-2025",
 )
 ```


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the model used for text generation in the summarizing-text.mdx file.

- The model used for text generation has been updated from `command-r-plus-08-2024` to `command-a-03-2025`.
- This change is reflected in all instances where the model is specified in the code.
- The update is applied consistently across all relevant functions, including those for generating concise summaries, one-sentence summaries, summaries in less than 10 words, and summaries as bullet points.
- The change also applies to the function that generates summaries with citations.
- The final function, which writes a short summary in bullet point form, also reflects this model update.

<!-- end-generated-description -->