### PR TITLE
Bump Fern CLI version

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "cohere",
-  "version": "0.64.25"
+  "version": "0.79.0"
 }


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the version of the fern.config.json file.

- The version has been updated from 0.64.25 to 0.79.0.

<!-- end-generated-description -->