### PR TITLE
Few fixes.

### DIFF
--- a/fern/pages/models/the-command-family-of-models/command-a-translate.mdx
+++ b/fern/pages/models/the-command-family-of-models/command-a-translate.mdx
@@ -45,11 +45,11 @@ print(response.message.content[0].text)
 
 Here’s a sample output:
 
-```python PYTHON 
+```mdx
 Las empresas dependen de la traducción para algunos de sus documentos más sensibles y críticos para su negocio y no pueden permitirse el riesgo de fugas de datos, incumplimientos normativos o malentendidos. Los documentos mal traducidos pueden reducir la confianza y tener implicaciones estratégicas.
 ```
 
 ## Conclusion 
-Command A Translate is great for one-shot translations but can also be embedded into more complicated workflows, such as translating long texts. Check out our cookbook for an example implementation.
+Command A Translate is great for one-shot translations but can also be embedded into more complicated workflows, such as translating long texts. Check out [our cookbook](https://docs.cohere.com/page/command-a-translate) for an example implementation.
 
-You may also be interested in Deep Translation, Cohere's agentic approach to reaching the highest-quality translations. You can reach out to our sales team about how to implement it.
+Cohere enterprise clients may be interested in Deep Translation, our agentic approach to reaching the highest-quality translations. You can reach out to our sales team for more information.


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the `fern/pages/models/the-command-family-of-models/command-a-translate.mdx` file.

**Summary of changes:**
- Changes the language from Python to mdx.
- Adds a link to the cookbook.
- Removes mention of Deep Translation and replaces it with Cohere enterprise clients.
- Removes the mention of the sales team and replaces it with a more general statement.

<!-- end-generated-description -->