### PR TITLE
Mark fine-tuning pages as hidden for each page separately

### DIFF
--- a/fern/v1.yml
+++ b/fern/v1.yml
@@ -176,50 +176,6 @@ navigation:
                 path: pages/text-embeddings/reranking/overview.mdx
               - page: Rerank Best Practices
                 path: pages/text-embeddings/reranking/reranking-best-practices.mdx
-      - section: Fine-Tuning
-        hidden: true
-        contents:
-          - page: Introduction
-            path: pages/fine-tuning/fine-tuning.mdx
-          - page: Fine-tuning with the Web-UI
-            path: pages/fine-tuning/fine-tuning-with-the-cohere-dashboard.mdx
-          - page: Programmatic Fine-tuning
-            path: pages/fine-tuning/fine-tuning-with-the-python-sdk.mdx
-          - section: Fine-tuning for Chat
-            path: pages/fine-tuning/chat-fine-tuning.mdx
-            contents:
-              - page: Preparing the Chat Fine-tuning Data
-                path: pages/fine-tuning/chat-fine-tuning/chat-preparing-the-data.mdx
-              - page: Starting the Chat Fine-Tuning
-                path: pages/fine-tuning/chat-fine-tuning/chat-starting-the-training.mdx
-              - page: Understanding the Chat Fine-tuning Results
-                path: pages/fine-tuning/chat-fine-tuning/chat-understanding-the-results.mdx
-              - page: Improving the Chat Fine-tuning Results
-                path: pages/fine-tuning/chat-fine-tuning/chat-improving-the-results.mdx
-          - section: Fine-tuning for Rerank
-            path: pages/fine-tuning/rerank-fine-tuning.mdx
-            contents:
-              - page: Preparing the Rerank Fine-tuning Data
-                path: pages/fine-tuning/rerank-fine-tuning/rerank-preparing-the-data.mdx
-              - page: Starting the Rerank Fine-Tuning
-                path: pages/fine-tuning/rerank-fine-tuning/rerank-starting-the-training.mdx
-              - page: Understanding the Rerank Fine-tuning Results
-                path: pages/fine-tuning/rerank-fine-tuning/rerank-understanding-the-results.mdx
-              - page: Improving the Rerank Fine-tuning Results
-                path: pages/fine-tuning/rerank-fine-tuning/rerank-improving-the-results.mdx
-          - section: Fine-tuning for Classify
-            path: pages/fine-tuning/classify-fine-tuning.mdx
-            contents:
-              - page: Preparing the Classify Fine-tuning data
-                path: pages/fine-tuning/classify-fine-tuning/classify-preparing-the-data.mdx
-              - page: Training and deploying a fine-tuned model
-                path: pages/fine-tuning/classify-fine-tuning/classify-starting-the-training.mdx
-              - page: Understanding the Classify Fine-tuning Results
-                path: pages/fine-tuning/classify-fine-tuning/classify-understanding-the-results.mdx
-              - page: Improving the Classify Fine-tuning Results
-                path: pages/fine-tuning/classify-fine-tuning/classify-improving-the-results.mdx
-          - page: FAQs / Troubleshooting
-            path: pages/fine-tuning/troubleshooting-a-fine-tuned-model.mdx
       - section: Going to Production
         contents:
           - page: API Keys and Rate Limits
@@ -620,6 +576,63 @@ navigation:
       - page: Top-k & Top-p
         hidden: true
         path: pages/-ARCHIVE-/controlling-generation-with-top-k-top-p.mdx
+      - page: Introduction
+        path: pages/fine-tuning/fine-tuning.mdx
+        hidden: true
+      - page: Fine-tuning with the Web-UI
+        path: pages/fine-tuning/fine-tuning-with-the-cohere-dashboard.mdx
+        hidden: true
+      - page: Programmatic Fine-tuning
+        path: pages/fine-tuning/fine-tuning-with-the-python-sdk.mdx
+        hidden: true
+      - page: Fine-tuning for Chat
+        path: pages/fine-tuning/chat-fine-tuning.mdx
+        hidden: true
+      - page: Preparing the Chat Fine-tuning Data
+        path: pages/fine-tuning/chat-fine-tuning/chat-preparing-the-data.mdx
+        hidden: true
+      - page: Starting the Chat Fine-Tuning
+        path: pages/fine-tuning/chat-fine-tuning/chat-starting-the-training.mdx
+        hidden: true
+      - page: Understanding the Chat Fine-tuning Results
+        path: pages/fine-tuning/chat-fine-tuning/chat-understanding-the-results.mdx
+        hidden: true
+      - page: Improving the Chat Fine-tuning Results
+        path: pages/fine-tuning/chat-fine-tuning/chat-improving-the-results.mdx
+        hidden: true
+      - page: Fine-tuning for Rerank
+        path: pages/fine-tuning/rerank-fine-tuning.mdx
+        hidden: true
+      - page: Preparing the Rerank Fine-tuning Data
+        path: pages/fine-tuning/rerank-fine-tuning/rerank-preparing-the-data.mdx
+        hidden: true
+      - page: Starting the Rerank Fine-Tuning
+        path: pages/fine-tuning/rerank-fine-tuning/rerank-starting-the-training.mdx
+        hidden: true
+      - page: Understanding the Rerank Fine-tuning Results
+        path: pages/fine-tuning/rerank-fine-tuning/rerank-understanding-the-results.mdx
+        hidden: true
+      - page: Improving the Rerank Fine-tuning Results
+        path: pages/fine-tuning/rerank-fine-tuning/rerank-improving-the-results.mdx
+        hidden: true
+      - page: Fine-tuning for Classify
+        path: pages/fine-tuning/classify-fine-tuning.mdx
+        hidden: true
+      - page: Preparing the Classify Fine-tuning data
+        path: pages/fine-tuning/classify-fine-tuning/classify-preparing-the-data.mdx
+        hidden: true
+      - page: Training and deploying a fine-tuned model
+        path: pages/fine-tuning/classify-fine-tuning/classify-starting-the-training.mdx
+        hidden: true
+      - page: Understanding the Classify Fine-tuning Results
+        path: pages/fine-tuning/classify-fine-tuning/classify-understanding-the-results.mdx
+        hidden: true
+      - page: Improving the Classify Fine-tuning Results
+        path: pages/fine-tuning/classify-fine-tuning/classify-improving-the-results.mdx
+        hidden: true
+      - page: FAQs / Troubleshooting
+        path: pages/fine-tuning/troubleshooting-a-fine-tuned-model.mdx
+        hidden: true
   - tab: api
     layout:
       - section: Cohere API

--- a/fern/v2.yml
+++ b/fern/v2.yml
@@ -174,50 +174,6 @@ navigation:
                 path: pages/v2/text-embeddings/reranking/overview.mdx
               - page: Rerank Best Practices
                 path: pages/v2/text-embeddings/reranking/reranking-best-practices.mdx
-      - section: Fine-Tuning
-        hidden: true
-        contents:
-          - page: Introduction
-            path: pages/fine-tuning/fine-tuning.mdx
-          - page: Fine-tuning with the Web-UI
-            path: pages/fine-tuning/fine-tuning-with-the-cohere-dashboard.mdx
-          - page: Programmatic Fine-tuning
-            path: pages/v2/fine-tuning/fine-tuning-with-the-python-sdk.mdx
-          - section: Fine-tuning for Chat
-            path: pages/fine-tuning/chat-fine-tuning.mdx
-            contents:
-              - page: Preparing the Chat Fine-tuning Data
-                path: pages/v2/fine-tuning/chat-fine-tuning/chat-preparing-the-data.mdx
-              - page: Starting the Chat Fine-Tuning
-                path: pages/v2/fine-tuning/chat-fine-tuning/chat-starting-the-training.mdx
-              - page: Understanding the Chat Fine-tuning Results
-                path: pages/fine-tuning/chat-fine-tuning/chat-understanding-the-results.mdx
-              - page: Improving the Chat Fine-tuning Results
-                path: pages/fine-tuning/chat-fine-tuning/chat-improving-the-results.mdx
-          - section: Fine-tuning for Rerank
-            path: pages/fine-tuning/rerank-fine-tuning.mdx
-            contents:
-              - page: Preparing the Rerank Fine-tuning Data
-                path: pages/v2/fine-tuning/rerank-fine-tuning/rerank-preparing-the-data.mdx
-              - page: Starting the Rerank Fine-Tuning
-                path: pages/v2/fine-tuning/rerank-fine-tuning/rerank-starting-the-training.mdx
-              - page: Understanding the Rerank Fine-tuning Results
-                path: pages/fine-tuning/rerank-fine-tuning/rerank-understanding-the-results.mdx
-              - page: Improving the Rerank Fine-tuning Results
-                path: pages/fine-tuning/rerank-fine-tuning/rerank-improving-the-results.mdx
-          - section: Fine-tuning for Classify
-            path: pages/fine-tuning/classify-fine-tuning.mdx
-            contents:
-              - page: Preparing the Classify Fine-tuning data
-                path: pages/v2/fine-tuning/classify-fine-tuning/classify-preparing-the-data.mdx
-              - page: Train and deploy a fine-tuned model
-                path: pages/v2/fine-tuning/classify-fine-tuning/classify-starting-the-training.mdx
-              - page: Understanding the Classify Fine-tuning Results
-                path: pages/fine-tuning/classify-fine-tuning/classify-understanding-the-results.mdx
-              - page: Improving the Classify Fine-tuning Results
-                path: pages/fine-tuning/classify-fine-tuning/classify-improving-the-results.mdx
-          - page: FAQs / Troubleshooting
-            path: pages/fine-tuning/troubleshooting-a-fine-tuned-model.mdx
       - section: Going to Production
         contents:
           - page: API Keys and Rate Limits
@@ -649,6 +605,63 @@ navigation:
       - page: Top-k & Top-p
         hidden: true
         path: pages/-ARCHIVE-/controlling-generation-with-top-k-top-p.mdx
+      - page: Introduction
+        path: pages/fine-tuning/fine-tuning.mdx
+        hidden: true
+      - page: Fine-tuning with the Web-UI
+        path: pages/fine-tuning/fine-tuning-with-the-cohere-dashboard.mdx
+        hidden: true
+      - page: Programmatic Fine-tuning
+        path: pages/v2/fine-tuning/fine-tuning-with-the-python-sdk.mdx
+        hidden: true
+      - page: Fine-tuning for Chat
+        path: pages/fine-tuning/chat-fine-tuning.mdx
+        hidden: true
+      - page: Preparing the Chat Fine-tuning Data
+        path: pages/v2/fine-tuning/chat-fine-tuning/chat-preparing-the-data.mdx
+        hidden: true
+      - page: Starting the Chat Fine-Tuning
+        path: pages/v2/fine-tuning/chat-fine-tuning/chat-starting-the-training.mdx
+        hidden: true
+      - page: Understanding the Chat Fine-tuning Results
+        path: pages/fine-tuning/chat-fine-tuning/chat-understanding-the-results.mdx
+        hidden: true
+      - page: Improving the Chat Fine-tuning Results
+        path: pages/fine-tuning/chat-fine-tuning/chat-improving-the-results.mdx
+        hidden: true
+      - page: Fine-tuning for Rerank
+        path: pages/fine-tuning/rerank-fine-tuning.mdx
+        hidden: true
+      - page: Preparing the Rerank Fine-tuning Data
+        path: pages/v2/fine-tuning/rerank-fine-tuning/rerank-preparing-the-data.mdx
+        hidden: true
+      - page: Starting the Rerank Fine-Tuning
+        path: pages/v2/fine-tuning/rerank-fine-tuning/rerank-starting-the-training.mdx
+        hidden: true
+      - page: Understanding the Rerank Fine-tuning Results
+        path: pages/fine-tuning/rerank-fine-tuning/rerank-understanding-the-results.mdx
+        hidden: true
+      - page: Improving the Rerank Fine-tuning Results
+        path: pages/fine-tuning/rerank-fine-tuning/rerank-improving-the-results.mdx
+        hidden: true
+      - page: Fine-tuning for Classify
+        path: pages/fine-tuning/classify-fine-tuning.mdx
+        hidden: true
+      - page: Preparing the Classify Fine-tuning data
+        path: pages/v2/fine-tuning/classify-fine-tuning/classify-preparing-the-data.mdx
+        hidden: true
+      - page: Train and deploy a fine-tuned model
+        path: pages/v2/fine-tuning/classify-fine-tuning/classify-starting-the-training.mdx
+        hidden: true
+      - page: Understanding the Classify Fine-tuning Results
+        path: pages/fine-tuning/classify-fine-tuning/classify-understanding-the-results.mdx
+        hidden: true
+      - page: Improving the Classify Fine-tuning Results
+        path: pages/fine-tuning/classify-fine-tuning/classify-improving-the-results.mdx
+        hidden: true
+      - page: FAQs / Troubleshooting
+        path: pages/fine-tuning/troubleshooting-a-fine-tuned-model.mdx
+        hidden: true
   - tab: api
     layout:
       - section: Cohere API


### PR DESCRIPTION
Looks like there's an issue with hidden fine-tuning pages, those pages returns 404 and do not accessible via direct links.
So I splitted section into separate pages and hide those