### PR TITLE
Update cohere-openapi.yaml

### DIFF
--- a/cohere-openapi.yaml
+++ b/cohere-openapi.yaml
@@ -5680,8 +5680,9 @@ paths:
                   description: |
                     The maximum number of output tokens the model will generate in the response. If not set, `max_tokens` defaults to the model's maximum output token limit. You can find the maximum output tokens for each model in the [model documentation](https://docs.cohere.com/docs/models).
 
-                    > Note: Setting a low value may result in incomplete generations. In such cases, the `finish_reason` field in the response will be set to `"MAX_TOKENS"`.
-                    > Note: If `max_tokens` is set higher than the model’s maximum output token limit, the generation will be capped at that model-specific maximum.
+                    Note: Setting a low value may result in incomplete generations. In such cases, the `finish_reason` field in the response will be set to `"MAX_TOKENS"`.
+
+                    Note: If `max_tokens` is set higher than the model’s maximum output token limit, the generation will be capped at that model-specific maximum.
                   writeOnly: true
                 max_input_tokens:
                   type: integer
@@ -6033,8 +6034,9 @@ paths:
                   description: |
                     The maximum number of output tokens the model will generate in the response. If not set, `max_tokens` defaults to the model's maximum output token limit. You can find the maximum output tokens for each model in the [model documentation](https://docs.cohere.com/docs/models).
 
-                    > Note: Setting a low value may result in incomplete generations. In such cases, the `finish_reason` field in the response will be set to `"MAX_TOKENS"`.
-                    > Note: If `max_tokens` is set higher than the model’s maximum output token limit, the generation will be capped at that model-specific maximum.
+                    Note: Setting a low value may result in incomplete generations. In such cases, the `finish_reason` field in the response will be set to `"MAX_TOKENS"`.
+
+                    Note: If `max_tokens` is set higher than the model’s maximum output token limit, the generation will be capped at that model-specific maximum.
                 stop_sequences:
                   x-fern-audiences:
                     - public

--- a/cohere-openapi.yaml
+++ b/cohere-openapi.yaml
@@ -5678,9 +5678,10 @@ paths:
                   x-fern-audiences:
                     - public
                   description: |
-                    The maximum number of tokens the model will generate as part of the response. Note: Setting a low value may result in incomplete generations.
+                    The maximum number of output tokens the model will generate in the response. If not set, `max_tokens` defaults to the model's maximum output token limit. You can find the maximum output tokens for each model in the [model documentation](https://docs.cohere.com/docs/models).
 
-                    Compatible Deployments: Cohere Platform, Azure, AWS Sagemaker/Bedrock, Private Deployments
+                    > Note: Setting a low value may result in incomplete generations. In such cases, the `finish_reason` field in the response will be set to `"MAX_TOKENS"`.
+                    > Note: If `max_tokens` is set higher than the model’s maximum output token limit, the generation will be capped at that model-specific maximum.
                   writeOnly: true
                 max_input_tokens:
                   type: integer
@@ -6030,9 +6031,10 @@ paths:
                     - public
                   type: integer
                   description: |
-                    The maximum number of tokens the model will generate as part of the response.
+                    The maximum number of output tokens the model will generate in the response. If not set, `max_tokens` defaults to the model's maximum output token limit. You can find the maximum output tokens for each model in the [model documentation](https://docs.cohere.com/docs/models).
 
-                    **Note**: Setting a low value may result in incomplete generations.
+                    > Note: Setting a low value may result in incomplete generations. In such cases, the `finish_reason` field in the response will be set to `"MAX_TOKENS"`.
+                    > Note: If `max_tokens` is set higher than the model’s maximum output token limit, the generation will be capped at that model-specific maximum.
                 stop_sequences:
                   x-fern-audiences:
                     - public


### PR DESCRIPTION
<!-- begin-generated-description -->

## Description
This PR updates the `cohere-openapi.yaml` file to clarify the `max_tokens` parameter in the API documentation. The changes aim to provide more detailed information about the default behavior of `max_tokens`, its relationship to the model's maximum output token limit, and the implications of setting it too low or too high.

## Changes
- **Clarified `max_tokens` Description**: The description of `max_tokens` now explicitly states that it defaults to the model's maximum output token limit if not set. It also provides a link to the [model documentation](https://docs.cohere.com/docs/models) for users to find the maximum output tokens for each model.
- **Added Notes for Edge Cases**: Two notes have been added to explain what happens when `max_tokens` is set too low or too high:
  - If set too low, the `finish_reason` field in the response will be set to `"MAX_TOKENS"`.
  - If set higher than the model's maximum output token limit, the generation will be capped at that model-specific maximum.
- **Updated Formatting**: The notes are now formatted using Markdown `> Note:` syntax for better readability and emphasis.
- **Removed Redundant Information**: The `Compatible Deployments` line has been removed, as it is no longer relevant or necessary in the updated description.

<!-- end-generated-description -->