### PR TITLE
Three fast follows.

### DIFF
--- a/fern/pages/changelog/2025-04-15-embed-multimodal-v4.mdx
+++ b/fern/pages/changelog/2025-04-15-embed-multimodal-v4.mdx
@@ -21,4 +21,4 @@ Embed v4 achieves state of the art in the following areas:
 2. Text-to-image retrieval 
 3. Text-to-mixed modality retrieval (from e.g. PDFs) 
 
-Embed v4 is available today on the [Cohere Platform](https://docs.cohere.com/docs/the-cohere-platform), AWS Sagemaker, and Azure AI Foundry. For more information, check out our dedicated blog post [here](https://cohere.com/blog/embed-4).
+Embed v4 is available today on the [Cohere Platform](https://docs.cohere.com/docs/the-cohere-platform), [AWS Sagemaker](https://docs.cohere.com/docs/amazon-sagemaker-setup-guide#embeddings), and [Azure AI Foundry](https://docs.cohere.com/docs/cohere-on-microsoft-azure#embeddings). For more information, check out our dedicated blog post [here](https://cohere.com/blog/embed-4).

--- a/fern/pages/get-started/frequently-asked-questions.mdx
+++ b/fern/pages/get-started/frequently-asked-questions.mdx
@@ -107,7 +107,7 @@ While this depends on the document structure itself, the best rule of thumb woul
 
 From there, you should associate each chunk to a page and a doc id which will allow you to have various levels of granularity for retrieval.
 
-You can find further guides on [chunking strategies](https://docs.cohere.com/page/chunking-strategies) and [handling PDFs with mixed data](https://docs.cohere.com/page/agentic-rag-mixed-data).
+You can find further guides on [chunking strategies](https://docs.cohere.com/page/chunking-strategies) and [handling PDFs with mixed data](https://docs.cohere.com/docs/semantic-search-embed#multimodal-pdf-search).
 
 </Accordion>
 

--- a/fern/pages/models/models.mdx
+++ b/fern/pages/models/models.mdx
@@ -85,7 +85,7 @@ In this table, we provide some important context for using Cohere Embed models o
 
 | Model Name                      | Amazon Bedrock Model ID        | Amazon SageMaker      | Azure AI Foundry         | Oracle OCI Generative AI Service       |
 | :------------------------------ | :----------------------------- | :-------------------- | :----------------------- | :------------------------------------- |
-| `embed-v4.0`                    | (Coming Soon)                  | Unique per deployment | (Coming Soon)            | (Coming Soon)                          |
+| `embed-v4.0`                    | (Coming Soon)                  | Unique per deployment | `cohere-embed-v-4-plan`  | (Coming Soon)                          |
 | `embed-english-v3.0`            | `cohere.embed-english-v3`      | Unique per deployment | Unique per deployment    | `cohere.embed-english-v3.0`            |
 | `embed-english-light-v3.0`      | N/A                            | N/A                   | N/A                      | `cohere.embed-english-light-v3.0`      |
 | `embed-multilingual-v3.0`       | `cohere.embed-multilingual-v3` | Unique per deployment | Unique per deployment    | `cohere.embed-multilingual-v3.0`       |


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the documentation with new links and information about the availability of Embed v4.

**Summary of Changes:**

- **Updated Links for Embed v4 Availability:**
  - The links for AWS Sagemaker and Azure AI Foundry have been updated to point to their respective setup guides.
- **Updated Link for Handling PDFs with Mixed Data:**
  - The link for handling PDFs with mixed data has been updated to point to the semantic search embed documentation.
- **Added Azure AI Foundry Model ID for Embed v4:**
  - The Azure AI Foundry model ID for `embed-v4.0` has been added as `cohere-embed-v-4-plan`.

These changes ensure that the documentation is up-to-date and provides accurate information about the availability and usage of Embed v4.

<!-- end-generated-description -->