### PR TITLE
Set redirect for old rarank-2 slug

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -610,6 +610,9 @@ redirects:
   - source: /docs/aya-multimodal
     destination: /docs/aya-vision
     permanent: true
+  - source: /docs/rerank-2
+    destination: /docs/rerank
+    permanent: true
 
 analytics:
   segment:


### PR DESCRIPTION
We've changed `Rerank` page slug from `rerank-2` to `rerank` in this [PR](https://github.com/cohere-ai/cohere-developer-experience/pull/501)
Now semrush reporting missing page at `/docs/rerank-2` so this should fix the issue