### PR TITLE
Updated temperature values, also changed the v2 banner in command-beta.

### DIFF
--- a/fern/pages/text-generation/predictable-outputs.mdx
+++ b/fern/pages/text-generation/predictable-outputs.mdx
@@ -43,7 +43,7 @@ Sampling from generation models incorporates randomness, so the same prompt may 
 
 ### How to pick temperature when sampling
 
-A lower temperature means less randomness; a temperature of 0 will always yield the same output. Lower temperatures (around `.1` to `.3`) are more appropriate when performing tasks that have a "correct" answer, like question answering or summarization. If the model starts repeating itself this is a sign that the temperature may be too low.
+A lower temperature means less randomness; a temperature of `0` will always yield the same output. Lower temperatures (around `.1` to `.3`) are more appropriate when performing tasks that have a "correct" answer, like question answering or summarization. If the model starts repeating itself this is a sign that the temperature may be too low.
 
 High temperature means more randomness and less grounding. This can help the model give more creative outputs, but if you're using [retrieval augmented generation](/docs/retrieval-augmented-generation-rag), it can also mean that it doesn't correctly use the context you provide. If the model starts going off topic, giving nonsensical outputs, or failing to ground properly, this is a sign that the temperature is too high.
 

--- a/fern/pages/text-generation/predictable-outputs.mdx
+++ b/fern/pages/text-generation/predictable-outputs.mdx
@@ -39,16 +39,16 @@ print(res.text)  # Sure! How about "onomatopoeia"?
 
 ## Temperature
 
-Sampling from generation models incorporates randomness, so the same prompt may yield different outputs from generation to generation. Temperature is a number used to tune the degree of randomness.
+Sampling from generation models incorporates randomness, so the same prompt may yield different outputs from generation to generation. Temperature is a parameter ranging from `0-1` used to tune the degree of randomness, and it defaults to a value of `.3`.
 
 ### How to pick temperature when sampling
 
-A lower temperature means less randomness; a temperature of 0 will always yield the same output. Lower temperatures (less than 1) are more appropriate when performing tasks that have a "correct" answer, like question answering or summarization. If the model starts repeating itself this is a sign that the temperature may be too low.
+A lower temperature means less randomness; a temperature of 0 will always yield the same output. Lower temperatures (around `.1` to `.3`) are more appropriate when performing tasks that have a "correct" answer, like question answering or summarization. If the model starts repeating itself this is a sign that the temperature may be too low.
 
 High temperature means more randomness and less grounding. This can help the model give more creative outputs, but if you're using [retrieval augmented generation](/docs/retrieval-augmented-generation-rag), it can also mean that it doesn't correctly use the context you provide. If the model starts going off topic, giving nonsensical outputs, or failing to ground properly, this is a sign that the temperature is too high.
 
 <img src='../../assets/images/775d949-Temperature_Visual_1.png' alt='setting' />
 
-Temperature can be tuned for different problems, but most people will find that a temperature of 1 is a good starting point.
+Temperature can be tuned for different problems, but most people will find that a temperature of `.3` or `.5` is a good starting point.
 
 As sequences get longer, the model naturally becomes more confident in its predictions, so you can raise the temperature much higher for long prompts without going off topic. In contrast, using high temperatures on short prompts can lead to outputs being very unstable.

--- a/fern/pages/v2/models/the-command-family-of-models/command-beta.mdx
+++ b/fern/pages/v2/models/the-command-family-of-models/command-beta.mdx
@@ -13,7 +13,8 @@ createdAt: "Mon Nov 07 2022 16:26:44 GMT+0000 (Coordinated Universal Time)"
 updatedAt: "Tue Jun 04 2024 18:34:22 GMT+0000 (Coordinated Universal Time)"
 ---
 <Info title="Note">  
- For most use cases we recommend our latest model [Command R](/v2/docs/command-r) instead.
+ For most use cases we recommend our latest model [Command A](https://docs.cohere.com/docs/command-a) instead.
+
 </Info>
 
 

--- a/fern/pages/v2/text-generation/predictable-outputs.mdx
+++ b/fern/pages/v2/text-generation/predictable-outputs.mdx
@@ -45,16 +45,16 @@ print(res.message.content[0].text)  # Sure! How about "onomatopoeia"?
 
 ## Temperature
 
-Sampling from generation models incorporates randomness, so the same prompt may yield different outputs from generation to generation. Temperature is a number used to tune the degree of randomness.
+Sampling from generation models incorporates randomness, so the same prompt may yield different outputs from generation to generation. Temperature is a parameter ranging from `0-1` used to tune the degree of randomness, and it defaults to a value of `.3`.
 
 ### How to pick temperature when sampling
 
-A lower temperature means less randomness; a temperature of 0 will always yield the same output. Lower temperatures (less than 1) are more appropriate when performing tasks that have a "correct" answer, like question answering or summarization. If the model starts repeating itself this is a sign that the temperature may be too low.
+A lower temperature means less randomness; a temperature of 0 will always yield the same output. Lower temperatures (around `.1` to `.3`) are more appropriate when performing tasks that have a "correct" answer, like question answering or summarization. If the model starts repeating itself this is a sign that the temperature may be too low.
 
 High temperature means more randomness and less grounding. This can help the model give more creative outputs, but if you're using [retrieval augmented generation](/v2/docs/retrieval-augmented-generation-rag), it can also mean that it doesn't correctly use the context you provide. If the model starts going off topic, giving nonsensical outputs, or failing to ground properly, this is a sign that the temperature is too high.
 
 <img src='../../../assets/images/775d949-Temperature_Visual_1.png' alt='setting' />
 
-Temperature can be tuned for different problems, but most people will find that a temperature of 1 is a good starting point.
+Temperature can be tuned for different problems, but most people will find that a temperature of `.3` or `.5` is a good starting point.
 
 As sequences get longer, the model naturally becomes more confident in its predictions, so you can raise the temperature much higher for long prompts without going off topic. In contrast, using high temperatures on short prompts can lead to outputs being very unstable.

--- a/fern/pages/v2/text-generation/predictable-outputs.mdx
+++ b/fern/pages/v2/text-generation/predictable-outputs.mdx
@@ -49,7 +49,7 @@ Sampling from generation models incorporates randomness, so the same prompt may 
 
 ### How to pick temperature when sampling
 
-A lower temperature means less randomness; a temperature of 0 will always yield the same output. Lower temperatures (around `.1` to `.3`) are more appropriate when performing tasks that have a "correct" answer, like question answering or summarization. If the model starts repeating itself this is a sign that the temperature may be too low.
+A lower temperature means less randomness; a temperature of `0` will always yield the same output. Lower temperatures (around `.1` to `.3`) are more appropriate when performing tasks that have a "correct" answer, like question answering or summarization. If the model starts repeating itself this is a sign that the temperature may be too low.
 
 High temperature means more randomness and less grounding. This can help the model give more creative outputs, but if you're using [retrieval augmented generation](/v2/docs/retrieval-augmented-generation-rag), it can also mean that it doesn't correctly use the context you provide. If the model starts going off topic, giving nonsensical outputs, or failing to ground properly, this is a sign that the temperature is too high.
 


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the temperature parameter and model recommendation in the documentation.

- The temperature parameter is now defined as a value ranging from `0-1` with a default value of `.3`.
- The recommended temperature range for tasks with a "correct" answer is now `0.1` to `0.3`.
- The suggested starting point for temperature is now `0.3` or `0.5` instead of `1`.
- The recommended model for most use cases is now [Command A](https://docs.cohere.com/docs/command-a) instead of [Command R](/v2/docs/command-r).

<!-- end-generated-description -->