### PR TITLE
Temporarily fix issue with duplicates titles

### DIFF
--- a/fern/v2.yml
+++ b/fern/v2.yml
@@ -778,7 +778,7 @@ navigation:
                 contents:
                   - endpoint: POST /v1/chat
                     slug: chat-v1
-                    title: Chat
+                    title: Chat (V1)
                   - endpoint: STREAM /v1/chat
                     slug: chat-stream-v1
                     title: Chat with Streaming Outputs (API V1)


### PR DESCRIPTION
Fixing issues with duplicated titles for chat endpoints in v1 and v2 until we'll be making overrides in schema.