### PR TITLE
Fix too long titles

### DIFF
--- a/fern/pages/changelog/2022-11-03-coclassify-powered-by-our-representational-model-embeddings.mdx
+++ b/fern/pages/changelog/2022-11-03-coclassify-powered-by-our-representational-model-embeddings.mdx
@@ -1,5 +1,5 @@
 ---
-title: Co.classify powered by our Representational model embeddings
+title: Co.classify uses Representational model embeddings
 slug: changelog/coclassify-powered-by-our-representational-model-embeddings
 type: improved
 createdAt: 'Thu Nov 03 2022 22:33:02 GMT+0000 (Coordinated Universal Time)'

--- a/fern/pages/changelog/2022-11-08-improvements-to-current-models-new-beta-model-command.mdx
+++ b/fern/pages/changelog/2022-11-08-improvements-to-current-models-new-beta-model-command.mdx
@@ -1,5 +1,5 @@
 ---
-title: Improvements to Current Models + New Beta Model (Command)!
+title: Current Model Upgrades + New Command Beta Model
 slug: changelog/improvements-to-current-models-new-beta-model-command
 type: added
 createdAt: 'Tue Nov 08 2022 16:43:50 GMT+0000 (Coordinated Universal Time)'

--- a/fern/pages/changelog/2022-12-12-multilingual-text-understanding-model-language-detection.mdx
+++ b/fern/pages/changelog/2022-12-12-multilingual-text-understanding-model-language-detection.mdx
@@ -1,5 +1,5 @@
 ---
-title: Multilingual Text Understanding Model + Language Detection!
+title: Multilingual Text Model + Language Detection
 slug: changelog/multilingual-text-understanding-model-language-detection
 type: added
 createdAt: 'Mon Dec 12 2022 15:52:44 GMT+0000 (Coordinated Universal Time)'

--- a/fern/pages/changelog/2025-01-31-classify-default-model-deprecation.mdx
+++ b/fern/pages/changelog/2025-01-31-classify-default-model-deprecation.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Deprecation of the Classify endpoint via default Embed models"
+title: "Deprecation of Classify via default Embed Models"
 slug: "changelog/classify-default-model-deprecation"
 createdAt: "Thu Jan 31 2025 12:51:00 (MST)"
 hidden: false

--- a/fern/pages/changelog/2025-02-26-compatibility-api.mdx
+++ b/fern/pages/changelog/2025-02-26-compatibility-api.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use Cohere models via the OpenAI SDK with the Compatibility API
+title: Cohere via OpenAI SDK Using Compatibility API
 slug: "changelog/compatibility-api"
 createdAt: "Wed Feb 26 2025 13:13:00 (MST)"
 hidden: false

--- a/fern/pages/cookbooks/article-recommender-with-text-embeddings.mdx
+++ b/fern/pages/cookbooks/article-recommender-with-text-embeddings.mdx
@@ -1,5 +1,5 @@
 ---
-title: Article Recommender with Text Embedding and Classification
+title: Article Recommender via Embedding & Classification
 slug: /page/article-recommender-with-text-embeddings
 
 description: "This page describes how to build a generative-AI tool to recommend articles with Cohere."

--- a/fern/pages/cookbooks/migrate-csv-agent.mdx
+++ b/fern/pages/cookbooks/migrate-csv-agent.mdx
@@ -1,5 +1,5 @@
 ---
-title: Migrating away from deprecated create_csv_agent in langchain-cohere
+title: Migrating away from create_csv_agent in langchain-cohere
 slug: /page/migrate-csv-agent
 
 description: "This page contains a tutorial on how to build a CSV agent without the deprecated `create_csv_agent` abstraction in langchain-cohere v0.3.5 and beyond."

--- a/fern/v2.yml
+++ b/fern/v2.yml
@@ -853,7 +853,7 @@ navigation:
         path: pages/cookbooks/csv-agent-native-api.mdx
       - page: Financial CSV Agent with Langchain
         path: pages/cookbooks/csv-agent.mdx
-      - page: Migrating away from deprecated create_csv_agent in langchain-cohere
+      - page: Migrating away from create_csv_agent in langchain-cohere
         path: pages/cookbooks/migrate-csv-agent.mdx
       - page: A Data Analyst Agent Built with Cohere and Langchain
         path: pages/cookbooks/data-analyst-agent.mdx


### PR DESCRIPTION
This PR should fix long titles reported by SemRush.
For some titles we add either `- cohere` or `(v1 API) — Cohere` which make titles longer than max limit 70 chars