### PR TITLE
chore: tokenize/detokenize only available in v1

### DIFF
--- a/fern/pages/v2/text-generation/tokens-and-tokenizers.mdx
+++ b/fern/pages/v2/text-generation/tokens-and-tokenizers.mdx
@@ -15,7 +15,7 @@ updatedAt: "Thu May 23 2024 05:39:13 GMT+0000 (Coordinated Universal Time)"
 
 Our language models understand "tokens" rather than characters or bytes. One token can be a part of a word, an entire word, or punctuation. Very common words like "water" will have their own unique tokens. A longer, less frequent word might be encoded into 2-3 tokens, e.g. "waterfall" gets encoded into two tokens, one for "water" and one for "fall". Note that tokenization is sensitive to whitespace and capitalization.
 
-Here are some references to calibrate how many tokens are in a text:
+Here are some references to calibrate how many teokens are in a text:
 
 - One word tends to be about 2-3 tokens.
 - A paragraph is about 128 tokens.
@@ -42,7 +42,7 @@ Cohere Tokenizers are publicly hosted and can be used locally to avoid network c
 ```python PYTHON
 import cohere
 
-co = cohere.ClientV2(api_key="<YOUR API KEY>")
+co = cohere.Client(api_key="<YOUR API KEY>")
 
 co.tokenize(
     text="caterpillar", model="command-a-03-2025"
@@ -60,7 +60,7 @@ If you are doing development work before going to production with your applicati
 ```python PYTHON
 import cohere
 
-co = cohere.ClientV2(api_key="<YOUR API KEY>")
+co = cohere.Client(api_key="<YOUR API KEY>")
 
 co.tokenize(
     text="caterpillar", model="command-a-03-2025", offline=False

--- a/fern/pages/v2/text-generation/tokens-and-tokenizers.mdx
+++ b/fern/pages/v2/text-generation/tokens-and-tokenizers.mdx
@@ -15,7 +15,7 @@ updatedAt: "Thu May 23 2024 05:39:13 GMT+0000 (Coordinated Universal Time)"
 
 Our language models understand "tokens" rather than characters or bytes. One token can be a part of a word, an entire word, or punctuation. Very common words like "water" will have their own unique tokens. A longer, less frequent word might be encoded into 2-3 tokens, e.g. "waterfall" gets encoded into two tokens, one for "water" and one for "fall". Note that tokenization is sensitive to whitespace and capitalization.
 
-Here are some references to calibrate how many teokens are in a text:
+Here are some references to calibrate how many tokens are in a text:
 
 - One word tends to be about 2-3 tokens.
 - A paragraph is about 128 tokens.


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the API client initialization in the Cohere Tokenizers code examples.

- `cohere.ClientV2(api_key="YOUR API KEY")` is replaced with `cohere.Client(api_key="YOUR API KEY")` in both code snippets.

<!-- end-generated-description -->