### PR TITLE
Marwan's edits.

### DIFF
--- a/fern/pages/deployment-options/north-eap-private-deployment.mdx
+++ b/fern/pages/deployment-options/north-eap-private-deployment.mdx
@@ -122,10 +122,10 @@ The defaults are set up to expect a secret named `credentials` in your installat
     global:
       config:
         cohere:
-          chatApiUrl: http://command-r-08-2024
-          denseApiUrl: http://embed-english-03
-          sparseApiUrl: http://sparse-01
-          rerankApiUrl: http://rerank-english-03
+          chatApiUrl: http://command
+          denseApiUrl: http://embed
+          sparseApiUrl: http://sparse
+          rerankApiUrl: http://rerank
         postgres:
           host: "postgresql" # required
           user: "cohere" # required
@@ -133,7 +133,7 @@ The defaults are set up to expect a secret named `credentials` in your installat
           sslMode: "" # verify-ca
           password:
             secretKeyRef:
-              name: persistence-credentials
+              name: credentials
               key: postgresPassword
           tls:
             caCerts:
@@ -145,7 +145,7 @@ The defaults are set up to expect a secret named `credentials` in your installat
           port: 6379
           password:
             secretKeyRef:
-              name: persistence-credentials
+              name: credentials
               key: redisPassword
           tls:
             caCerts:
@@ -217,6 +217,8 @@ The defaults are set up to expect a secret named `credentials` in your installat
               name: ""
               key: ""
         modelDeploymentType: single_container
+        singleContainer:
+	      model: "command"
       backend:
         monitoring:
           enabled: false
@@ -240,7 +242,7 @@ The defaults are set up to expect a secret named `credentials` in your installat
       fullnameOverride: "north-valkey"
       architecture: "standalone"
       auth:
-        existingSecret: persistence-credentials
+        existingSecret: credentials
         existingSecretPasswordKey: redisPassword
       commonConfiguration: |-
         save 60 1


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the default configuration settings for the cohere and postgres sections, and adds a new singleContainer section.

- Updates the cohere API URLs to use generic names instead of specific versions.
- Changes the secretKeyRef name for postgres and redis passwords to `credentials` from `persistence-credentials`.
- Adds a new `singleContainer` section with a `model` field set to `command`.
- Updates the `existingSecret` field in the redis auth section to `credentials`.

<!-- end-generated-description -->