### PR TITLE
Updating the embedding dimensions to the default: 1536

### DIFF
--- a/fern/pages/cookbooks/document-parsing-for-enterprises.mdx
+++ b/fern/pages/cookbooks/document-parsing-for-enterprises.mdx
@@ -1056,7 +1056,7 @@ Create document index and add embedded chunks
 
 import hnswlib
 
-index = hnswlib.Index(space='ip', dim=1024) # space: inner product
+index = hnswlib.Index(space='ip', dim=1536) # space: inner product
 index.init_index(max_elements=len(document_embeddings), ef_construction=512, M=64)
 index.add_items(document_embeddings, list(range(len(document_embeddings))))
 print("Count:", index.element_count)


### PR DESCRIPTION
source: https://docs.cohere.com/v2/reference/embed#request.body.output_dimension