### PR TITLE
🌿Fern Support: Bump Python Generator Version

### DIFF
--- a/fern/apis/sdks/generators.yml
+++ b/fern/apis/sdks/generators.yml
@@ -93,7 +93,7 @@ groups:
       - sdk-only
     generators:
       - name: fernapi/fern-python-sdk
-        version: 4.21.2
+        version: 4.32.2
         smart-casing: true
         config:
           pyproject_python_version: "^3.9"


### PR DESCRIPTION
<!-- begin-generated-description -->

**Description**
The version of the fernapi/fern-python-sdk generator has been updated from 4.21.2 to 4.32.2.

**Changes**
- The version of the fernapi/fern-python-sdk generator has been updated from 4.21.2 to 4.32.2.

<!-- end-generated-description -->