### PR TITLE
Add reasoning code examples

### DIFF
--- a/notebooks/guides/reasoning/1_tool_use_basic_reasoning.ipynb
+++ b/notebooks/guides/reasoning/1_tool_use_basic_reasoning.ipynb
@@ -1,6 +1,24 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "43ed9350",
+   "metadata": {},
+   "source": [
+    "# Command A Reasoning - Basic Tool Use Example\n",
+    "\n",
+    "## Overview\n",
+    "This notebook demonstrates the fundamental concepts of tool use with Cohere's Command A reasoning model. You'll learn how to define tools, make function calls, handle responses, and work with the reasoning traces that show the model's decision-making process.\n",
+    "\n",
+    "## Contents\n",
+    "- Setting up basic tool definitions and function mappings\n",
+    "- Understanding tool schemas and parameter specifications\n",
+    "- Making your first tool call with reasoning traces\n",
+    "- Processing tool results and generating responses\n",
+    "- Working with citations and source attribution"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "be2b9a95",

--- a/notebooks/guides/reasoning/2_agent_web_search_reasoning.ipynb
+++ b/notebooks/guides/reasoning/2_agent_web_search_reasoning.ipynb
@@ -1,8 +1,25 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Command A Reasoning - Web Search Agent Example\n",
+    "\n",
+    "## Overview\n",
+    "This notebook demonstrates how to build a web search reasoning agent using Cohere's Command A reasoning model. The agent can search the internet for information (and in multiple steps if needed), reason through the results, and provide accurate, well-cited responses to user queries.\n",
+    "\n",
+    "## Contents\n",
+    "- Setting up the web search tool integration\n",
+    "- Configuring the reasoning agent with system prompts\n",
+    "- Implementing a basic agent with reasoning capabilities\n",
+    "- Handling search results and generating responses\n",
+    "- Working with citations and source attribution"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR adds two new Jupyter notebooks to the `notebooks/guides/reasoning` directory:

- `1_tool_use_basic_reasoning.ipynb`
- `2_agent_web_search_reasoning.ipynb`

The notebooks demonstrate the use of Cohere's Command A reasoning model for basic tool use and web search agent applications.

**Changes:**
- **Basic Tool Use Notebook (`1_tool_use_basic_reasoning.ipynb`):**
  - Demonstrates setting up basic tool definitions and function mappings.
  - Explains tool schemas and parameter specifications.
  - Shows how to make the first tool call with reasoning traces.
  - Covers processing tool results and generating responses.
  - Includes working with citations and source attribution.

- **Web Search Agent Notebook (`2_agent_web_search_reasoning.ipynb`):**
  - Demonstrates setting up web search tool integration.
  - Explains configuring the reasoning agent with system prompts.
  - Shows how to implement a basic agent with reasoning capabilities.
  - Covers handling search results and generating responses.
  - Includes working with citations and source attribution.

<!-- end-generated-description -->