### PR TITLE
Add navigation link to command A techical report

### DIFF
--- a/fern/v1.yml
+++ b/fern/v1.yml
@@ -333,6 +333,8 @@ navigation:
             href: https://cohere.ai/security
           - page: Usage Policy
             path: pages/responsible-use/responsible-use/usage-guidelines.mdx 
+          - link: Command A Technical Report
+            href: https://cohere.com/research/papers/command-a-technical-report.pdf#page=46&zoom=100,62,620
           - page: Command R and Command R+ Model Card
             path: pages/responsible-use/responsible-use.mdx                      
       - section: Cohere Labs

--- a/fern/v2.yml
+++ b/fern/v2.yml
@@ -359,6 +359,8 @@ navigation:
             href: https://cohere.ai/security
           - page: Usage Policy
             path: pages/responsible-use/responsible-use/usage-guidelines.mdx
+          - link: Command A Technical Report
+            href: https://cohere.com/research/papers/command-a-technical-report.pdf#page=46&zoom=100,62,620
           - page: Command R and Command R+ Model Card
             path: pages/responsible-use/responsible-use.mdx   
       - section: Cohere Labs


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR adds a link to the Command A Technical Report in the navigation section of the v1.yml and v2.yml files.

- A new link to the Command A Technical Report has been added to the navigation section of the v1.yml and v2.yml files.
- The link points to the PDF file located at https://cohere.com/research/papers/command-a-technical-report.pdf#page=46&zoom=100,62,620.

<!-- end-generated-description -->