### PR TITLE
Correct misspelling of "strategy" in data dictionary

### DIFF
--- a/notebooks/guides/Document_Parsing_For_Enterprises.ipynb
+++ b/notebooks/guides/Document_Parsing_For_Enterprises.ipynb
@@ -1028,7 +1028,7 @@
     "        files={\"files\": (\"{}.{}\".format(source_filename, extension), file_data)},\n",
     "        data={\n",
     "            \"output_format\": (None, \"application/json\"),\n",
-    "            \"stratergy\": \"hi_res\",\n",
+    "            \"strategy\": \"hi_res\",\n",
     "            \"pdf_infer_table_structure\": \"true\",\n",
     "            \"include_page_breaks\": \"true\"\n",
     "        },\n",


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the Document_Parsing_For_Enterprises.ipynb file by correcting the spelling of the "strategy" variable.

- The spelling of the "strategy" variable has been corrected.

<!-- end-generated-description -->