### PR TITLE
provide example service endpoint for unstructured container

### DIFF
--- a/fern/pages/cookbooks/document-parsing-for-enterprises.mdx
+++ b/fern/pages/cookbooks/document-parsing-for-enterprises.mdx
@@ -769,7 +769,8 @@ The guide assumes an endpoint exists that hosts this service. The API is offered
 import os
 import requests
 
-UNSTRUCTURED_URL = "" # enter service endpoint
+UNSTRUCTURED_URL = "" # enter service endpoint, for example "http://localhost:9500/general/v0/general" (assuming the container is running locally and exposing the service with a -p 9500:9500 port mapping)
+
 
 parsed_documents = []
 


### PR DESCRIPTION
Adding example service endpoint to commented portion: 

`# enter service endpoint, for example "http://localhost:9500/general/v0/general" (assuming the container is running locally and exposing the service with a -p 9500:9500 port mapping)`