### PR TITLE
Updating the index to use the default dimension size of Embed (1536)

### DIFF
--- a/notebooks/guides/Document_Parsing_For_Enterprises.ipynb
+++ b/notebooks/guides/Document_Parsing_For_Enterprises.ipynb
@@ -1548,7 +1548,7 @@
     "\n",
     "import hnswlib\n",
     "\n",
-    "index = hnswlib.Index(space='ip', dim=1024) # space: inner product\n",
+    "index = hnswlib.Index(space='ip', dim=1536) # space: inner product\n",
     "index.init_index(max_elements=len(document_embeddings), ef_construction=512, M=64)\n",
     "index.add_items(document_embeddings, list(range(len(document_embeddings))))\n",
     "print(\"Count:\", index.element_count)"


### PR DESCRIPTION
source: https://docs.cohere.com/v2/reference/embed#request.body.output_dimension