### PR TITLE
update chat rate limit wording

### DIFF
--- a/fern/pages/going-to-production/rate-limits.mdx
+++ b/fern/pages/going-to-production/rate-limits.mdx
@@ -17,7 +17,7 @@ The table below shows the rate limits for each endpoint, expressed in requests p
 
 | Endpoint                                   | Trial rate limit      | Production rate limit |
 | ------------------------------------------ | --------------------- | --------------------- |
-| [Chat](/reference/chat)                    | 20/min                | 500/min               |
+| [Chat](/reference/chat)                    | 10/min                | 500/min               |
 | [Embed](/reference/embed)                  | 100/min               | 2,000/min             |
 | [Embed (Images)](/reference/embed)         | 5/min                 | 400/min               |
 | [Rerank](/reference/rerank)                | 10/min                | 1,000/min             |


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the rate limits for the Chat endpoint in the `fern/pages/going-to-production/rate-limits.mdx` file.

- The Trial rate limit for the Chat endpoint has been reduced from 20/min to 10/min.
- The Production rate limit for the Chat endpoint remains unchanged at 500/min.

<!-- end-generated-description -->