### PR TITLE
Remove pricing information from new command-a models

### DIFF
--- a/fern/components/model-showcase.tsx
+++ b/fern/components/model-showcase.tsx
@@ -126,7 +126,7 @@ type Model = {
   description: string;
   longDescription?: string;
   capabilities: Capability[];
-  pricing: { input: number; output: number };
+  pricing?: { input: number; output: number };
   specs: { contextWindow: number; maxOutputTokens: number; knowledgeCutoff: string, customSpecs: { name: string; value: string }[] };
   endpoints: Endpoint[];
 };
@@ -173,16 +173,31 @@ export const ModelShowcase = ({ model }: { model: Model }) => (
 
       {/* Pricing */}
       <Card title="Pricing" icon={IconCoins}>
-        <div className="grid grid-cols-2 gap-4 text-center">
-          <div>
-            <div className="text-sm text-gray-500">Input</div>
-            <p className="text-lg font-medium">${model.pricing.input} / 1M tokens</p>
+        {model.pricing ? (
+          <div className="grid grid-cols-2 gap-4 text-center">
+            <div>
+              <div className="text-sm text-gray-500">Input</div>
+              <p className="text-lg font-medium">${model.pricing.input} / 1M tokens</p>
+            </div>
+            <div>
+              <div className="text-sm text-gray-500">Output</div>
+              <p className="text-lg font-medium">${model.pricing.output} / 1M tokens</p>
+            </div>
           </div>
-          <div>
-            <div className="text-sm text-gray-500">Output</div>
-            <p className="text-lg font-medium">${model.pricing.output} / 1M tokens</p>
+        ) : (
+          <div className="text-sm text-gray-600">
+            <p className="mb-3">
+              <strong>{model.name}</strong> is available for free trial usage up to rate limits.
+            </p>
+            <p>
+              For production usage, please reach out to sales at{' '}
+              <a href="mailto:sales@cohere.com" className="text-blue-600 hover:text-blue-800 underline">
+                sales@cohere.com
+              </a>
+              .
+            </p>
           </div>
-        </div>
+        )}
       </Card>
 
       {/* Specs */}

--- a/fern/pages/models/the-command-family-of-models/command-a-reasoning.mdx
+++ b/fern/pages/models/the-command-family-of-models/command-a-reasoning.mdx
@@ -24,7 +24,6 @@ import { ModelShowcase, Capability, Endpoint} from "../../../components/model-sh
     Capability.StructuredOutputs,
     Capability.Multilingual,
   ],
-  pricing: { input: 2.50, output: 10.0 },
   specs: {
     contextWindow: '256,000',
     maxOutputTokens: '32,000',

--- a/fern/pages/models/the-command-family-of-models/command-a-translate.mdx
+++ b/fern/pages/models/the-command-family-of-models/command-a-translate.mdx
@@ -22,7 +22,6 @@ import { ModelShowcase, Capability, Endpoint} from "../../../components/model-sh
     Capability.StructuredOutputs,
     Capability.Multilingual,
   ],
-  pricing: { input: 2.50, output: 10.0 },
   specs: {
     contextWindow: '8,000',
     maxOutputTokens: '8,000',

--- a/fern/pages/models/the-command-family-of-models/command-a-vision.mdx
+++ b/fern/pages/models/the-command-family-of-models/command-a-vision.mdx
@@ -23,7 +23,6 @@ import { ModelShowcase, Capability, Endpoint} from "../../../components/model-sh
     Capability.Multilingual,
     Capability.ImageInputs
   ],
-  pricing: { input: 2.50, output: 10.0 },
   specs: {
     contextWindow: '128,000',
     maxOutputTokens: '8,000',


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the pricing display logic in the ModelShowcase component and removes pricing information from specific model pages.

- **ModelShowcase Component**:
  - Made the `pricing` field optional in the `Model` type.
  - Updated the pricing section to conditionally render pricing details or a free trial message based on the presence of `model.pricing`.
  - If pricing is available, it displays input and output costs per 1M tokens.
  - If pricing is not available, it shows a message about free trial usage and instructions for production usage.

- **Model Pages**:
  - Removed pricing information from the Command-A-Reasoning, Command-A-Translate, and Command-A-Vision model pages.

<!-- end-generated-description -->