### PR TITLE
Fix urls for notebook and file path

### DIFF
--- a/fern/pages/text-embeddings/semantic-search-embed.mdx
+++ b/fern/pages/text-embeddings/semantic-search-embed.mdx
@@ -298,7 +298,7 @@ import cohere
 Next, turn a PDF file into a list of images, with one image per page. Then format these images into the content structure expected by the Embed endpoint.
 
 ```python PYTHON
-pdf_path = "PDF_FILE_PATH" # https://github.com/cohere-ai/cohere-developer-experience/raw/main/notebooks/guide/embed-v4-pdf-search/data/Samsung_Home_Theatre_HW-N950_ZA_FullManual_02_ENG_180809_2.pdf
+pdf_path = "PDF_FILE_PATH"  # https://github.com/cohere-ai/cohere-developer-experience/raw/main/notebooks/guide/embed-v4-pdf-search/data/Samsung_Home_Theatre_HW-N950_ZA_FullManual_02_ENG_180809_2.pdf
 pages = convert_from_path(pdf_path, dpi=200)
 
 input_array = []

--- a/fern/pages/text-embeddings/semantic-search-embed.mdx
+++ b/fern/pages/text-embeddings/semantic-search-embed.mdx
@@ -298,7 +298,7 @@ import cohere
 Next, turn a PDF file into a list of images, with one image per page. Then format these images into the content structure expected by the Embed endpoint.
 
 ```python PYTHON
-pdf_path = "https://github.com/cohere-ai/cohere-developer-experience/raw/main/notebooks/guide/embed-v4-pdf-search/data/Samsung_Home_Theatre_HW-N950_ZA_FullManual_02_ENG_180809_2.pdf"
+pdf_path = "PDF_FILE_PATH" # https://github.com/cohere-ai/cohere-developer-experience/raw/main/notebooks/guide/embed-v4-pdf-search/data/Samsung_Home_Theatre_HW-N950_ZA_FullManual_02_ENG_180809_2.pdf
 pages = convert_from_path(pdf_path, dpi=200)
 
 input_array = []
@@ -373,5 +373,5 @@ The top-ranked page is shown below:
 <img src='../../assets/images/multimodal-pdf-search-example-1.png' />
 
 <Note>
-For a more complete example of multimodal PDF search, see [the cookbook version](https://github.com/cohere-ai/cohere-developer-experience/tree/main/notebooks/guides/embed-v4-pdf-search).
+For a more complete example of multimodal PDF search, see [the cookbook version](https://github.com/cohere-ai/cohere-developer-experience/blob/main/notebooks/guides/embed-v4-pdf-search/embed-v4-pdf-search.ipynb).
 </Note>

--- a/fern/pages/v2/text-embeddings/semantic-search-embed.mdx
+++ b/fern/pages/v2/text-embeddings/semantic-search-embed.mdx
@@ -301,7 +301,7 @@ import cohere
 Next, turn a PDF file into a list of images, with one image per page. Then format these images into the content structure expected by the Embed endpoint.
 
 ```python PYTHON
-pdf_path = "https://github.com/cohere-ai/cohere-developer-experience/raw/main/notebooks/guide/embed-v4-pdf-search/data/Samsung_Home_Theatre_HW-N950_ZA_FullManual_02_ENG_180809_2.pdf"
+pdf_path = "PDF_FILE_PATH" # https://github.com/cohere-ai/cohere-developer-experience/raw/main/notebooks/guide/embed-v4-pdf-search/data/Samsung_Home_Theatre_HW-N950_ZA_FullManual_02_ENG_180809_2.pdf
 pages = convert_from_path(pdf_path, dpi=200)
 
 input_array = []
@@ -376,5 +376,5 @@ The top-ranked page is shown below:
 <img src='../../../assets/images/multimodal-pdf-search-example-1.png' />
 
 <Note>
-For a more complete example of multimodal PDF search, see [the cookbook version](https://github.com/cohere-ai/cohere-developer-experience/tree/main/notebooks/guides/embed-v4-pdf-search).
+For a more complete example of multimodal PDF search, see [the cookbook version](https://github.com/cohere-ai/cohere-developer-experience/blob/main/notebooks/guides/embed-v4-pdf-search/embed-v4-pdf-search.ipynb).
 </Note>

--- a/fern/pages/v2/text-embeddings/semantic-search-embed.mdx
+++ b/fern/pages/v2/text-embeddings/semantic-search-embed.mdx
@@ -301,7 +301,7 @@ import cohere
 Next, turn a PDF file into a list of images, with one image per page. Then format these images into the content structure expected by the Embed endpoint.
 
 ```python PYTHON
-pdf_path = "PDF_FILE_PATH" # https://github.com/cohere-ai/cohere-developer-experience/raw/main/notebooks/guide/embed-v4-pdf-search/data/Samsung_Home_Theatre_HW-N950_ZA_FullManual_02_ENG_180809_2.pdf
+pdf_path = "PDF_FILE_PATH"  # https://github.com/cohere-ai/cohere-developer-experience/raw/main/notebooks/guide/embed-v4-pdf-search/data/Samsung_Home_Theatre_HW-N950_ZA_FullManual_02_ENG_180809_2.pdf
 pages = convert_from_path(pdf_path, dpi=200)
 
 input_array = []


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the `pdf_path` variable in the Python code and the link to the cookbook version of the multimodal PDF search example.

- The `pdf_path` variable is updated to `"PDF_FILE_PATH"` and the original path is added as a comment.
- The link to the cookbook version of the multimodal PDF search example is updated to point to the `embed-v4-pdf-search.ipynb` file.

<!-- end-generated-description -->