### PR TITLE
Replace Cohere for AI with Cohere Labs

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -613,6 +613,9 @@ redirects:
   - source: /docs/rerank-2
     destination: /docs/rerank
     permanent: true
+  - source: /docs/c4ai-acceptable-use-policy
+    destination: /docs/cohere-labs-acceptable-use-policy
+    permanent: true
 
 analytics:
   segment:

--- a/fern/pages/changelog/2025-03-04-aya-vision-is-here.mdx
+++ b/fern/pages/changelog/2025-03-04-aya-vision-is-here.mdx
@@ -7,7 +7,7 @@ description: >-
   Release announcement for the new multimodal Aya Vision model 
 ---
 
-Today, Cohere For AI, Cohere’s research arm, is proud to announce [Aya Vision](https://cohere.com/blog/aya-vision), a state-of-the-art multimodal large language model excelling across multiple languages and modalities. Aya Vision outperforms the leading open-weight models in critical benchmarks for language, text, and image capabilities. 
+Today, Cohere Labs, Cohere’s research arm, is proud to announce [Aya Vision](https://cohere.com/blog/aya-vision), a state-of-the-art multimodal large language model excelling across multiple languages and modalities. Aya Vision outperforms the leading open-weight models in critical benchmarks for language, text, and image capabilities. 
 
 built as a foundation for multilingual and multimodal communication, this groundbreaking AI model supports tasks such as image captioning, visual question answering, text generation, and translations from both texts and images into coherent text.
 

--- a/fern/pages/cohere-for-ai/c4ai-acceptable-use-policy.mdx
+++ b/fern/pages/cohere-for-ai/c4ai-acceptable-use-policy.mdx
@@ -1,5 +1,5 @@
 ---
-title: Cohere For AI Acceptable Use Policy
+title: Cohere Labs Acceptable Use Policy
 slug: docs/c4ai-acceptable-use-policy
 hidden: false
 description: >-

--- a/fern/pages/cohere-labs/cohere-labs-acceptable-use-policy.mdx
+++ b/fern/pages/cohere-labs/cohere-labs-acceptable-use-policy.mdx
@@ -1,6 +1,6 @@
 ---
 title: Cohere Labs Acceptable Use Policy
-slug: docs/c4ai-acceptable-use-policy
+slug: docs/cohere-labs-acceptable-use-policy
 hidden: false
 description: >-
   "Promoting safe and ethical use of generative AI with guidelines to prevent

--- a/fern/pages/cookbooks/aya_vision_intro.mdx
+++ b/fern/pages/cookbooks/aya_vision_intro.mdx
@@ -4,7 +4,7 @@ slug: /page/aya-vision-intro
 
 description: "In this notebook, we will explore the capabilities of Aya Vision, which can take text and image inputs to generates text responses."
 image: "../../assets/images/f1cc130-cohere_meta_image.jpg"  
-keywords: "Aya, Cohere for AI, multimodal model, multilingual model"
+keywords: "Aya, Cohere Labs, multimodal model, multilingual model"
 ---
 import { CookbookHeader } from "../../components/cookbook-header";
 

--- a/fern/pages/llm-university/intro-text-generation/introduction-to-text-generation.mdx
+++ b/fern/pages/llm-university/intro-text-generation/introduction-to-text-generation.mdx
@@ -27,7 +27,7 @@ Here are some key features of Command R:
 - **Low latency and high throughput**: Command R targets the “scalable” category of models that balance high performance with strong accuracy, enabling companies to move beyond proof of concept and into production.
 - **128k context length and lower pricing**: Command R features a longer context length, supporting up to 128k tokens in its initial release.
 - **Strong capabilities across 10 key languages**: The model excels at 10 major languages for global business: English, French, Spanish, Italian, German, Portuguese, Japanese, Korean, Arabic, and Chinese.
-- **Model weights available for research and evaluation**: [Cohere For AI](https://cohere.com/research) is releasing the weights for this version of [Command R publicly](https://huggingface.co/CohereForAI/c4ai-command-r-v01), so that it can be used for research purposes.
+- **Model weights available for research and evaluation**: [Cohere Labs](https://cohere.com/research) is releasing the weights for this version of [Command R publicly](https://huggingface.co/CohereForAI/c4ai-command-r-v01), so that it can be used for research purposes.
 
 ## How an LLM Chatbot Works
 

--- a/fern/pages/llm-university/intro-the-cohere-platform/foundation-models.mdx
+++ b/fern/pages/llm-university/intro-the-cohere-platform/foundation-models.mdx
@@ -36,7 +36,7 @@ Here are some key features of Command-R:
 - Low latency and high throughput: Command-R targets the “scalable” category of models that balance high performance with strong accuracy, enabling companies to move beyond proof of concept and into production.
 - 128k context length and lower pricing: Command-R features a longer context length, supporting up to 128k tokens in its initial release.
 - Strong capabilities across 10 key languages: The model excels at 10 major languages for global business: English, French, Spanish, Italian, German, Portuguese, Japanese, Korean, Arabic, and Chinese.
-- Model weights available for research and evaluation: [Cohere For AI](https://cohere.com/research) is releasing the weights for this version of [Command-R publicly](https://huggingface.co/CohereForAI/c4ai-command-r-v01), so that it can be used for research purposes.
+- Model weights available for research and evaluation: [Cohere Labs](https://cohere.com/research) is releasing the weights for this version of [Command-R publicly](https://huggingface.co/CohereForAI/c4ai-command-r-v01), so that it can be used for research purposes.
 
 #### Command-light
 

--- a/fern/pages/models/aya-expanse.mdx
+++ b/fern/pages/models/aya-expanse.mdx
@@ -3,7 +3,7 @@ title: Aya Expanse
 slug: "docs/aya-expanse"
 hidden: false
 description: >-
-  Understand Cohere for AI's highly performant multilingual Aya models, which aim to bring many more languages into generative AI.
+  Understand Cohere Labs highly performant multilingual Aya models, which aim to bring many more languages into generative AI.
 image: ../../assets/images/6c1b0e4-cohere_meta_image.jpg
 keywords: 'Cohere AI, multilingual large language models, generative AI'
 createdAt: 'Thu Nov 21 2024 14:18:00 MST (U.S. Mountain Time)'
@@ -71,7 +71,7 @@ Al final de su aventura, María se sintió feliz y orgullosa de haber descubiert
 Espero que esta historia te sea útil para ilustrar vocabulario sencillo en español. ¡Puedes adaptar y expandir la trama según tus necesidades!
 ```
 
-Finally, you can directly download the raw models for research purposes because Cohere For AI has released [Aya Expanse 8B](https://huggingface.co/CohereForAI/aya-expanse-8b) and [Aya Expanse 32B](https://huggingface.co/CohereForAI/aya-expanse-32b) as open-weight models, through HuggingFace. What’s more, the massively multilingual instruction data used for development of these models has been [made available](https://huggingface.co/datasets/CohereForAI/aya_collection) for download as well.
+Finally, you can directly download the raw models for research purposes because Cohere Labs has released [Aya Expanse 8B](https://huggingface.co/CohereForAI/aya-expanse-8b) and [Aya Expanse 32B](https://huggingface.co/CohereForAI/aya-expanse-32b) as open-weight models, through HuggingFace. What’s more, the massively multilingual instruction data used for development of these models has been [made available](https://huggingface.co/datasets/CohereForAI/aya_collection) for download as well.
 
 ### Aya Expanse Integration with WhatsApp
 
@@ -96,7 +96,7 @@ Aya Expanse is a multilingual language model capable of conversing in 23 languag
 Yes, you can send the “/clear” command to the model via WhatsApp to clear the context of your previous chat with the model and start a fresh conversation with Aya Expanse.
 
 #### How do I Know It's Really Aya Expanse I'm Talking to?
-If you follow the link provided above and see the "Aya Expanse by Cohere for AI" banner at the top, it's Aya.
+If you follow the link provided above and see the "Aya Expanse by Cohere Labs" banner at the top, it's Aya.
 
 #### What Should I do if the Model Becomes Unresponsive?
 Aya Expanse should be accessible via Whatsapp at all times. Sometimes, a simple app refresh can resolve any temporary glitches. If the problem persists, we encourage you to report the issue on the [Cohere Discord server](https://discord.com/invite/co-mmunity).

--- a/fern/pages/models/aya-multimodal.mdx
+++ b/fern/pages/models/aya-multimodal.mdx
@@ -3,7 +3,7 @@ title: Aya Vision
 slug: "docs/aya-vision"
 hidden: false
 description: >-
-  Understand Cohere for AI's groundbreaking multilingual model Aya Vision, a state-of-the-art multimodal language model excelling at multiple tasks.
+  Understand Cohere Labs groundbreaking multilingual model Aya Vision, a state-of-the-art multimodal language model excelling at multiple tasks.
 image: ../../assets/images/6c1b0e4-cohere_meta_image.jpg
 keywords: 'Cohere AI, multilingual large language models, generative AI'
 createdAt: 'Wed Feb 26 2025 11:55:00 MST (U.S. Mountain Time)'
@@ -99,7 +99,7 @@ The wall in this room showcases a collection of musical instruments and related 
    - A small table lamp with a warm-toned shade.
 ```
 
-Finally, you can directly download the raw models for research purposes because Cohere For AI has released Aya Vision as open-weight models, through HuggingFace. We also released a new valuable evaluation set -- [Aya Vision Benchmark](https://huggingface.co/datasets/CohereForAI/AyaVisionBench) -- to measure progress on multilingual models here. 
+Finally, you can directly download the raw models for research purposes because Cohere Labs has released Aya Vision as open-weight models, through HuggingFace. We also released a new valuable evaluation set -- [Aya Vision Benchmark](https://huggingface.co/datasets/CohereForAI/AyaVisionBench) -- to measure progress on multilingual models here. 
 
 ### Aya Expanse Integration with WhatsApp.
 

--- a/fern/pages/models/aya.mdx
+++ b/fern/pages/models/aya.mdx
@@ -3,7 +3,7 @@ title: Aya Family of Models
 slug: "docs/aya"
 hidden: false
 description: >-
-  Understand Cohere for AI's groundbreaking multilingual Aya models, which aim to bring many more languages into generative AI.
+  Understand Cohere Labs groundbreaking multilingual Aya models, which aim to bring many more languages into generative AI.
 image: ../../assets/images/6c1b0e4-cohere_meta_image.jpg
 keywords: 'Cohere AI, multilingual large language models, generative AI'
 createdAt: 'Thu Nov 21 2024 14:18:00 MST (U.S. Mountain Time)'

--- a/fern/v1.yml
+++ b/fern/v1.yml
@@ -327,9 +327,9 @@ navigation:
             path: pages/responsible-use/responsible-use/usage-guidelines.mdx 
           - page: Command R and Command R+ Model Card
             path: pages/responsible-use/responsible-use.mdx                      
-      - section: Cohere for AI
+      - section: Cohere Labs
         contents:
-          - page: Cohere For AI Acceptable Use Policy
+          - page: Cohere Labs Acceptable Use Policy
             path: pages/cohere-for-ai/c4ai-acceptable-use-policy.mdx
       - section: More Resources
         contents:

--- a/fern/v1.yml
+++ b/fern/v1.yml
@@ -330,7 +330,7 @@ navigation:
       - section: Cohere Labs
         contents:
           - page: Cohere Labs Acceptable Use Policy
-            path: pages/cohere-for-ai/c4ai-acceptable-use-policy.mdx
+            path: pages/cohere-labs/cohere-labs-acceptable-use-policy.mdx
       - section: More Resources
         contents:
           - page: Cohere Toolkit

--- a/fern/v2.yml
+++ b/fern/v2.yml
@@ -353,7 +353,7 @@ navigation:
       - section: Cohere Labs
         contents:
           - page: Cohere Labs Acceptable Use Policy
-            path: pages/cohere-for-ai/c4ai-acceptable-use-policy.mdx
+            path: pages/labs/cohere-labs-acceptable-use-policy.mdx
       - section: More Resources
         contents:
           - page: Cohere Toolkit

--- a/fern/v2.yml
+++ b/fern/v2.yml
@@ -353,7 +353,7 @@ navigation:
       - section: Cohere Labs
         contents:
           - page: Cohere Labs Acceptable Use Policy
-            path: pages/labs/cohere-labs-acceptable-use-policy.mdx
+            path: pages/cohere-labs/cohere-labs-acceptable-use-policy.mdx
       - section: More Resources
         contents:
           - page: Cohere Toolkit

--- a/fern/v2.yml
+++ b/fern/v2.yml
@@ -350,9 +350,9 @@ navigation:
             path: pages/responsible-use/responsible-use/usage-guidelines.mdx
           - page: Command R and Command R+ Model Card
             path: pages/responsible-use/responsible-use.mdx   
-      - section: Cohere for AI
+      - section: Cohere Labs
         contents:
-          - page: Cohere For AI Acceptable Use Policy
+          - page: Cohere Labs Acceptable Use Policy
             path: pages/cohere-for-ai/c4ai-acceptable-use-policy.mdx
       - section: More Resources
         contents:


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the name of Cohere's research arm from 'Cohere For AI' to 'Cohere Labs' across the following files:

- fern/pages/changelog/2025-03-04-aya-vision-is-here.mdx
- fern/pages/cohere-for-ai/c4ai-acceptable-use-policy.mdx
- fern/pages/cookbooks/aya_vision_intro.mdx
- fern/pages/llm-university/intro-text-generation/introduction-to-text-generation.mdx
- fern/pages/llm-university/intro-the-cohere-platform/foundation-models.mdx
- fern/pages/models/aya-expanse.mdx
- fern/pages/models/aya-multimodal.mdx
- fern/pages/models/aya.mdx
- fern/v1.yml
- fern/v2.yml

<!-- end-generated-description -->