### PR TITLE
Fix R-command capabilties cards

### DIFF
--- a/fern/pages/models/the-command-family-of-models/command-r-plus.mdx
+++ b/fern/pages/models/the-command-family-of-models/command-r-plus.mdx
@@ -18,7 +18,6 @@ import { ModelShowcase, Capability, Endpoint} from "../../../components/model-sh
   name: 'Command R+',
   id: 'command-r-plus-08-2024',
   capabilities: [
-    Capability.Reasoning,
     Capability.SafetyModes,
     Capability.Citations,
     Capability.ToolUse,

--- a/fern/pages/models/the-command-family-of-models/command-r.mdx
+++ b/fern/pages/models/the-command-family-of-models/command-r.mdx
@@ -20,7 +20,6 @@ import { ModelShowcase, Capability, Endpoint} from "../../../components/model-sh
   name: 'Command R',
   id: 'command-r-08-2024',
   capabilities: [
-    Capability.Reasoning,
     Capability.SafetyModes,
     Capability.Citations,
     Capability.ToolUse,

--- a/fern/pages/models/the-command-family-of-models/command-r7b.mdx
+++ b/fern/pages/models/the-command-family-of-models/command-r7b.mdx
@@ -18,7 +18,6 @@ import { ModelShowcase, Capability, Endpoint} from "../../../components/model-sh
   name: 'Command R7B',
   id: 'command-r7b-12-2024',
   capabilities: [
-    Capability.Reasoning,
     Capability.Multilingual,
     Capability.ToolUse,
     Capability.Citation,


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR removes the `Capability.Reasoning` from the `capabilities` array in the `command-r-plus.mdx`, `command-r.mdx`, and `command-r7b.mdx` files.

- The `Capability.Reasoning` has been removed from the `capabilities` array in the `command-r-plus.mdx` file.
- The `Capability.Reasoning` has been removed from the `capabilities` array in the `command-r.mdx` file.
- The `Capability.Reasoning` has been removed from the `capabilities` array in the `command-r7b.mdx` file.

<!-- end-generated-description -->