### PR TITLE
Sep 2025 deprecation changelog

### DIFF
--- a/fern/pages/changelog/2025-09-16-announcing-major-command-deprecations.mdx
+++ b/fern/pages/changelog/2025-09-16-announcing-major-command-deprecations.mdx
@@ -1,0 +1,30 @@
+---
+title: "Announcing Major Command Deprecations"
+slug: "changelog/2025-09-15-major-command-deprecations"
+createdAt: "Mon Sep 15 2025 00:00:00 (MST)"
+hidden: false
+description: >-
+ This announcement covers a series of major deprecations, including of classic Command models, several parameters, and entire endpoints.
+---
+
+As part of our ongoing commitment to delivering advanced AI solutions, we are deprecating the following models, features, and API endpoints:
+
+Deprecated Models:
+- `command-light` (Use `command-r-08-2024` or `command-a-03-2025` instead).
+- `command` (Use `command-r-03-2024` or `command-r-plus-04-2024`).
+- summarize (Refer to https://docs.cohere.com/docs/summarizing-text#migration-from-summarize-to-chat-endpoint for alternatives).
+
+Retired Fine-Tuning Capabilities:
+All fine-tuning options via dashboard and API for models including `command-light`, `command`, `command-r`, `classify`, and `rerank` are being retired. Previously fine-tuned models will no longer be accessible.
+
+Deprecated Features and API Endpoints:
+- `/v1/connectors` (Managed connectors for RAG)
+- `/v1/chat` parameters: `connectors`, `search_queries_only`
+- `/v1/generate` (Legacy generative endpoint)
+- `/v1/summarize` (Legacy summarization endpoint)
+- `/v1/classify`
+- Slack App integration
+- Coral Web UI (chat.cohere.com)
+
+## Conclusion
+For questions, reach out to support@cohere.com

--- a/fern/pages/changelog/2025-09-16-announcing-major-command-deprecations.mdx
+++ b/fern/pages/changelog/2025-09-16-announcing-major-command-deprecations.mdx
@@ -10,6 +10,8 @@ description: >-
 As part of our ongoing commitment to delivering advanced AI solutions, we are deprecating the following models, features, and API endpoints:
 
 Deprecated Models:
+- `command-r-03-2024`  (and the alias `command-r`)
+- `command-r-plus-04-2024`  (and the alias `command-r-plus`)
 - `command-light` 
 - `command`
 - summarize (Refer to [the migration guide](https://docs.cohere.com/docs/summarizing-text#migration-from-summarize-to-chat-endpoint) for alternatives).

--- a/fern/pages/changelog/2025-09-16-announcing-major-command-deprecations.mdx
+++ b/fern/pages/changelog/2025-09-16-announcing-major-command-deprecations.mdx
@@ -26,6 +26,6 @@ Deprecated Features and API Endpoints:
 - `/v1/summarize` (Legacy summarization endpoint)
 - `/v1/classify`
 - Slack App integration
-- Coral Web UI (chat.cohere.com)
+- Coral Web UI (chat.cohere.com and coral.cohere.com)
 
 For questions, reach out to support@cohere.com

--- a/fern/pages/changelog/2025-09-16-announcing-major-command-deprecations.mdx
+++ b/fern/pages/changelog/2025-09-16-announcing-major-command-deprecations.mdx
@@ -14,7 +14,7 @@ Deprecated Models:
 - `command-r-plus-04-2024`  (and the alias `command-r-plus`)
 - `command-light` 
 - `command`
-- summarize (Refer to [the migration guide](https://docs.cohere.com/docs/summarizing-text#migration-from-summarize-to-chat-endpoint) for alternatives).
+- `summarize` (Refer to [the migration guide](https://docs.cohere.com/docs/summarizing-text#migration-from-summarize-to-chat-endpoint) for alternatives).
 
 For command model replacements, we recommend you use `command-r-08-2024`, `command-r-plus-08-2024`, or `command-a-03-2025` (which is the strongest-performing model across domains) instead. 
 

--- a/fern/pages/changelog/2025-09-16-announcing-major-command-deprecations.mdx
+++ b/fern/pages/changelog/2025-09-16-announcing-major-command-deprecations.mdx
@@ -12,7 +12,7 @@ As part of our ongoing commitment to delivering advanced AI solutions, we are de
 Deprecated Models:
 - `command-light` (Use `command-r-08-2024` or `command-a-03-2025` instead).
 - `command` (Use `command-r-03-2024` or `command-r-plus-04-2024`).
-- summarize (Refer to https://docs.cohere.com/docs/summarizing-text#migration-from-summarize-to-chat-endpoint for alternatives).
+- summarize (Refer to [the migration guide](https://docs.cohere.com/docs/summarizing-text#migration-from-summarize-to-chat-endpoint) for alternatives).
 
 Retired Fine-Tuning Capabilities:
 All fine-tuning options via dashboard and API for models including `command-light`, `command`, `command-r`, `classify`, and `rerank` are being retired. Previously fine-tuned models will no longer be accessible.

--- a/fern/pages/changelog/2025-09-16-announcing-major-command-deprecations.mdx
+++ b/fern/pages/changelog/2025-09-16-announcing-major-command-deprecations.mdx
@@ -26,5 +26,4 @@ Deprecated Features and API Endpoints:
 - Slack App integration
 - Coral Web UI (chat.cohere.com)
 
-## Conclusion
 For questions, reach out to support@cohere.com

--- a/fern/pages/changelog/2025-09-16-announcing-major-command-deprecations.mdx
+++ b/fern/pages/changelog/2025-09-16-announcing-major-command-deprecations.mdx
@@ -10,9 +10,11 @@ description: >-
 As part of our ongoing commitment to delivering advanced AI solutions, we are deprecating the following models, features, and API endpoints:
 
 Deprecated Models:
-- `command-light` (Use `command-r-08-2024` or `command-a-03-2025` instead).
-- `command` (Use `command-r-03-2024` or `command-r-plus-04-2024`).
+- `command-light` 
+- `command`
 - summarize (Refer to [the migration guide](https://docs.cohere.com/docs/summarizing-text#migration-from-summarize-to-chat-endpoint) for alternatives).
+
+For command model replacements, we recommend you use `command-r-08-2024`, `command-r-plus-08-2024`, or `command-a-03-2025` (which is the strongest-performing model across domains) instead. 
 
 Retired Fine-Tuning Capabilities:
 All fine-tuning options via dashboard and API for models including `command-light`, `command`, `command-r`, `classify`, and `rerank` are being retired. Previously fine-tuned models will no longer be accessible.

--- a/fern/pages/going-to-production/deprecations.mdx
+++ b/fern/pages/going-to-production/deprecations.mdx
@@ -28,6 +28,28 @@ To ensure a smooth transition, we recommend thorough testing of your application
 ## Deprecation History
 All deprecations are listed below with the most recent announcements at the top.
 
+### 2025-09-15: Various older command models, a number of endpoints, all of fine-tuning.
+Effective September 15, 2025, the following deprecatations will roll out.
+
+Deprecated Models:
+- `command-light (use `command-r-08-2024` or `command-a-03-2025` instead)
+- `command (use `command-r-03-2024` or `command-r-plus-04-2024`)
+- summarize (refer to migration guide for alternatives)
+
+Retired Fine-Tuning Capabilities:
+All fine-tuning options via dashboard and API for models including command-light, command, command-r, classify, and rerank are being retired. Previously fine-tuned models will no longer be accessible.
+
+Deprecated Features and API Endpoints:
+- `/v1/connectors` (Managed connectors for RAG)
+- `/v1/chat` parameters: `connectors`, `search_queries_only`
+- `/v1/generate` (Legacy generative endpoint)
+- `/v1/summarize` (Legacy summarization endpoint)
+- `/v1/classify`
+- Slack App integration
+- Coral Web UI (chat.cohere.com)
+
+These changes reflect our commitment to innovation and performance optimization. We encourage users to assess their current implementations and migrate to recommended alternatives. Our support team is available at support@cohere.com to assist with the transition. For detailed guidance, please refer to our migration resources and technical documentation.
+
 ### 2025-03-08: Command-R-03-2024 Fine-tuned Models
 
 On March 08, 2025, we will sunset all models fine-tuned with Command-R-03-2024. As part of our ongoing efforts to enhance our services, we are making the following changes to our fine-tuning capabilities:

--- a/fern/pages/going-to-production/deprecations.mdx
+++ b/fern/pages/going-to-production/deprecations.mdx
@@ -32,9 +32,11 @@ All deprecations are listed below with the most recent announcements at the top.
 Effective September 15, 2025, the following deprecatations will roll out.
 
 Deprecated Models:
+- `command-r-03-2024`  (and the alias `command-r`)
+- `command-r-plus-04-2024`  (and the alias `command-r-plus`)
 - `command-light` 
 - `command`
-- summarize (Refer to [the migration guide](https://docs.cohere.com/docs/summarizing-text#migration-from-summarize-to-chat-endpoint) for alternatives).
+- `summarize` (Refer to [the migration guide](https://docs.cohere.com/docs/summarizing-text#migration-from-summarize-to-chat-endpoint) for alternatives).
 
 For command model replacements, we recommend you use `command-r-08-2024`, `command-r-plus-08-2024`, or `command-a-03-2025` (which is the strongest-performing model across domains) instead. 
 
@@ -48,7 +50,7 @@ Deprecated Features and API Endpoints:
 - `/v1/summarize` (Legacy summarization endpoint)
 - `/v1/classify`
 - Slack App integration
-- Coral Web UI (chat.cohere.com)
+- Coral Web UI (chat.cohere.com and coral.cohere.com)
 
 These changes reflect our commitment to innovation and performance optimization. We encourage users to assess their current implementations and migrate to recommended alternatives. Our support team is available at support@cohere.com to assist with the transition. For detailed guidance, please refer to our migration resources and technical documentation.
 

--- a/fern/pages/going-to-production/deprecations.mdx
+++ b/fern/pages/going-to-production/deprecations.mdx
@@ -32,9 +32,11 @@ All deprecations are listed below with the most recent announcements at the top.
 Effective September 15, 2025, the following deprecatations will roll out.
 
 Deprecated Models:
-- `command-light` (use `command-r-08-2024` or `command-a-03-2025` instead)
-- `command` (use `command-r-03-2024` or `command-r-plus-04-2024`)
-- `summarize` (refer to [the migration guide](https://docs.cohere.com/docs/summarizing-text#migration-from-summarize-to-chat-endpoint) for alternatives)
+- `command-light` 
+- `command`
+- summarize (Refer to [the migration guide](https://docs.cohere.com/docs/summarizing-text#migration-from-summarize-to-chat-endpoint) for alternatives).
+
+For command model replacements, we recommend you use `command-r-08-2024`, `command-r-plus-08-2024`, or `command-a-03-2025` (which is the strongest-performing model across domains) instead. 
 
 Retired Fine-Tuning Capabilities:
 Fine-tuning for the `command-light`, `command`, `command-r`, `classify`, and `rerank` models is being retired. This covers both the Cohere dashboard and API. Previously fine-tuned models will no longer be accessible.

--- a/fern/pages/going-to-production/deprecations.mdx
+++ b/fern/pages/going-to-production/deprecations.mdx
@@ -32,12 +32,12 @@ All deprecations are listed below with the most recent announcements at the top.
 Effective September 15, 2025, the following deprecatations will roll out.
 
 Deprecated Models:
-- `command-light (use `command-r-08-2024` or `command-a-03-2025` instead)
-- `command (use `command-r-03-2024` or `command-r-plus-04-2024`)
-- summarize (refer to migration guide for alternatives)
+- `command-light` (use `command-r-08-2024` or `command-a-03-2025` instead)
+- `command` (use `command-r-03-2024` or `command-r-plus-04-2024`)
+- `summarize` (refer to [the migration guide](https://docs.cohere.com/docs/summarizing-text#migration-from-summarize-to-chat-endpoint) for alternatives)
 
 Retired Fine-Tuning Capabilities:
-All fine-tuning options via dashboard and API for models including command-light, command, command-r, classify, and rerank are being retired. Previously fine-tuned models will no longer be accessible.
+Fine-tuning for the `command-light`, `command`, `command-r`, `classify`, and `rerank` models is being retired. This covers both the Cohere dashboard and API. Previously fine-tuned models will no longer be accessible.
 
 Deprecated Features and API Endpoints:
 - `/v1/connectors` (Managed connectors for RAG)


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR introduces a new changelog entry and updates the existing deprecation history with the following changes:

- Deprecates the `command-light` and `command` models, recommending alternatives like `command-r-08-2024` and `command-a-03-2025` for `command-light`, and `command-r-03-2024` or `command-r-plus-04-2024` for `command`.
- Retires fine-tuning capabilities for models including `command-light`, `command`, `command-r`, `classify`, and `rerank`, making previously fine-tuned models inaccessible.
- Deprecates several API endpoints and features, including:
  - `/v1/connectors` (Managed connectors for RAG)
  - `/v1/chat` parameters: `connectors`, `search_queries_only`
  - `/v1/generate` (Legacy generative endpoint)
  - `/v1/summarize` (Legacy summarization endpoint)
  - `/v1/classify`
  - Slack App integration
  - Coral Web UI (chat.cohere.com)
- Provides a conclusion section with contact information for support.
- Encourages users to assess their implementations and migrate to recommended alternatives, offering support and resources for the transition.

<!-- end-generated-description -->