### PR TITLE
bump go generator ver

### DIFF
--- a/fern/apis/sdks/generators.yml
+++ b/fern/apis/sdks/generators.yml
@@ -57,7 +57,7 @@ groups:
       - sdk-only
     generators:
       - name: fernapi/fern-go-sdk
-        version: 1.14.1
+        version: 1.21.2
         github:
           repository: cohere-ai/cohere-go
           mode: pull-request


### PR DESCRIPTION
<!-- begin-generated-description -->

**Description**
The version of the generator has been updated from 1.14.1 to 1.21.2.

**Changes**
- The version of the generator has been updated from 1.14.1 to 1.21.2.

<!-- end-generated-description -->