### PR TITLE
Fix embed-4 url

### DIFF
--- a/fern/pages/changelog/2025-04-15-embed-multimodal-v4.mdx
+++ b/fern/pages/changelog/2025-04-15-embed-multimodal-v4.mdx
@@ -21,4 +21,4 @@ Embed v4 achieves state of the art in the following areas:
 2. Text-to-image retrieval 
 3. Text-to-mixed modality retrieval (from e.g. PDFs) 
 
-Embed v4 is available today on the [Cohere Platform](https://docs.cohere.com/docs/the-cohere-platform), AWS Sagemaker, and Azure AI Foundry. For more information, check out our dedicated blog post [here](cohere.com/blog/embed-4).
+Embed v4 is available today on the [Cohere Platform](https://docs.cohere.com/docs/the-cohere-platform), AWS Sagemaker, and Azure AI Foundry. For more information, check out our dedicated blog post [here](https://cohere.com/blog/embed-4).


### PR DESCRIPTION
At the moment embed-4 url redirects people to `https://docs.cohere.com/cohere.com/blog/embed-4`