### PR TITLE
Command a roy changes

### DIFF
--- a/fern/pages/models/the-command-family-of-models/command-beta.mdx
+++ b/fern/pages/models/the-command-family-of-models/command-beta.mdx
@@ -11,7 +11,7 @@ createdAt: 'Mon Nov 07 2022 16:26:44 GMT+0000 (Coordinated Universal Time)'
 updatedAt: 'Tue Jun 04 2024 18:34:22 GMT+0000 (Coordinated Universal Time)'
 ---
 <Info title="Note">  
- For most use cases we recommend our latest model [Command R](/docs/command-r) instead.
+ For most use cases we recommend our latest model [Command A](https://docs.cohere.com/docs/command-a) instead.
 </Info>
 
 

--- a/fern/pages/models/the-command-family-of-models/command-beta.mdx
+++ b/fern/pages/models/the-command-family-of-models/command-beta.mdx
@@ -61,7 +61,7 @@ co = cohere.Client(api_key)
 ### Create prompt
 
 ```python PYTHON
-message = "Write an introductory paragraph for a blog post about language models."
+message = "Write an introductory paragraph for a blog post discussing language models."
 ```
 
 ### Generate text

--- a/fern/pages/models/the-command-family-of-models/command-r-plus.mdx
+++ b/fern/pages/models/the-command-family-of-models/command-r-plus.mdx
@@ -11,9 +11,9 @@ createdAt: 'Thu Apr 04 2024 08:03:47 GMT+0000 (Coordinated Universal Time)'
 updatedAt: 'Wed Dec 18 2024 14:16:00 GMT+0000 (Coordinated Universal Time)'
 ---
 
-Command R+ is Cohere's newest large language model, optimized for conversational interaction and long-context tasks. It aims at being extremely performant, enabling companies to move beyond proof of concept and into production.
+Command R+ is optimized for conversational interaction and long-context tasks. It aims at being extremely performant, enabling companies to move beyond proof of concept and into production.
 
-We recommend using Command R+ for those workflows that lean on complex RAG functionality and [multi-step tool use (agents)](/docs/multi-hop-tool-use). Command R, on the other hand, is great for simpler [retrieval augmented generation](/docs/retrieval-augmented-generation-rag) (RAG) and [single-step tool use](/docs/tool-use) tasks, as well as applications where price is a major consideration.
+We recommend using Command R+ for workflows that lean on complex RAG functionality and [multi-step tool use (agents)](/docs/multi-hop-tool-use). Command R, on the other hand, is great for simpler [retrieval augmented generation](/docs/retrieval-augmented-generation-rag) (RAG) and [single-step tool use](/docs/tool-use) tasks, as well as applications where price is a major consideration.
 
 For information on toxicity, safety, and using this model responsibly check out our [Command model card](https://docs.cohere.com/docs/responsible-use).
 


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the Command R+ and Command Beta documentation.

- Command R+ is no longer referred to as Cohere's newest large language model.
- Command Beta now recommends Command A instead of Command R.
- The prompt in the Command Beta documentation has been updated to be more specific.

<!-- end-generated-description -->