### PR TITLE
Remove redirect for docs homepage

### DIFF
--- a/fern/v1.yml
+++ b/fern/v1.yml
@@ -19,6 +19,7 @@ tabs:
 landing-page:
   page: Cohere Documentation
   path: pages/index.mdx
+  slug: /
 
 navigation:
   - tab: docs

--- a/fern/v2.yml
+++ b/fern/v2.yml
@@ -19,6 +19,7 @@ tabs:
 landing-page:
   page: Cohere Documentation
   path: pages/index.mdx
+  slug: /
 
 navigation:
   - tab: docs


### PR DESCRIPTION
Currently if we visit docs.cohere.com we redirected automatically to docs.cohere.com/cohere-documentation
This PR should fix that and we should get page docs.cohere.com without any redirects.

on preview app it looks ok