### PR TITLE
Use warning component for reasoning effort note

### DIFF
--- a/fern/pages/v2/text-generation/compatibility-api.mdx
+++ b/fern/pages/v2/text-generation/compatibility-api.mdx
@@ -811,8 +811,8 @@ The following is the list supported parameters in the Compatibility API, includi
 - `presence_penalty`
 
 <Warning title="Note">  
-Currently, only **`none`** and **`high`** are supported for `reasoning_effort`.
-These correspond to enabling or disabling `thinking` in the Cohere Chat API.
+Currently, only **`none`** and **`high`** are supported for `reasoning_effort`.  
+These correspond to enabling or disabling `thinking` in the Cohere Chat API.  
 Passing **`medium`** or **`low`** is **not supported** at this time.
 </Warning>
 


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the compatibility API documentation by reformatting the note on supported values for `reasoning_effort` into a warning box.

- Replaces the note on supported values for `reasoning_effort` with a warning box.
- Retains the original content within the warning box.

<!-- end-generated-description -->