### PR TITLE
Fix broken external urls

### DIFF
--- a/fern/pages/cookbooks/agentic-rag-mixed-data.mdx
+++ b/fern/pages/cookbooks/agentic-rag-mixed-data.mdx
@@ -41,7 +41,7 @@ We recommend the following notebook as a guide to [semi-structured RAG](https://
 
 We also recommend the following notebook to explore various parsing techniques for [PDFs](https://github.com/cohere-ai/cohere-developer-experience/blob/main/notebooks/guides/Document_Parsing_For_Enterprises.ipynb).
 
-Various LangChain-supported parsers can be found [here](https://python.langchain.com/docs/modules/data_connection/document_loaders/pdf/).
+Various LangChain-supported parsers can be found [here](https://python.langchain.com/docs/how_to/document_loader_pdf/).
 
 ## Install Dependencies
 
@@ -150,7 +150,7 @@ print(len(text_elements))
 There are many options for setting up a vector store. Here, we show how to do so using [Chroma](https://www.trychroma.com/) and Langchain's Multi-vector retrieval.
 As the name implies, multi-vector retrieval allows us to store multiple vectors per document; for instance, for a single document chunk, one could keep embeddings for both the chunk itself, and a summary of that document. A summary may be able to distill more accurately what a chunk is about, leading to better retrieval.
 
-You can read more about this here: https://python.langchain.com/docs/modules/data_connection/retrievers/multi_vector/
+You can read more about this here: https://python.langchain.com/docs/how_to/multi_vector/
 
 Below, we demonstrate the following process:
 

--- a/fern/pages/cookbooks/elasticsearch-and-cohere.mdx
+++ b/fern/pages/cookbooks/elasticsearch-and-cohere.mdx
@@ -100,7 +100,7 @@ client.inference.put_model(
 
 ## Create an ingest pipeline with an inference processor
 
-Create an ingest pipeline with an inference processor by using the [`put_pipeline`](https://www.elastic.co/guide/en/elasticsearch/reference/master/put-pipeline-api.html) method. Reference the inference endpoint created above as the `model_id` to infer against the data that is being ingested in the pipeline.
+Create an ingest pipeline with an inference processor by using the [`put_pipeline`](https://www.elastic.co/guide/en/elasticsearch/reference/current/put-pipeline-api.html) method. Reference the inference endpoint created above as the `model_id` to infer against the data that is being ingested in the pipeline.
 
 ```python PYTHON
 client.options(ignore_status=[404]).ingest.delete_pipeline(id="cohere_embeddings")

--- a/fern/pages/integrations/cohere-and-langchain/chat-on-langchain.mdx
+++ b/fern/pages/integrations/cohere-and-langchain/chat-on-langchain.mdx
@@ -44,7 +44,7 @@ print(llm.invoke(current_message_and_history))
 
 ### Cohere Agents with LangChain
 
-LangChain [Agents](https://python.langchain.com/docs/modules/agents/) use a language model to choose a sequence of actions to take.
+LangChain [Agents](https://python.langchain.com/docs/how_to/#agents) use a language model to choose a sequence of actions to take.
 
 To use Cohere's multi hop agent create a `create_cohere_react_agent` and pass in the LangChain tools you would like to use.
 

--- a/fern/pages/integrations/integrations/elasticsearch-and-cohere.mdx
+++ b/fern/pages/integrations/integrations/elasticsearch-and-cohere.mdx
@@ -13,7 +13,7 @@ updatedAt: 'Thu May 30 2024 15:56:35 GMT+0000 (Coordinated Universal Time)'
 
 <img src="../../../assets/images/17b17dc-elastic-search-logo.png" width="200px" height="auto" class="light-bg" />
 
-[Elasticsearch](https://www.elastic.co/search-labs/blog/elasticsearch-cohere-embeddings-support) has all the tools developers need to build next generation search experiences with generative AI, and it supports native integration with [Cohere](https://www.elastic.co/search-labs/blog/elasticsearch-cohere-embeddings-support) through their [inference API](https://www.elastic.co/guide/en/elasticsearch/reference/master/semantic-search-inference.html).
+[Elasticsearch](https://www.elastic.co/search-labs/blog/elasticsearch-cohere-embeddings-support) has all the tools developers need to build next generation search experiences with generative AI, and it supports native integration with [Cohere](https://www.elastic.co/search-labs/blog/elasticsearch-cohere-embeddings-support) through their [inference API](https://www.elastic.co/guide/en/elasticsearch/reference/current/semantic-search-inference.html).
 
 Use Elastic if you’d like to build with:
 

--- a/scripts/cookbooks-mdx/agentic-rag-mixed-data.mdx
+++ b/scripts/cookbooks-mdx/agentic-rag-mixed-data.mdx
@@ -187,7 +187,7 @@ We recommend the following notebook as a guide to [semi-structured RAG](https://
 
 We also recommend the following notebook to explore various parsing techniques for [PDFs](https://github.com/cohere-ai/cohere-developer-experience/blob/main/notebooks/guides/Document_Parsing_For_Enterprises.ipynb).
 
-Various LangChain-supported parsers can be found [here](https://python.langchain.com/docs/modules/data_connection/document_loaders/pdf/).
+Various LangChain-supported parsers can be found [here](https://python.langchain.com/docs/how_to/document_loader_pdf/).
 
 ## Table of Contents
 - Section 1
@@ -311,7 +311,7 @@ print(len(text_elements))
 There are many options for setting up a vector store. Here, we show how to do so using [Chroma](https://www.trychroma.com/) and Langchain's Multi-vector retrieval.
 As the name implies, multi-vector retrieval allows us to store multiple vectors per document; for instance, for a single document chunk, one could keep embeddings for both the chunk itself, and a summary of that document. A summary may be able to distill more accurately what a chunk is about, leading to better retrieval.
 
-You can read more about this here: https://python.langchain.com/docs/modules/data_connection/retrievers/multi_vector/
+You can read more about this here: https://python.langchain.com/docs/how_to/multi_vector/
 
 Below, we demonstrate the following process:
 - summaries of each chunk are embedded

--- a/scripts/cookbooks-mdx/elasticsearch-and-cohere.mdx
+++ b/scripts/cookbooks-mdx/elasticsearch-and-cohere.mdx
@@ -234,7 +234,7 @@ client.inference.put_model(
 
 ## Create an ingest pipeline with an inference processor
 
-Create an ingest pipeline with an inference processor by using the [`put_pipeline`](https://www.elastic.co/guide/en/elasticsearch/reference/master/put-pipeline-api.html) method. Reference the inference endpoint created above as the `model_id` to infer against the data that is being ingested in the pipeline.
+Create an ingest pipeline with an inference processor by using the [`put_pipeline`](https://www.elastic.co/guide/en/elasticsearch/reference/current/put-pipeline-api.html) method. Reference the inference endpoint created above as the `model_id` to infer against the data that is being ingested in the pipeline.
 
 
 ```python PYTHON


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates links in the documentation to ensure they point to the most current and relevant resources.

- **fern/pages/cookbooks/agentic-rag-mixed-data.mdx**: Updated the link for LangChain-supported parsers from `https://python.langchain.com/docs/modules/data_connection/document_loaders/pdf/` to `https://python.langchain.com/docs/how_to/document_loader_pdf/`.
- **fern/pages/cookbooks/agentic-rag-mixed-data.mdx**: Updated the link for multi-vector retrieval from `https://python.langchain.com/docs/modules/data_connection/retrievers/multi_vector/` to `https://python.langchain.com/docs/how_to/multi_vector/`.
- **fern/pages/cookbooks/elasticsearch-and-cohere.mdx**: Updated the link for the `put_pipeline` method from `https://www.elastic.co/guide/en/elasticsearch/reference/master/put-pipeline-api.html` to `https://www.elastic.co/guide/en/elasticsearch/reference/current/put-pipeline-api.html`.
- **fern/pages/integrations/cohere-and-langchain/chat-on-langchain.mdx**: Updated the link for LangChain Agents from `https://python.langchain.com/docs/modules/agents/` to `https://python.langchain.com/docs/how_to/#agents`.
- **fern/pages/integrations/integrations/elasticsearch-and-cohere.mdx**: Updated the link for Elasticsearch's inference API from `https://www.elastic.co/guide/en/elasticsearch/reference/master/semantic-search-inference.html` to `https://www.elastic.co/guide/en/elasticsearch/reference/current/semantic-search-inference.html`.
- **scripts/cookbooks-mdx/agentic-rag-mixed-data.mdx**: Updated the link for LangChain-supported parsers from `https://python.langchain.com/docs/modules/data_connection/document_loaders/pdf/` to `https://python.langchain.com/docs/how_to/document_loader_pdf/`.
- **scripts/cookbooks-mdx/agentic-rag-mixed-data.mdx**: Updated the link for multi-vector retrieval from `https://python.langchain.com/docs/modules/data_connection/retrievers/multi_vector/` to `https://python.langchain.com/docs/how_to/multi_vector/`.
- **scripts/cookbooks-mdx/elasticsearch-and-cohere.mdx**: Updated the link for the `put_pipeline` method from `https://www.elastic.co/guide/en/elasticsearch/reference/master/put-pipeline-api.html` to `https://www.elastic.co/guide/en/elasticsearch/reference/current/put-pipeline-api.html`.

<!-- end-generated-description -->