### PR TITLE
correct misspelling of "strategy" in data dictionary

### DIFF
--- a/fern/pages/cookbooks/document-parsing-for-enterprises.mdx
+++ b/fern/pages/cookbooks/document-parsing-for-enterprises.mdx
@@ -780,7 +780,7 @@ with open(input_path, 'rb') as file_data:
         files={"files": ("{}.{}".format(source_filename, extension), file_data)},
         data={
             "output_format": (None, "application/json"),
-            "stratergy": "hi_res",
+            "strategy": "hi_res",
             "pdf_infer_table_structure": "true",
             "include_page_breaks": "true"
         },


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR fixes a typo in the file fern/pages/cookbooks/document-parsing-for-enterprises.mdx.

- Line 780: 'stratergy' is changed to 'strategy'

<!-- end-generated-description -->