### PR TITLE
Add pydantic ai for retrieval cookbook

### DIFF
--- a/fern/pages/cookbooks.mdx
+++ b/fern/pages/cookbooks.mdx
@@ -303,6 +303,14 @@ export const searchCards = [
     tags: ["search"],
     href: "/page/rag-cohere-mongodb",
   },
+  {
+    title: "Retrieval Evaluation with LLM-as-a-Judge via Pydantic AI",
+    description:
+      "Evaluate retrieval systems using LLMs as judges via Pydantic AI.",
+    imageSrc: "https://fern-image-hosting.s3.amazonaws.com/cohere/28ee583-Community_Demo_4.png",
+    tags: ["search"],
+    href: "/page/retrieval-eval-pydantic-ai",
+  },
 ];
 
 export const cloudCards = [

--- a/fern/pages/cookbooks/retrieval-eval-pydantic-ai.mdx
+++ b/fern/pages/cookbooks/retrieval-eval-pydantic-ai.mdx
@@ -1,0 +1,396 @@
+---
+title: Retrieval evaluation using LLM-as-a-judge via Pydantic AI
+slug: /page/retrieval-eval-pydantic-ai
+
+description: "This page contains a tutorial on how to evaluate retrieval systems using LLMs as judges via Pydantic AI."
+image: "../../assets/images/f1cc130-cohere_meta_image.jpg"  
+keywords: "Cohere, retrieval evaluation, LLM-as-a-judge, Pydantic AI"
+---
+import { CookbookHeader } from "../../components/cookbook-header";
+
+<CookbookHeader href="https://github.com/cohere-ai/cohere-developer-experience/blob/main/notebooks/guides/retrieval_eval_pydantic_ai.ipynb" />
+
+# Retrieval evaluation using LLM-as-a-judge via Pydantic AI
+
+We'll explore how to evaluate retrieval systems using Large Language Models (LLMs) as judges.Retrieval evaluation is a critical component in building high-quality information retrieval systems, and recent advancements in LLMs have made it possible to automate this evaluation process.
+
+#### What we'll cover
+
+- How to query the Wikipedia API
+- How to implement and compare two different retrieval approaches:
+  - The original search results from the Wikipedia API
+  - Using Cohere's reranking model to rerank the search results
+- How to set up an LLM-as-a-judge evaluation framework using Pydantic AI
+
+#### Tools We'll Use
+
+- **Cohere's API**: For reranking search results and providing evaluation models
+- **Wikipedia's API**: As our information source
+- **Pydantic AI**: For creating evaluation agents
+
+This tutorial demonstrates a methodology for comparing different retrieval systems objectively. By the end, you'll have an example you can adapt to evaluate your own retrieval systems across different domains and use cases.
+
+## Setup
+
+First, let's import the necessary libraries.
+
+```python PYTHON
+%pip install -U cohere pydantic-ai
+```
+
+```python PYTHON
+import requests
+import cohere
+import pandas as pd
+from pydantic_ai import Agent
+from pydantic_ai.models import KnownModelName
+from collections import Counter
+
+import os
+co = cohere.ClientV2(os.getenv("COHERE_API_KEY"))
+```
+
+
+```python PYTHON
+import nest_asyncio
+nest_asyncio.apply()
+```
+
+## Perform Wikipedia search
+
+Next, we implement a function to query Wikipedia for relevant information based on user input. The `search_wikipedia()` function allows us to retrieve a specified number of Wikipedia search results, extracting their titles, snippets, and page IDs.
+
+This will provide us with the dataset for our retrieval evaluation experiment, where we'll compare different approaches to finding and ranking relevant information.
+
+We'll use a small dataset of 10 questions about geography to test the Wikipedia search.
+
+
+```python PYTHON
+import requests
+
+def search_wikipedia(query, limit=10):
+    url = "https://en.wikipedia.org/w/api.php"
+    params = {
+        'action': 'query',
+        'list': 'search',
+        'srsearch': query,
+        'format': 'json',
+        'srlimit': limit
+    }
+
+    response = requests.get(url, params=params)
+    data = response.json()
+    
+    # Format the results
+    results = []
+    for item in data['query']['search']:
+        results.append({
+            "title": item["title"],
+            "snippet": item["snippet"].replace("<span class=\"searchmatch\">", "").replace("</span>", ""),
+        })
+            
+    return results
+```
+
+
+```python PYTHON
+# Generate 10 questions about geography to test the Wikipedia search
+geography_questions = [
+    "What is the capital of France?",
+    "What is the longest river in the world?",
+    "What is the largest desert in the world?",
+    "What is the highest mountain peak on Earth?",
+    "What are the major tectonic plates?",
+    "What is the Ring of Fire?",
+    "What is the largest ocean on Earth?",
+    "What are the Seven Wonders of the Natural World?",
+    "What causes the Northern Lights?",
+    "What is the Great Barrier Reef?"
+]
+```
+
+
+```python PYTHON
+# Run search_wikipedia for each question
+results = []
+
+for question in geography_questions:
+    question_results = search_wikipedia(question, limit=10)
+    
+    # Format the results as requested
+    formatted_results = []
+    for item in question_results:
+        formatted_result = f"{item['title']}\n{item['snippet']}"
+        formatted_results.append(formatted_result)
+    
+    # Add to the results list
+    results.append({
+        "question": question,
+        "search_results": formatted_results
+    })
+```
+
+## Rerank the search results and filter the top_n results ("Engine A")
+
+In this section, we'll implement our first retrieval approach using Cohere's reranking model. Reranking is a technique that takes an initial set of search results and reorders them based on their relevance to the original query.
+
+We'll use Cohere's `rerank` API to:
+1. Take the Wikipedia search results we obtained earlier
+2. Send them to Cohere's reranking model along with the original query
+3. Filter to keep only the top-n most relevant results
+
+This approach will be referred to as "Engine A" in our evaluation, and we'll compare its performance against the original Wikipedia search rankings.
+
+
+```python PYTHON
+# Rerank the search results for each question
+top_n = 3
+results_reranked_top_n = []
+
+for item in results:
+    question = item["question"]
+    documents = item["search_results"]
+    
+    # Rerank the documents using Cohere
+    reranked = co.rerank(
+        model="rerank-v3.5",
+        query=question,
+        documents=documents,
+        top_n=top_n  # Get top 3 results
+    )
+    
+    # Format the reranked results
+    top_results = []
+    for result in reranked.results:
+        top_results.append(documents[result.index])
+    
+    # Add to the reranked results list
+    results_reranked_top_n.append({
+        "question": question,
+        "search_results": top_results
+    })
+
+# Print a sample of the reranked results
+print(f"Original question: {results_reranked_top_n[0]['question']}")
+print(f"Top 3 reranked results:")
+for i, result in enumerate(results_reranked_top_n[0]['search_results']):
+    print(f"\n{i+1}. {result}")
+
+```
+```
+Original question: What is the capital of France?
+Top 3 reranked results:
+
+1. France
+semi-presidential republic and its capital, largest city and main cultural and economic centre is Paris. Metropolitan France was settled during the Iron Age by Celtic
+
+2. Closed-ended question
+variants of the above closed-ended questions that possess specific responses are: On what day were you born? (&quot;Saturday.&quot;) What is the capital of France? (&quot;Paris
+
+3. Capital city
+seat of the government. A capital is typically a city that physically encompasses the government&#039;s offices and meeting places; the status as capital is often
+```
+
+## Take the original search results and filter the top_n results ("Engine B")
+
+In this section, we'll implement our second retrieval approach as a baseline comparison. For "Engine B", we'll simply take the original Wikipedia search results without any reranking and select the top-n results.
+
+This approach reflects how many traditional search engines work - returning results based on their original relevance score from the data source. By comparing this baseline against our reranked approach (Engine A), we can evaluate whether reranking provides meaningful improvements in result quality.
+
+We'll use the same number of results (top_n) as Engine A to ensure a fair comparison in our evaluation.
+
+
+```python PYTHON
+results_top_n = []
+
+for item in results:
+    results_top_n.append({
+        "question": item["question"],
+        "search_results": item["search_results"][:top_n]
+    })
+    
+# Print a sample of the top_n results (without reranking)
+print(f"Original question: {results_top_n[0]['question']}")
+print(f"Top {top_n} results (without reranking):")
+for i, result in enumerate(results_top_n[0]['search_results']):
+    print(f"\n{i+1}. {result}")
+```
+```
+Original question: What is the capital of France?
+Top 3 results (without reranking):
+
+1. Closed-ended question
+variants of the above closed-ended questions that possess specific responses are: On what day were you born? (&quot;Saturday.&quot;) What is the capital of France? (&quot;Paris
+
+2. France
+semi-presidential republic and its capital, largest city and main cultural and economic centre is Paris. Metropolitan France was settled during the Iron Age by Celtic
+
+3. What Is a Nation?
+&quot;What Is a Nation?&quot; (French: Qu&#039;est-ce qu&#039;une nation ?) is an 1882 lecture by French historian Ernest Renan (1823–1892) at the Sorbonne, known for the
+```
+
+## Run LLM-as-a-judge evaluation to compare the two engines
+
+Now we'll implement an evaluation framework using LLMs as judges to compare our two retrieval approaches:
+- Engine A: Wikipedia results reranked by Cohere's reranking model
+- Engine B: Original Wikipedia search results
+
+Using LLMs as evaluators allows us to programmatically assess the quality of search results without human annotation. The following code implements the following steps:
+
+- Setting up the evaluation protocol
+  - First, define a clear protocol for how the LLM judges will evaluate the search results. This includes creating a system prompt and a template for each evaluation.
+- Using multiple models as independent judges
+  - To get more robust results, use multiple LLM models as independent judges. This reduces bias from any single model.
+- Implementing a majority voting system
+  - Combine judgments from multiple models using a majority voting system to determine which engine performed better for each query:
+- Presenting the results
+  - After evaluating all queries, present the results to determine which retrieval approach performed better overall.
+
+This approach provides a scalable, reproducible method to evaluate and compare retrieval systems quantitatively.
+
+
+```python PYTHON
+# System prompt for the AI evaluator
+SYSTEM_PROMPT = """
+You are an AI search evaluator. You will compare search results from two engines and
+determine which set provides more relevant and diverse information. You will only
+answer with the verdict rather than explaining your reasoning; simply say "Engine A" or
+"Engine B".
+"""
+
+# Prompt template for each evaluation
+PROMPT_TEMPLATE = """
+For the following question, which search engine provides more relevant results?
+
+## Question:
+{query}
+
+## Engine A:
+{engine_a_results}
+
+## Engine B:
+{engine_b_results}
+"""
+
+def format_results(results):
+    """Format search results in a readable way"""
+    formatted = []
+    for i, result in enumerate(results):
+        formatted.append(f"Result {i+1}: {result[:200]}...")
+    return "\n\n".join(formatted)
+
+def judge_query(query, engine_a_results, engine_b_results, model_name):
+    """Use a single model to judge which engine has better results"""
+    agent = Agent(model_name, system_prompt=SYSTEM_PROMPT)
+    
+    # Format the results
+    engine_a_formatted = format_results(engine_a_results)
+    engine_b_formatted = format_results(engine_b_results)
+    
+    # Create the prompt
+    prompt = PROMPT_TEMPLATE.format(
+        query=query,
+        engine_a_results=engine_a_formatted,
+        engine_b_results=engine_b_formatted
+    )
+    
+    # Get the model's judgment
+    response = agent.run_sync(prompt)
+    return response.data
+
+def evaluate_search_results(reranked_results, regular_results, models):
+    """
+    Evaluate both sets of search results using multiple models.
+    
+    Args:
+        reranked_results: List of dictionaries with 'question' and 'search_results'
+        regular_results: List of dictionaries with 'question' and 'search_results'
+        models: List of model names to use as judges
+    
+    Returns:
+        DataFrame with evaluation results
+    """
+    # Prepare data structure for results
+    evaluation_results = []
+    
+    # Evaluate each query
+    for i in range(len(reranked_results)):
+        query = reranked_results[i]['question']
+        engine_a_results = reranked_results[i]['search_results']  # Reranked results
+        engine_b_results = regular_results[i]['search_results']   # Regular results
+        
+        # Get judgments from each model
+        judgments = []
+        for model in models:
+            judgment = judge_query(query, engine_a_results, engine_b_results, model)
+            judgments.append(judgment)
+        
+        # Determine winner by majority vote
+        votes = Counter(judgments)
+        if votes["Engine A"] > votes["Engine B"]:
+            winner = "Engine A"
+        elif votes["Engine B"] > votes["Engine A"]:
+            winner = "Engine B"
+        else:
+            winner = "Tie"
+        
+        # Add results for this query
+        row = [query] + judgments + [winner]
+        evaluation_results.append(row)
+    
+    # Create DataFrame
+    column_names = ["question"] + [f"judge_{i+1} ({model})" for i, model in enumerate(models)] + ["winner"]
+    df = pd.DataFrame(evaluation_results, columns=column_names)
+    
+    return df
+```
+
+
+```python PYTHON
+# Define the search engines
+engine_a = results_reranked_top_n
+engine_b = results_top_n
+
+# Define the models to use as judges
+models = [
+    "cohere:command-a-03-2025",
+    "cohere:command-r-plus-08-2024",
+    "cohere:command-r-08-2024",
+    "cohere:c4ai-aya-expanse-32b",
+    "cohere:c4ai-aya-expanse-8b",
+]
+
+# Get evaluation results
+results_df = evaluate_search_results(engine_a, engine_b, models)
+
+# Calculate overall statistics
+winner_counts = Counter(results_df["winner"])
+total_queries = len(results_df)
+
+# Display summary of results
+print("\nPercentage of questions won by each engine:")
+for engine, count in winner_counts.items():
+    percentage = (count / total_queries) * 100
+    print(f"{engine}: {percentage:.2f}% ({count}/{total_queries})")
+    
+# Display dataframe
+results_df.head()
+
+# Save to CSV
+results_csv = results_df.to_csv("search_results_evaluation.csv", index=False)
+```
+```
+
+Percentage of questions won by each engine:
+Engine A: 80.00% (8/10)
+Tie: 10.00% (1/10)
+Engine B: 10.00% (1/10)
+```
+
+## Conclusion
+
+This tutorial demonstrates how to evaluate retrieval systems using LLMs as judges through Pydantic AI, comparing original Wikipedia search results against those reranked by Cohere's reranking model. 
+
+The evaluation framework uses multiple Cohere models as independent judges with majority voting to determine which system provides more relevant results. 
+
+Results showed the reranked approach (Engine A) outperformed the original search rankings (Engine B) by winning 80% of queries, demonstrating the effectiveness of neural reranking in improving search relevance.

--- a/fern/pages/cookbooks/retrieval-eval-pydantic-ai.mdx
+++ b/fern/pages/cookbooks/retrieval-eval-pydantic-ai.mdx
@@ -10,11 +10,10 @@ import { CookbookHeader } from "../../components/cookbook-header";
 
 <CookbookHeader href="https://github.com/cohere-ai/cohere-developer-experience/blob/main/notebooks/guides/retrieval_eval_pydantic_ai.ipynb" />
 
-# Retrieval evaluation using LLM-as-a-judge via Pydantic AI
 
 We'll explore how to evaluate retrieval systems using Large Language Models (LLMs) as judges.Retrieval evaluation is a critical component in building high-quality information retrieval systems, and recent advancements in LLMs have made it possible to automate this evaluation process.
 
-#### What we'll cover
+**What we'll cover**
 
 - How to query the Wikipedia API
 - How to implement and compare two different retrieval approaches:
@@ -22,7 +21,7 @@ We'll explore how to evaluate retrieval systems using Large Language Models (LLM
   - Using Cohere's reranking model to rerank the search results
 - How to set up an LLM-as-a-judge evaluation framework using Pydantic AI
 
-#### Tools We'll Use
+**Tools We'll Use**
 
 - **Cohere's API**: For reranking search results and providing evaluation models
 - **Wikipedia's API**: As our information source

--- a/fern/v1.yml
+++ b/fern/v1.yml
@@ -855,3 +855,5 @@ navigation:
         path: pages/cookbooks/sql-agent-cohere-langchain.mdx
       - page: Introduction to Aya Vision
         path: pages/cookbooks/aya_vision_intro.mdx
+      - page: Retrieval Evaluation with LLM-as-a-Judge via Pydantic AI
+        path: pages/cookbooks/retrieval-eval-pydantic-ai.mdx

--- a/fern/v2.yml
+++ b/fern/v2.yml
@@ -910,3 +910,5 @@ navigation:
         path: pages/cookbooks/sql-agent-cohere-langchain.mdx
       - page: Introduction to Aya Vision
         path: pages/cookbooks/aya_vision_intro.mdx
+      - page: Retrieval Evaluation with LLM-as-a-Judge via Pydantic AI
+        path: pages/cookbooks/retrieval-eval-pydantic-ai.mdx

--- a/notebooks/guides/retrieval_eval_pydantic_ai.ipynb
+++ b/notebooks/guides/retrieval_eval_pydantic_ai.ipynb
@@ -1,0 +1,530 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/cohere-ai/cohere-developer-experience/blob/main/notebooks/guides/retrieval_eval_pydantic_ai.ipynb\">\n",
+    "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
+    "</a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Retrieval evaluation using LLM-as-a-judge via Pydantic AI"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll explore how to evaluate retrieval systems using Large Language Models (LLMs) as judges.Retrieval evaluation is a critical component in building high-quality information retrieval systems, and recent advancements in LLMs have made it possible to automate this evaluation process.\n",
+    "\n",
+    "#### What we'll cover\n",
+    "\n",
+    "- How to query the Wikipedia API\n",
+    "- How to implement and compare two different retrieval approaches:\n",
+    "  - The original search results from the Wikipedia API\n",
+    "  - Using Cohere's reranking model to rerank the search results\n",
+    "- How to set up an LLM-as-a-judge evaluation framework using Pydantic AI\n",
+    "\n",
+    "#### Tools We'll Use\n",
+    "\n",
+    "- **Cohere's API**: For reranking search results and providing evaluation models\n",
+    "- **Wikipedia's API**: As our information source\n",
+    "- **Pydantic AI**: For creating evaluation agents\n",
+    "\n",
+    "This tutorial demonstrates a methodology for comparing different retrieval systems objectively. By the end, you'll have an example you can adapt to evaluate your own retrieval systems across different domains and use cases."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "First, let's import the necessary libraries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -U cohere pydantic-ai"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "import cohere\n",
+    "import pandas as pd\n",
+    "from pydantic_ai import Agent\n",
+    "from pydantic_ai.models import KnownModelName\n",
+    "from collections import Counter\n",
+    "\n",
+    "import os\n",
+    "co = cohere.ClientV2(os.getenv(\"COHERE_API_KEY\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import nest_asyncio\n",
+    "nest_asyncio.apply()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Perform Wikipedia search\n",
+    "\n",
+    "Next, we implement a function to query Wikipedia for relevant information based on user input. The `search_wikipedia()` function allows us to retrieve a specified number of Wikipedia search results, extracting their titles, snippets, and page IDs.\n",
+    "\n",
+    "This will provide us with the dataset for our retrieval evaluation experiment, where we'll compare different approaches to finding and ranking relevant information.\n",
+    "\n",
+    "We'll use a small dataset of 10 questions about geography to test the Wikipedia search."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "\n",
+    "def search_wikipedia(query, limit=10):\n",
+    "    url = \"https://en.wikipedia.org/w/api.php\"\n",
+    "    params = {\n",
+    "        'action': 'query',\n",
+    "        'list': 'search',\n",
+    "        'srsearch': query,\n",
+    "        'format': 'json',\n",
+    "        'srlimit': limit\n",
+    "    }\n",
+    "\n",
+    "    response = requests.get(url, params=params)\n",
+    "    data = response.json()\n",
+    "    \n",
+    "    # Format the results\n",
+    "    results = []\n",
+    "    for item in data['query']['search']:\n",
+    "        results.append({\n",
+    "            \"title\": item[\"title\"],\n",
+    "            \"snippet\": item[\"snippet\"].replace(\"<span class=\\\"searchmatch\\\">\", \"\").replace(\"</span>\", \"\"),\n",
+    "        })\n",
+    "            \n",
+    "    return results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generate 10 questions about geography to test the Wikipedia search\n",
+    "geography_questions = [\n",
+    "    \"What is the capital of France?\",\n",
+    "    \"What is the longest river in the world?\",\n",
+    "    \"What is the largest desert in the world?\",\n",
+    "    \"What is the highest mountain peak on Earth?\",\n",
+    "    \"What are the major tectonic plates?\",\n",
+    "    \"What is the Ring of Fire?\",\n",
+    "    \"What is the largest ocean on Earth?\",\n",
+    "    \"What are the Seven Wonders of the Natural World?\",\n",
+    "    \"What causes the Northern Lights?\",\n",
+    "    \"What is the Great Barrier Reef?\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run search_wikipedia for each question\n",
+    "results = []\n",
+    "\n",
+    "for question in geography_questions:\n",
+    "    question_results = search_wikipedia(question, limit=10)\n",
+    "    \n",
+    "    # Format the results as requested\n",
+    "    formatted_results = []\n",
+    "    for item in question_results:\n",
+    "        formatted_result = f\"{item['title']}\\n{item['snippet']}\"\n",
+    "        formatted_results.append(formatted_result)\n",
+    "    \n",
+    "    # Add to the results list\n",
+    "    results.append({\n",
+    "        \"question\": question,\n",
+    "        \"search_results\": formatted_results\n",
+    "    })"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Rerank the search results and filter the top_n results (\"Engine A\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this section, we'll implement our first retrieval approach using Cohere's reranking model. Reranking is a technique that takes an initial set of search results and reorders them based on their relevance to the original query.\n",
+    "\n",
+    "We'll use Cohere's `rerank` API to:\n",
+    "1. Take the Wikipedia search results we obtained earlier\n",
+    "2. Send them to Cohere's reranking model along with the original query\n",
+    "3. Filter to keep only the top-n most relevant results\n",
+    "\n",
+    "This approach will be referred to as \"Engine A\" in our evaluation, and we'll compare its performance against the original Wikipedia search rankings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original question: What is the capital of France?\n",
+      "Top 3 reranked results:\n",
+      "\n",
+      "1. France\n",
+      "semi-presidential republic and its capital, largest city and main cultural and economic centre is Paris. Metropolitan France was settled during the Iron Age by Celtic\n",
+      "\n",
+      "2. Closed-ended question\n",
+      "variants of the above closed-ended questions that possess specific responses are: On what day were you born? (&quot;Saturday.&quot;) What is the capital of France? (&quot;Paris\n",
+      "\n",
+      "3. Capital city\n",
+      "seat of the government. A capital is typically a city that physically encompasses the government&#039;s offices and meeting places; the status as capital is often\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Rerank the search results for each question\n",
+    "top_n = 3\n",
+    "results_reranked_top_n = []\n",
+    "\n",
+    "for item in results:\n",
+    "    question = item[\"question\"]\n",
+    "    documents = item[\"search_results\"]\n",
+    "    \n",
+    "    # Rerank the documents using Cohere\n",
+    "    reranked = co.rerank(\n",
+    "        model=\"rerank-v3.5\",\n",
+    "        query=question,\n",
+    "        documents=documents,\n",
+    "        top_n=top_n  # Get top 3 results\n",
+    "    )\n",
+    "    \n",
+    "    # Format the reranked results\n",
+    "    top_results = []\n",
+    "    for result in reranked.results:\n",
+    "        top_results.append(documents[result.index])\n",
+    "    \n",
+    "    # Add to the reranked results list\n",
+    "    results_reranked_top_n.append({\n",
+    "        \"question\": question,\n",
+    "        \"search_results\": top_results\n",
+    "    })\n",
+    "\n",
+    "# Print a sample of the reranked results\n",
+    "print(f\"Original question: {results_reranked_top_n[0]['question']}\")\n",
+    "print(f\"Top 3 reranked results:\")\n",
+    "for i, result in enumerate(results_reranked_top_n[0]['search_results']):\n",
+    "    print(f\"\\n{i+1}. {result}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Take the original search results and filter the top_n results (\"Engine B\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this section, we'll implement our second retrieval approach as a baseline comparison. For \"Engine B\", we'll simply take the original Wikipedia search results without any reranking and select the top-n results.\n",
+    "\n",
+    "This approach reflects how many traditional search engines work - returning results based on their original relevance score from the data source. By comparing this baseline against our reranked approach (Engine A), we can evaluate whether reranking provides meaningful improvements in result quality.\n",
+    "\n",
+    "We'll use the same number of results (top_n) as Engine A to ensure a fair comparison in our evaluation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original question: What is the capital of France?\n",
+      "Top 3 results (without reranking):\n",
+      "\n",
+      "1. Closed-ended question\n",
+      "variants of the above closed-ended questions that possess specific responses are: On what day were you born? (&quot;Saturday.&quot;) What is the capital of France? (&quot;Paris\n",
+      "\n",
+      "2. France\n",
+      "semi-presidential republic and its capital, largest city and main cultural and economic centre is Paris. Metropolitan France was settled during the Iron Age by Celtic\n",
+      "\n",
+      "3. What Is a Nation?\n",
+      "&quot;What Is a Nation?&quot; (French: Qu&#039;est-ce qu&#039;une nation ?) is an 1882 lecture by French historian Ernest Renan (1823–1892) at the Sorbonne, known for the\n"
+     ]
+    }
+   ],
+   "source": [
+    "results_top_n = []\n",
+    "\n",
+    "for item in results:\n",
+    "    results_top_n.append({\n",
+    "        \"question\": item[\"question\"],\n",
+    "        \"search_results\": item[\"search_results\"][:top_n]\n",
+    "    })\n",
+    "    \n",
+    "# Print a sample of the top_n results (without reranking)\n",
+    "print(f\"Original question: {results_top_n[0]['question']}\")\n",
+    "print(f\"Top {top_n} results (without reranking):\")\n",
+    "for i, result in enumerate(results_top_n[0]['search_results']):\n",
+    "    print(f\"\\n{i+1}. {result}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run LLM-as-a-judge evaluation to compare the two engines"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we'll implement an evaluation framework using LLMs as judges to compare our two retrieval approaches:\n",
+    "- Engine A: Wikipedia results reranked by Cohere's reranking model\n",
+    "- Engine B: Original Wikipedia search results\n",
+    "\n",
+    "Using LLMs as evaluators allows us to programmatically assess the quality of search results without human annotation. The following code implements the following steps:\n",
+    "\n",
+    "- Setting up the evaluation protocol\n",
+    "  - First, define a clear protocol for how the LLM judges will evaluate the search results. This includes creating a system prompt and a template for each evaluation.\n",
+    "- Using multiple models as independent judges\n",
+    "  - To get more robust results, use multiple LLM models as independent judges. This reduces bias from any single model.\n",
+    "- Implementing a majority voting system\n",
+    "  - Combine judgments from multiple models using a majority voting system to determine which engine performed better for each query:\n",
+    "- Presenting the results\n",
+    "  - After evaluating all queries, present the results to determine which retrieval approach performed better overall.\n",
+    "\n",
+    "This approach provides a scalable, reproducible method to evaluate and compare retrieval systems quantitatively."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# System prompt for the AI evaluator\n",
+    "SYSTEM_PROMPT = \"\"\"\n",
+    "You are an AI search evaluator. You will compare search results from two engines and\n",
+    "determine which set provides more relevant and diverse information. You will only\n",
+    "answer with the verdict rather than explaining your reasoning; simply say \"Engine A\" or\n",
+    "\"Engine B\".\n",
+    "\"\"\"\n",
+    "\n",
+    "# Prompt template for each evaluation\n",
+    "PROMPT_TEMPLATE = \"\"\"\n",
+    "For the following question, which search engine provides more relevant results?\n",
+    "\n",
+    "## Question:\n",
+    "{query}\n",
+    "\n",
+    "## Engine A:\n",
+    "{engine_a_results}\n",
+    "\n",
+    "## Engine B:\n",
+    "{engine_b_results}\n",
+    "\"\"\"\n",
+    "\n",
+    "def format_results(results):\n",
+    "    \"\"\"Format search results in a readable way\"\"\"\n",
+    "    formatted = []\n",
+    "    for i, result in enumerate(results):\n",
+    "        formatted.append(f\"Result {i+1}: {result[:200]}...\")\n",
+    "    return \"\\n\\n\".join(formatted)\n",
+    "\n",
+    "def judge_query(query, engine_a_results, engine_b_results, model_name):\n",
+    "    \"\"\"Use a single model to judge which engine has better results\"\"\"\n",
+    "    agent = Agent(model_name, system_prompt=SYSTEM_PROMPT)\n",
+    "    \n",
+    "    # Format the results\n",
+    "    engine_a_formatted = format_results(engine_a_results)\n",
+    "    engine_b_formatted = format_results(engine_b_results)\n",
+    "    \n",
+    "    # Create the prompt\n",
+    "    prompt = PROMPT_TEMPLATE.format(\n",
+    "        query=query,\n",
+    "        engine_a_results=engine_a_formatted,\n",
+    "        engine_b_results=engine_b_formatted\n",
+    "    )\n",
+    "    \n",
+    "    # Get the model's judgment\n",
+    "    response = agent.run_sync(prompt)\n",
+    "    return response.data\n",
+    "\n",
+    "def evaluate_search_results(reranked_results, regular_results, models):\n",
+    "    \"\"\"\n",
+    "    Evaluate both sets of search results using multiple models.\n",
+    "    \n",
+    "    Args:\n",
+    "        reranked_results: List of dictionaries with 'question' and 'search_results'\n",
+    "        regular_results: List of dictionaries with 'question' and 'search_results'\n",
+    "        models: List of model names to use as judges\n",
+    "    \n",
+    "    Returns:\n",
+    "        DataFrame with evaluation results\n",
+    "    \"\"\"\n",
+    "    # Prepare data structure for results\n",
+    "    evaluation_results = []\n",
+    "    \n",
+    "    # Evaluate each query\n",
+    "    for i in range(len(reranked_results)):\n",
+    "        query = reranked_results[i]['question']\n",
+    "        engine_a_results = reranked_results[i]['search_results']  # Reranked results\n",
+    "        engine_b_results = regular_results[i]['search_results']   # Regular results\n",
+    "        \n",
+    "        # Get judgments from each model\n",
+    "        judgments = []\n",
+    "        for model in models:\n",
+    "            judgment = judge_query(query, engine_a_results, engine_b_results, model)\n",
+    "            judgments.append(judgment)\n",
+    "        \n",
+    "        # Determine winner by majority vote\n",
+    "        votes = Counter(judgments)\n",
+    "        if votes[\"Engine A\"] > votes[\"Engine B\"]:\n",
+    "            winner = \"Engine A\"\n",
+    "        elif votes[\"Engine B\"] > votes[\"Engine A\"]:\n",
+    "            winner = \"Engine B\"\n",
+    "        else:\n",
+    "            winner = \"Tie\"\n",
+    "        \n",
+    "        # Add results for this query\n",
+    "        row = [query] + judgments + [winner]\n",
+    "        evaluation_results.append(row)\n",
+    "    \n",
+    "    # Create DataFrame\n",
+    "    column_names = [\"question\"] + [f\"judge_{i+1} ({model})\" for i, model in enumerate(models)] + [\"winner\"]\n",
+    "    df = pd.DataFrame(evaluation_results, columns=column_names)\n",
+    "    \n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Percentage of questions won by each engine:\n",
+      "Engine A: 80.00% (8/10)\n",
+      "Tie: 10.00% (1/10)\n",
+      "Engine B: 10.00% (1/10)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Define the search engines\n",
+    "engine_a = results_reranked_top_n\n",
+    "engine_b = results_top_n\n",
+    "\n",
+    "# Define the models to use as judges\n",
+    "models = [\n",
+    "    \"cohere:command-a-03-2025\",\n",
+    "    \"cohere:command-r-plus-08-2024\",\n",
+    "    \"cohere:command-r-08-2024\",\n",
+    "    \"cohere:c4ai-aya-expanse-32b\",\n",
+    "    \"cohere:c4ai-aya-expanse-8b\",\n",
+    "]\n",
+    "\n",
+    "# Get evaluation results\n",
+    "results_df = evaluate_search_results(engine_a, engine_b, models)\n",
+    "\n",
+    "# Calculate overall statistics\n",
+    "winner_counts = Counter(results_df[\"winner\"])\n",
+    "total_queries = len(results_df)\n",
+    "\n",
+    "# Display summary of results\n",
+    "print(\"\\nPercentage of questions won by each engine:\")\n",
+    "for engine, count in winner_counts.items():\n",
+    "    percentage = (count / total_queries) * 100\n",
+    "    print(f\"{engine}: {percentage:.2f}% ({count}/{total_queries})\")\n",
+    "    \n",
+    "# Display dataframe\n",
+    "results_df.head()\n",
+    "\n",
+    "# Save to CSV\n",
+    "results_csv = results_df.to_csv(\"search_results_evaluation.csv\", index=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "This tutorial demonstrates how to evaluate retrieval systems using LLMs as judges through Pydantic AI, comparing original Wikipedia search results against those reranked by Cohere's reranking model. \n",
+    "\n",
+    "The evaluation framework uses multiple Cohere models as independent judges with majority voting to determine which system provides more relevant results. \n",
+    "\n",
+    "Results showed the reranked approach (Engine A) outperformed the original search rankings (Engine B) by winning 80% of queries, demonstrating the effectiveness of neural reranking in improving search relevance."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "base"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR adds a tutorial on how to evaluate retrieval systems using LLMs as judges via Pydantic AI.

- Adds a new page to the Cookbooks section titled "Retrieval evaluation using LLM-as-a-judge via Pydantic AI"
- Includes a description, image, and keywords for the new page
- Imports the CookbookHeader component and adds a header linking to the GitHub repository
- Provides an overview of the tutorial's objectives and the tools used
- Adds a Setup section with instructions to import necessary libraries and install required packages
- Includes code snippets and explanations for:
  - Performing a Wikipedia search
  - Reranking search results using Cohere's API
  - Filtering top_n results for comparison
  - Implementing an LLM-as-a-judge evaluation framework
- Adds a Conclusion section summarizing the tutorial's key points
- Updates the navigation to include the new page in both v1.yml and v2.yml
- Adds a corresponding Jupyter notebook with the same content and code as the new page

<!-- end-generated-description -->