### PR TITLE
Add docs/v2 preambles redirect

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -619,6 +619,9 @@ redirects:
   - source: /docs/preambles
     destination: /docs/system-instructions
     permanent: true
+  - source: /v2/docs/preambles
+    destination: /docs/system-instructions
+    permanent: true
 
 analytics:
   segment:


### PR DESCRIPTION
It was found that we have links fto v2/docs/preambles which currenly is not handled
```
Top search result for cohere developer preamble [links to a broken page](https://docs.cohere.com/v2/docs/preambles)
```