### PR TITLE
chore: update compat api unsupported params

### DIFF
--- a/fern/pages/v2/text-generation/compatibility-api.mdx
+++ b/fern/pages/v2/text-generation/compatibility-api.mdx
@@ -826,15 +826,12 @@ The following parameters are not supported in the Compatibility API:
 - `reasoning_effort`
 - `metadata`
 - `logit_bias`
-- `logprobs`
 - `top_logprobs`
-- `max_completion_tokens`
 - `n`
 - `modalities`
 - `prediction`
 - `audio`
 - `service_tier`
-- `stream_options`
 - `parallel_tool_calls`
 
 ### Embeddings


### PR DESCRIPTION
we now support logprogs, max_completion_tokens, and stream_options