### PR TITLE
Set titles for chat navigation to general naming

### DIFF
--- a/fern/v1.yml
+++ b/fern/v1.yml
@@ -649,9 +649,9 @@ navigation:
                 skip-slug: true
                 contents:
                   - endpoint: POST /v1/chat
-                    title: Chat (V1)
+                    title: Chat
                   - endpoint: STREAM /v1/chat
-                    title: Chat with Streaming (V1)
+                    title: Chat with Streaming
               - section: "v1/embed"
                 skip-slug: true
                 contents:


### PR DESCRIPTION
This PR set reference `chat` navigation titles to general names (without spacifying versions)
At the same time we'll set page title in schema file. ([Relevant PR](https://github.com/cohere-ai/blobheart/pull/22176))
Once relevant PR is merged we'll refresh `openapi-cohere.yaml` file
here's preview app I used for testing
https://cohere-preview-76629041-aea0-468c-8e30-73d1c1669734.docs.buildwithfern.com/v1/reference/chat
title tag in html page is chat v1