### PR TITLE
Update reasoning_effort support for compatibility api

### DIFF
--- a/fern/pages/v2/text-generation/compatibility-api.mdx
+++ b/fern/pages/v2/text-generation/compatibility-api.mdx
@@ -799,6 +799,7 @@ The following is the list supported parameters in the Compatibility API, includi
 - `model`
 - `messages`
 - `stream`
+- `reasoning_effort` (Only "none" and "high" are currently supported.)
 - `response_format`
 - `tools`
 - `temperature`
@@ -808,6 +809,11 @@ The following is the list supported parameters in the Compatibility API, includi
 - `top_p`
 - `frequency_penalty`
 - `presence_penalty`
+
+> **Note**  
+> Currently, only **`none`** and **`high`** are supported for `reasoning_effort`.  
+> These correspond to passing `{ thinking: { type: "disabled" \| "enabled" } }` in Chat V2.  
+> Passing **`medium`** or **`low`** is **not supported** at this time.
 
 
 ### Embeddings
@@ -823,7 +829,6 @@ The following parameters are not supported in the Compatibility API:
 ### Chat completions
 
 - `store`
-- `reasoning_effort`
 - `metadata`
 - `logit_bias`
 - `top_logprobs`


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR adds the `reasoning_effort` parameter to the list of supported parameters in the Compatibility API. It also adds a note to clarify that only `none` and `high` are supported for `reasoning_effort` and that passing `medium` or `low` is not supported.

- Adds `reasoning_effort` to the list of supported parameters in the Compatibility API.
- Adds a note to clarify that only `none` and `high` are supported for `reasoning_effort` and that passing `medium` or `low` is not supported.
- Removes `reasoning_effort` from the list of unsupported parameters in the Compatibility API.

<!-- end-generated-description -->