### PR TITLE
adding embedding_types parameter in Embed request (required in Embed v4)

### DIFF
--- a/notebooks/guides/Document_Parsing_For_Enterprises.ipynb
+++ b/notebooks/guides/Document_Parsing_For_Enterprises.ipynb
@@ -1519,7 +1519,7 @@
     "\"\"\"\n",
     "Embed document chunks\n",
     "\"\"\"\n",
-    "document_embeddings = co.embed(texts=documents, model=\"embed-v4.0\", input_type=\"search_document\").embeddings"
+    "document_embeddings = co.embed(texts=documents, model=\"embed-v4.0\", input_type=\"search_document\", embedding_types=[\"float\"]).embeddings"
    ]
   },
   {
@@ -1579,7 +1579,7 @@
     "Fetch k nearest neighbors\n",
     "\"\"\"\n",
     "\n",
-    "query_emb = co.embed(texts=[prompt], model='embed-v4.0', input_type=\"search_query\").embeddings\n",
+    "query_emb = co.embed(texts=[prompt], model='embed-v4.0', input_type=\"search_query\", embedding_types=[\"float\"]).embeddings\n",
     "default_knn = 10\n",
     "knn = default_knn if default_knn <= index.element_count else index.element_count\n",
     "result = index.knn_query(query_emb, k=knn)\n",


### PR DESCRIPTION
This PR updates the `co.embed()` function call in the `document-parsing-for-enterprises.mdx` file by adding the `embedding_types` parameter with the value `["float"]`.  `embedding_types` is a required parameter in Embed v4: 
https://docs.cohere.com/v2/reference/embed#request.body.embedding_types