### PR TITLE
changed shutdown dates

### DIFF
--- a/fern/pages/going-to-production/deprecations.mdx
+++ b/fern/pages/going-to-production/deprecations.mdx
@@ -48,8 +48,8 @@ Fine-tuned models created from these base models are not affected by this deprec
 
 | Shutdown Date| Deprecated Model| Deprecated Model Price| Recommended Replacement|
 |--------------|-----------------|-----------------------|------------------------|
-| 2025-03-31 | `rerank-english-v2.0` | $1.00 / 1K searches | `rerank-v3.5`|
-| 2025-03-31 | `rerank-multilingual-v2.0` | $1.00 / 1K searches | `rerank-v3.5`|
+| 2025-04-30 | `rerank-english-v2.0` | $1.00 / 1K searches | `rerank-v3.5`|
+| 2025-04-30 | `rerank-multilingual-v2.0` | $1.00 / 1K searches | `rerank-v3.5`|
 
 
 


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the shutdown date for the `rerank-english-v2.0` and `rerank-multilingual-v2.0` models in the `fern/pages/going-to-production/deprecations.mdx` file.

- The shutdown date for both models has been extended from 2025-03-31 to 2025-04-30.

<!-- end-generated-description -->