### PR TITLE
Fix duplicated titles for R and R+ commands, fix favicon path

### DIFF
--- a/fern/pages/models/the-command-family-of-models/command-r-plus.mdx
+++ b/fern/pages/models/the-command-family-of-models/command-r-plus.mdx
@@ -1,5 +1,5 @@
 ---
-title: Cohere's Command R+ Model 
+title: Cohere's Command R+ Model (Command R Plus)
 subtitle: Command R+ model details and specifications
 slug: docs/command-r-plus
 hidden: false

--- a/fern/pages/text-generation/image-inputs.mdx
+++ b/fern/pages/text-generation/image-inputs.mdx
@@ -118,7 +118,7 @@ co.chat(
 )
 ```
 
-An HTTP image URL (e.g., “https://cohere.com/favicon-32x32.png”) is faster, but requires you to upload your image somewhere and is not available in outside platforms (Azure, Bedrock, etc.) HTTP image URLs make the API easy to try out, as data URLs are long and difficult to deal with. Moreover, including long data URLs in the request increases the request size and the corresponding network latency.
+An HTTP image URL (e.g., "https://cohere.com/favicon-32x32.png") is faster, but requires you to upload your image somewhere and is not available in outside platforms (Azure, Bedrock, etc.) HTTP image URLs make the API easy to try out, as data URLs are long and difficult to deal with. Moreover, including long data URLs in the request increases the request size and the corresponding network latency.
 
 Here's what that looks like:
 


### PR DESCRIPTION
There were a couple issues reported by seo tool.
That command R and R+ have duplicated titles - so I added extra information to R+ command.
And also double-queotes was recognized as special characters.