### PR TITLE
Updating a broken link in the playground guide.

### DIFF
--- a/fern/pages/get-started/playground-overview.mdx
+++ b/fern/pages/get-started/playground-overview.mdx
@@ -38,7 +38,7 @@ Here's what's available:
 
 - `Model`: Choose from a list of our generation models (we recommend `command-a-03-2025`, the default).
 - `Functions`: Function calling allows developers to connect models to external functions like APIs, databases, etc., take actions in them, and return results for users to interact with. Learn more in [tool use](https://docs.cohere.com/docs/tool-use) docs.
-- `JSON Mode`: This is part of Cohere's [structured output](https://docs.cohere.com/docs/structured-outputs) functionality. When enabled, the model's response will be a JSON object that matched the schema that you have supplied. Learn more in [JSON mode](https://docs.cohere.com/docs/json-mode).
+- `JSON Mode`: This is part of Cohere's [structured output](https://docs.cohere.com/docs/structured-outputs) functionality. When enabled, the model's response will be a JSON object that matched the schema that you have supplied. Learn more in [JSON mode](https://docs.cohere.com/docs/parameter-types-in-json).
 - Under `Advanced Parameters`, you can customize the `temperature` and `seed`. A higher temperature will make the model more creative, while a lower temperature will make the model more focused and deterministic, and seed can help you keep outputs consistent. Learn more [here](https://docs.cohere.com/docs/predictable-outputs).
 - Under `Advanced Parameters`, you'll also see the ability to turn on reasoning. This will cause the model to consider the implications of its response and provide a justification for its output. More information will be available as we continue to roll out this feature.
 


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the JSON mode link in the Playground Overview page.

- The JSON mode link has been updated to https://docs.cohere.com/docs/parameter-types-in-json

<!-- end-generated-description -->