### PR TITLE
provide example service endpoint for unstructured container

### DIFF
--- a/notebooks/guides/Document_Parsing_For_Enterprises.ipynb
+++ b/notebooks/guides/Document_Parsing_For_Enterprises.ipynb
@@ -1017,7 +1017,7 @@
     "import os\n",
     "import requests\n",
     "\n",
-    "UNSTRUCTURED_URL = \"\" # enter service endpoint\n",
+    "UNSTRUCTURED_URL = \"\" # enter service endpoint, for example "http://localhost:9500/general/v0/general" (assuming the container is running locally and exposing the service with a -p 9500:9500 port mapping)\n",
     "\n",
     "parsed_documents = []\n",
     "\n",


### PR DESCRIPTION
Adding example service endpoint to commented line

`# enter service endpoint, for example "http://localhost:9500/general/v0/general" (assuming the container is running locally and exposing the service with a -p 9500:9500 port mapping)`
