### PR TITLE
Update unstructured parsing strategy to use `fast`

### DIFF
--- a/fern/pages/cookbooks/document-parsing-for-enterprises.mdx
+++ b/fern/pages/cookbooks/document-parsing-for-enterprises.mdx
@@ -780,7 +780,7 @@ with open(input_path, 'rb') as file_data:
         files={"files": ("{}.{}".format(source_filename, extension), file_data)},
         data={
             "output_format": (None, "application/json"),
-            "strategy": "hi_res",
+            "strategy": "fast",
             "pdf_infer_table_structure": "true",
             "include_page_breaks": "true"
         },


### PR DESCRIPTION
the `hi_res` parsing strategy doesn't complete in the current configuration