### PR TITLE
Reorder models in navigation

### DIFF
--- a/fern/v1.yml
+++ b/fern/v1.yml
@@ -56,14 +56,14 @@ navigation:
             contents:
               - page: Command A
                 path: pages/models/the-command-family-of-models/command-a.mdx
-              - page: Command R7B
-                path: pages/models/the-command-family-of-models/command-r7b.mdx
-              - page: Command A Translate
-                path: pages/models/the-command-family-of-models/command-a-translate.mdx
               - page: Command A Reasoning
                 path: pages/models/the-command-family-of-models/command-a-reasoning.mdx
+              - page: Command A Translate
+                path: pages/models/the-command-family-of-models/command-a-translate.mdx
               - page: Command A Vision
                 path: pages/models/the-command-family-of-models/command-a-vision.mdx
+              - page: Command R7B
+                path: pages/models/the-command-family-of-models/command-r7b.mdx
               - page: Command R+
                 path: pages/models/the-command-family-of-models/command-r-plus.mdx
               - page: Command R

--- a/fern/v2.yml
+++ b/fern/v2.yml
@@ -56,14 +56,14 @@ navigation:
             contents:
               - page: Command A
                 path: pages/models/the-command-family-of-models/command-a.mdx
-              - page: Command R7B
-                path: pages/models/the-command-family-of-models/command-r7b.mdx
-              - page: Command A Translate
-                path: pages/models/the-command-family-of-models/command-a-translate.mdx
               - page: Command A Reasoning
                 path: pages/models/the-command-family-of-models/command-a-reasoning.mdx
+              - page: Command A Translate
+                path: pages/models/the-command-family-of-models/command-a-translate.mdx
               - page: Command A Vision
                 path: pages/models/the-command-family-of-models/command-a-vision.mdx
+              - page: Command R7B
+                path: pages/models/the-command-family-of-models/command-r7b.mdx
               - page: Command R+
                 path: pages/models/the-command-family-of-models/command-r-plus.mdx
               - page: Command R


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR reorders the navigation structure in the `fern/v1.yml` and `fern/v2.yml` files.

- `Command A Translate` is moved above `Command A Reasoning` and `Command A Vision` in both files.
- `Command R7B` is moved below `Command A Vision` in both files.

<!-- end-generated-description -->