### PR TITLE
The v2 doc was missed.

### DIFF
--- a/fern/pages/v2/text-generation/structured-outputs.mdx
+++ b/fern/pages/v2/text-generation/structured-outputs.mdx
@@ -18,6 +18,7 @@ updatedAt: "Tue Jun 11 2024 02:43:00 GMT+0000 (Coordinated Universal Time)"
 Structured Outputs is a feature that forces the LLM’s response to strictly follow a schema specified by the user. When Structured Outputs is turned on, the LLM will generate structured data that follows the desired schema, provided by the user, 100% of the time. This increases the reliability of LLMs in enterprise applications where downstream applications expect the LLM output to be correctly formatted. With Structured Outputs, hallucinated fields and entries in structured data can be reliably eliminated.
 
 Compatible models:
+- Command A
 - Command R+ 08 2024
 - Command R+
 - Command R 08 2024
@@ -53,7 +54,7 @@ import cohere
 co = cohere.ClientV2(api_key="YOUR API KEY")
 
 res = co.chat(
-    model="command-r-plus-08-2024",
+    model="command-a-03-2025",
     messages=[
         {
             "role": "user",
@@ -99,7 +100,7 @@ import cohere
 co = cohere.ClientV2(api_key="YOUR API KEY")
 
 res = co.chat(
-    model="command-r-plus-08-2024",
+    model="command-a-03-2025",
     messages=[
         {
             "role": "user",
@@ -232,7 +233,7 @@ tools = [
     },
 ]
 
-response = co.chat(model="command-r-plus-08-2024",
+response = co.chat(model="command-a-03-2025",
                    messages=[{"role": "user", "content": "What's the weather in Toronto?"}],
                    tools=tools,
                    strict_tools=True)


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the documentation for the Structured Outputs feature, adding Command A to the list of compatible models and changing the model name in the code examples from `command-r-plus-08-2024` to `command-a-03-2025`.

- Adds Command A to the list of compatible models for Structured Outputs
- Updates the model name in the code examples from `command-r-plus-08-2024` to `command-a-03-2025`

<!-- end-generated-description -->