### PR TITLE
Update figures 

### DIFF
--- a/fern/pages/deployment-options/single-container-on-private-clouds.mdx
+++ b/fern/pages/deployment-options/single-container-on-private-clouds.mdx
@@ -117,7 +117,7 @@ curl --header "Content-Type: application/json" --request POST http://localhost:8
 docker stop rerank-multilingual
 ```
 ```Text Command
-docker run -d --rm --name command --gpus=4 --net=host $IMAGE_TAG
+docker run -d --rm --name command --gpus=2 --net=host $IMAGE_TAG
 
 curl --header "Content-Type: application/json" --request POST http://localhost:8080/chat --data-raw '{"query":"Docker is good because"}'
 
@@ -263,7 +263,7 @@ With that done, fill in the environment variables and generate the application m
 ```
 APP=cohere # or any other name you want to use
 IMAGE= <IMAGE_TAG_FROM_COHERE> # replace with the image cohere provided
-GPUS=4 # use 4 GPUs for command, 1 is enough for embed / rerank 
+GPUS=2 # use 2 GPUs for command, 1 is enough for embed / rerank 
 
 cat <<EOF > cohere.yaml
 ---

--- a/fern/pages/deployment-options/single-container-on-private-clouds.mdx
+++ b/fern/pages/deployment-options/single-container-on-private-clouds.mdx
@@ -117,7 +117,7 @@ curl --header "Content-Type: application/json" --request POST http://localhost:8
 docker stop rerank-multilingual
 ```
 ```Text Command
-docker run -d --rm --name command --gpus=2 --net=host $IMAGE_TAG
+docker run -d --rm --name command --gpus=2 --net=host $IMAGE_TAG # Number of GPUs may be different depending on the target model
 
 curl --header "Content-Type: application/json" --request POST http://localhost:8080/chat --data-raw '{"query":"Docker is good because"}'
 
@@ -263,7 +263,7 @@ With that done, fill in the environment variables and generate the application m
 ```
 APP=cohere # or any other name you want to use
 IMAGE= <IMAGE_TAG_FROM_COHERE> # replace with the image cohere provided
-GPUS=2 # use 2 GPUs for command, 1 is enough for embed / rerank 
+GPUS= <Number of GPUs for the target model> 
 
 cat <<EOF > cohere.yaml
 ---

--- a/fern/pages/v2/deployment-options/private-deployment/single-container-on-private-clouds.mdx
+++ b/fern/pages/v2/deployment-options/private-deployment/single-container-on-private-clouds.mdx
@@ -133,7 +133,7 @@ curl --header "Content-Type: application/json" --request POST http://localhost:8
 docker stop rerank-multilingual
 ```
 ```Text Command
-docker run -d --rm --name command --gpus=4 --net=host $IMAGE_TAG
+docker run -d --rm --name command --gpus=2 --net=host $IMAGE_TAG # Number of GPUs may be different depending on the target model
 
 curl --header "Content-Type: application/json" --request POST http://localhost:8080/chat --data-raw '{"query":"Docker is good because"}'
 
@@ -279,7 +279,7 @@ With that done, fill in the environment variables and generate the application m
 ```
 APP=cohere # or any other name you want to use
 IMAGE= <IMAGE_TAG_FROM_COHERE> # replace with the image cohere provided
-GPUS=4 # use 4 GPUs for command, 1 is enough for embed / rerank 
+GPUS= <Number of GPUs for the target model> 
 
 cat <<EOF > cohere.yaml
 ---


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the number of GPUs used for the command in the `docker run` command and environment variable configuration.

- Reduces the number of GPUs from 4 to 2 in the `docker run` command for the `command` container.
- Adds a comment indicating that the number of GPUs may vary depending on the target model.
- Updates the `GPUS` environment variable to accept a dynamic value representing the number of GPUs required for the target model, instead of a fixed value of 4.

<!-- end-generated-description -->