### PR TITLE
Update pricing text for command a models

### DIFF
--- a/fern/components/model-showcase.tsx
+++ b/fern/components/model-showcase.tsx
@@ -187,10 +187,14 @@ export const ModelShowcase = ({ model }: { model: Model }) => (
         ) : (
           <div className="text-sm text-gray-600">
             <p className="mb-3">
-              <strong>{model.name}</strong> is available for free trial usage up to rate limits.
+              For both trial keys and production keys, {model.name} is free until rate limits are reached. Learn more about rate limits for different models and key types{' '}
+              <a href="https://docs.cohere.com/docs/rate-limits" className="text-blue-600 hover:text-blue-800 underline" target="_blank" rel="noopener noreferrer">
+                here
+              </a>
+              .
             </p>
             <p>
-              For production usage, please reach out to sales at{' '}
+              To use {model.name} in production, please reach out to sales at{' '}
               <a href="mailto:sales@cohere.com" className="text-blue-600 hover:text-blue-800 underline">
                 sales@cohere.com
               </a>


### PR DESCRIPTION
<!-- begin-generated-description -->

**Description**

This PR updates the `model-showcase.tsx` file to provide clearer information about rate limits for different models and key types.

**Changes**

- The text `{model.name} is available for free trial usage up to rate limits.` has been replaced with `For both trial keys and production keys, {model.name} is free until rate limits are reached. Learn more about rate limits for different models and key types here.`.
- A hyperlink has been added to the text `here` which links to `https://docs.cohere.com/docs/rate-limits`.
- The text `For production usage, please reach out to sales at` has been replaced with `To use {model.name} in production, please reach out to sales at`.

<!-- end-generated-description -->