### PR TITLE
Revert changing titles until it's possible to manage titles in navigation

### DIFF
--- a/fern/v1.yml
+++ b/fern/v1.yml
@@ -649,9 +649,9 @@ navigation:
                 skip-slug: true
                 contents:
                   - endpoint: POST /v1/chat
-                    title: Chat
+                    title: Chat  (V1)
                   - endpoint: STREAM /v1/chat
-                    title: Chat with Streaming
+                    title: Chat with Streaming (V1)
               - section: "v1/embed"
                 skip-slug: true
                 contents:


### PR DESCRIPTION
Temporary resolving issue with titles navigation (reverting previous change) until we'll be able to set different page titles and meta titles