### PR TITLE
Fix basic-tool-use cookbooks

### DIFF
--- a/fern/pages/cookbooks/basic-tool-use.mdx
+++ b/fern/pages/cookbooks/basic-tool-use.mdx
@@ -165,7 +165,7 @@ response = co.chat(
     message=message,
     tools=tools,
     preamble=preamble,
-    model="command-r"
+    model="command-a-03-2025",
 )
 
 
@@ -175,16 +175,8 @@ print("\n".join(str(tool_call) for tool_call in response.tool_calls))
 
 ```
 The model recommends doing the following tool calls:
-cohere.ToolCall {
-	name: query_daily_sales_report
-	parameters: {'day': '2023-09-29'}
-	generation_id: eaf955e3-623d-4796-bf51-23b07c66ed2c
-}
-cohere.ToolCall {
-	name: query_product_catalog
-	parameters: {'category': 'Electronics'}
-	generation_id: eaf955e3-623d-4796-bf51-23b07c66ed2c
-}
+name='query_daily_sales_report' parameters={'day': '2023-09-29'}
+name='query_product_catalog' parameters={'category': 'Electronics'}
 ```
 
 ## Step 3 – The tool calls are executed
@@ -208,7 +200,9 @@ for tool_call in response.tool_calls:
     })
 
 print("Tool results that will be fed back to the model in step 4:")
-print(json.dumps(tool_results, indent=4))
+
+serializable_results = [{"call": {"name": r["call"].name, "parameters": r["call"].parameters}, "outputs": r["outputs"]} for r in tool_results]
+print(json.dumps(serializable_results, indent=4))
 ```
 
 ```
@@ -223,8 +217,7 @@ Tool results that will be fed back to the model in step 4:
             "name": "query_daily_sales_report",
             "parameters": {
                 "day": "2023-09-29"
-            },
-            "generation_id": "eaf955e3-623d-4796-bf51-23b07c66ed2c"
+            }
         },
         "outputs": [
             {
@@ -238,8 +231,7 @@ Tool results that will be fed back to the model in step 4:
             "name": "query_product_catalog",
             "parameters": {
                 "category": "Electronics"
-            },
-            "generation_id": "eaf955e3-623d-4796-bf51-23b07c66ed2c"
+            }
         },
         "outputs": [
             {
@@ -280,8 +272,9 @@ response = co.chat(
     tools=tools,
     tool_results=tool_results,
     preamble=preamble,
-    model="command-r",
-    temperature=0.3
+    model="command-a-03-2025",
+    temperature=0.3,
+    force_single_step=True
 )
 ```
 
@@ -292,17 +285,15 @@ print(response.text)
 
 ```
 Final answer:
-On the 29th of September 2023, there were 10,000 sales with 250 units sold.
+On the 29th September 2023, the total sales amount was 10,000 and the total units sold was 250.
 
-The Electronics category contains three products. There are details below:
+Here are the details of the products in the 'Electronics' category:
 
-| Product Name | Price | Stock Level |
-| ------------ | ----- | ----------- |
-| Smartphone | 500 | 20 |
-| Laptop | 1000 | 15 |
-| Tablet | 300 | 25 |
-
-The total stock level for Electronics items is 50.
+| Product Name | Price | Product ID | Stock Level |
+|---|---|---|---|
+| Smartphone | 500 | E1001 | 20 |
+| Laptop | 1000 | E1002 | 15 |
+| Tablet | 300 | E1003 | 25 |
 ```
 
 ## Bonus: Citations come for free with Cohere! 🎉
@@ -321,18 +312,25 @@ for cite in response.citations:
 
 ```
 Citations that support the final answer:
-{'start': 7, 'end': 29, 'text': '29th of September 2023', 'document_ids': ['query_daily_sales_report:0:0']}
-{'start': 42, 'end': 75, 'text': '10,000 sales with 250 units sold.', 'document_ids': ['query_daily_sales_report:0:0']}
-{'start': 112, 'end': 127, 'text': 'three products.', 'document_ids': ['query_product_catalog:1:0']}
-{'start': 234, 'end': 244, 'text': 'Smartphone', 'document_ids': ['query_product_catalog:1:0']}
-{'start': 247, 'end': 250, 'text': '500', 'document_ids': ['query_product_catalog:1:0']}
-{'start': 253, 'end': 255, 'text': '20', 'document_ids': ['query_product_catalog:1:0']}
-{'start': 260, 'end': 266, 'text': 'Laptop', 'document_ids': ['query_product_catalog:1:0']}
-{'start': 269, 'end': 273, 'text': '1000', 'document_ids': ['query_product_catalog:1:0']}
-{'start': 276, 'end': 278, 'text': '15', 'document_ids': ['query_product_catalog:1:0']}
-{'start': 283, 'end': 289, 'text': 'Tablet', 'document_ids': ['query_product_catalog:1:0']}
-{'start': 292, 'end': 295, 'text': '300', 'document_ids': ['query_product_catalog:1:0']}
-{'start': 298, 'end': 300, 'text': '25', 'document_ids': ['query_product_catalog:1:0']}
+{'start': 7, 'end': 26, 'text': '29th September 2023', 'document_ids': ['query_daily_sales_report:0:0']}
+{'start': 32, 'end': 61, 'text': 'total sales amount was 10,000', 'document_ids': ['query_daily_sales_report:0:0']}
+{'start': 70, 'end': 95, 'text': 'total units sold was 250.', 'document_ids': ['query_daily_sales_report:0:0']}
+{'start': 168, 'end': 180, 'text': 'Product Name', 'document_ids': ['query_product_catalog:1:0']}
+{'start': 183, 'end': 188, 'text': 'Price', 'document_ids': ['query_product_catalog:1:0']}
+{'start': 191, 'end': 201, 'text': 'Product ID', 'document_ids': ['query_product_catalog:1:0']}
+{'start': 204, 'end': 215, 'text': 'Stock Level', 'document_ids': ['query_product_catalog:1:0']}
+{'start': 238, 'end': 248, 'text': 'Smartphone', 'document_ids': ['query_product_catalog:1:0']}
+{'start': 251, 'end': 254, 'text': '500', 'document_ids': ['query_product_catalog:1:0']}
+{'start': 257, 'end': 262, 'text': 'E1001', 'document_ids': ['query_product_catalog:1:0']}
+{'start': 265, 'end': 267, 'text': '20', 'document_ids': ['query_product_catalog:1:0']}
+{'start': 272, 'end': 278, 'text': 'Laptop', 'document_ids': ['query_product_catalog:1:0']}
+{'start': 281, 'end': 285, 'text': '1000', 'document_ids': ['query_product_catalog:1:0']}
+{'start': 288, 'end': 293, 'text': 'E1002', 'document_ids': ['query_product_catalog:1:0']}
+{'start': 296, 'end': 298, 'text': '15', 'document_ids': ['query_product_catalog:1:0']}
+{'start': 303, 'end': 309, 'text': 'Tablet', 'document_ids': ['query_product_catalog:1:0']}
+{'start': 312, 'end': 315, 'text': '300', 'document_ids': ['query_product_catalog:1:0']}
+{'start': 318, 'end': 323, 'text': 'E1003', 'document_ids': ['query_product_catalog:1:0']}
+{'start': 326, 'end': 328, 'text': '25', 'document_ids': ['query_product_catalog:1:0']}
 ```
 
 ```python PYTHON
@@ -377,22 +375,20 @@ print(insert_citations_in_order(response.text, response.citations))
 ```
 
 ```
-On the **29th of September 2023**[1], there were **10,000 sales with 250 units sold.**[1]
+On the **29th September 2023**[1], the **total sales amount was 10,000**[1] and the **total units sold was 250.**[1]
 
-The Electronics category contains **three products.**[2] There are details below:
+Here are the details of the products in the 'Electronics' category:
 
-| Product Name | Price | Stock Level |
-| ------------ | ----- | ----------- |
-| **Smartphone**[2] | **500**[2] | **20**[2] |
-| **Laptop**[2] | **1000**[2] | **15**[2] |
-| **Tablet**[2] | **300**[2] | **25**[2] |
-
-The total stock level for Electronics items is 50.
+| **Product Name**[2] | **Price**[2] | **Product ID**[2] | **Stock Level**[2] |
+|---|---|---|---|
+| **Smartphone**[2] | **500**[2] | **E1001**[2] | **20**[2] |
+| **Laptop**[2] | **1000**[2] | **E1002**[2] | **15**[2] |
+| **Tablet**[2] | **300**[2] | **E1003**[2] | **25**[2] |
 
 [1] source: [{'date': '2023-09-29', 'summary': 'Total Sales Amount: 10000, Total Units Sold: 250'}]
-    based on tool call: {'name': 'query_daily_sales_report', 'parameters': {'day': '2023-09-29'}, 'generation_id': 'eaf955e3-623d-4796-bf51-23b07c66ed2c'}
+    based on tool call: {'name': 'query_daily_sales_report', 'parameters': {'day': '2023-09-29'}}
 [2] source: [{'category': 'Electronics', 'products': [{'product_id': 'E1001', 'name': 'Smartphone', 'price': 500, 'stock_level': 20}, {'product_id': 'E1002', 'name': 'Laptop', 'price': 1000, 'stock_level': 15}, {'product_id': 'E1003', 'name': 'Tablet', 'price': 300, 'stock_level': 25}]}]
-    based on tool call: {'name': 'query_product_catalog', 'parameters': {'category': 'Electronics'}, 'generation_id': 'eaf955e3-623d-4796-bf51-23b07c66ed2c'}
+    based on tool call: {'name': 'query_product_catalog', 'parameters': {'category': 'Electronics'}}
 ```
 
 Now, you've used Cohere for Tool Use. Tool use opens up a wide range of new use cases. Here are a few examples:

--- a/notebooks/agents/Vanilla_Tool_Use.ipynb
+++ b/notebooks/agents/Vanilla_Tool_Use.ipynb
@@ -32,7 +32,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 1,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -45,16 +45,13 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m52.8/52.8 kB\u001b[0m \u001b[31m1.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3.1/3.1 MB\u001b[0m \u001b[31m28.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25h"
+            "Note: you may need to restart the kernel to use updated packages.\n"
           ]
         }
       ],
       "source": [
         "# we'll use Cohere to do Tool Use\n",
-        "# TODO: upgrade to \"cohere>5\"\n",
-        "%pip install \"cohere<5\" --quiet"
+        "%pip install \"cohere\" --quiet"
       ]
     },
     {
@@ -82,7 +79,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 3,
       "metadata": {
         "id": "yZffY8xItLGp"
       },
@@ -132,7 +129,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 4,
       "metadata": {
         "id": "YuIH4us8tLGp"
       },
@@ -191,7 +188,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 5,
       "metadata": {
         "id": "aIk-of_OtLGp"
       },
@@ -240,7 +237,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 6,
       "metadata": {
         "id": "JuDgJ7fjtLGq"
       },
@@ -271,7 +268,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 7,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -285,16 +282,8 @@
           "output_type": "stream",
           "text": [
             "The model recommends doing the following tool calls:\n",
-            "cohere.ToolCall {\n",
-            "\tname: query_daily_sales_report\n",
-            "\tparameters: {'day': '2023-09-29'}\n",
-            "\tgeneration_id: eaf955e3-623d-4796-bf51-23b07c66ed2c\n",
-            "}\n",
-            "cohere.ToolCall {\n",
-            "\tname: query_product_catalog\n",
-            "\tparameters: {'category': 'Electronics'}\n",
-            "\tgeneration_id: eaf955e3-623d-4796-bf51-23b07c66ed2c\n",
-            "}\n"
+            "name='query_daily_sales_report' parameters={'day': '2023-09-29'}\n",
+            "name='query_product_catalog' parameters={'category': 'Electronics'}\n"
           ]
         }
       ],
@@ -303,7 +292,7 @@
         "    message=message,\n",
         "    tools=tools,\n",
         "    preamble=preamble,\n",
-        "    model=\"command-r\"\n",
+        "    model=\"command-a-03-2025\",\n",
         ")\n",
         "\n",
         "# Note that the Cohere Chat API also exposes:\n",
@@ -330,7 +319,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 8,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -354,8 +343,7 @@
             "            \"name\": \"query_daily_sales_report\",\n",
             "            \"parameters\": {\n",
             "                \"day\": \"2023-09-29\"\n",
-            "            },\n",
-            "            \"generation_id\": \"eaf955e3-623d-4796-bf51-23b07c66ed2c\"\n",
+            "            }\n",
             "        },\n",
             "        \"outputs\": [\n",
             "            {\n",
@@ -369,8 +357,7 @@
             "            \"name\": \"query_product_catalog\",\n",
             "            \"parameters\": {\n",
             "                \"category\": \"Electronics\"\n",
-            "            },\n",
-            "            \"generation_id\": \"eaf955e3-623d-4796-bf51-23b07c66ed2c\"\n",
+            "            }\n",
             "        },\n",
             "        \"outputs\": [\n",
             "            {\n",
@@ -419,7 +406,9 @@
         "    })\n",
         "\n",
         "print(\"Tool results that will be fed back to the model in step 4:\")\n",
-        "print(json.dumps(tool_results, indent=4))"
+        "\n",
+        "serializable_results = [{\"call\": {\"name\": r[\"call\"].name, \"parameters\": r[\"call\"].parameters}, \"outputs\": r[\"outputs\"]} for r in tool_results]\n",
+        "print(json.dumps(serializable_results, indent=4))"
       ]
     },
     {
@@ -441,7 +430,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 9,
       "metadata": {
         "id": "MKnjXVfXtLGr"
       },
@@ -452,14 +441,15 @@
         "    tools=tools,\n",
         "    tool_results=tool_results,\n",
         "    preamble=preamble,\n",
-        "    model=\"command-r\",\n",
-        "    temperature=0.3\n",
+        "    model=\"command-a-03-2025\",\n",
+        "    temperature=0.3,\n",
+        "    force_single_step=True\n",
         ")"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 10,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -473,17 +463,15 @@
           "output_type": "stream",
           "text": [
             "Final answer:\n",
-            "On the 29th of September 2023, there were 10,000 sales with 250 units sold. \n",
+            "On the 29th September 2023, the total sales amount was 10,000 and the total units sold was 250.\n",
             "\n",
-            "The Electronics category contains three products. There are details below:\n",
+            "Here are the details of the products in the 'Electronics' category:\n",
             "\n",
-            "| Product Name | Price | Stock Level |\n",
-            "| ------------ | ----- | ----------- |\n",
-            "| Smartphone | 500 | 20 |\n",
-            "| Laptop | 1000 | 15 |\n",
-            "| Tablet | 300 | 25 | \n",
-            "\n",
-            "The total stock level for Electronics items is 50.\n"
+            "| Product Name | Price | Product ID | Stock Level |\n",
+            "|---|---|---|---|\n",
+            "| Smartphone | 500 | E1001 | 20 |\n",
+            "| Laptop | 1000 | E1002 | 15 |\n",
+            "| Tablet | 300 | E1003 | 25 |\n"
           ]
         }
       ],
@@ -509,7 +497,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 12,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -523,18 +511,24 @@
           "output_type": "stream",
           "text": [
             "Citations that support the final answer:\n",
-            "{'start': 7, 'end': 29, 'text': '29th of September 2023', 'document_ids': ['query_daily_sales_report:0:0']}\n",
-            "{'start': 42, 'end': 75, 'text': '10,000 sales with 250 units sold.', 'document_ids': ['query_daily_sales_report:0:0']}\n",
-            "{'start': 112, 'end': 127, 'text': 'three products.', 'document_ids': ['query_product_catalog:1:0']}\n",
-            "{'start': 234, 'end': 244, 'text': 'Smartphone', 'document_ids': ['query_product_catalog:1:0']}\n",
-            "{'start': 247, 'end': 250, 'text': '500', 'document_ids': ['query_product_catalog:1:0']}\n",
-            "{'start': 253, 'end': 255, 'text': '20', 'document_ids': ['query_product_catalog:1:0']}\n",
-            "{'start': 260, 'end': 266, 'text': 'Laptop', 'document_ids': ['query_product_catalog:1:0']}\n",
-            "{'start': 269, 'end': 273, 'text': '1000', 'document_ids': ['query_product_catalog:1:0']}\n",
-            "{'start': 276, 'end': 278, 'text': '15', 'document_ids': ['query_product_catalog:1:0']}\n",
-            "{'start': 283, 'end': 289, 'text': 'Tablet', 'document_ids': ['query_product_catalog:1:0']}\n",
-            "{'start': 292, 'end': 295, 'text': '300', 'document_ids': ['query_product_catalog:1:0']}\n",
-            "{'start': 298, 'end': 300, 'text': '25', 'document_ids': ['query_product_catalog:1:0']}\n"
+            "start=32 end=61 text='total sales amount was 10,000' document_ids=['query_daily_sales_report:0:0'] type='TEXT_CONTENT'\n",
+            "start=70 end=95 text='total units sold was 250.' document_ids=['query_daily_sales_report:0:0'] type='TEXT_CONTENT'\n",
+            "start=168 end=180 text='Product Name' document_ids=['query_product_catalog:1:0'] type='TEXT_CONTENT'\n",
+            "start=183 end=188 text='Price' document_ids=['query_product_catalog:1:0'] type='TEXT_CONTENT'\n",
+            "start=191 end=201 text='Product ID' document_ids=['query_product_catalog:1:0'] type='TEXT_CONTENT'\n",
+            "start=204 end=215 text='Stock Level' document_ids=['query_product_catalog:1:0'] type='TEXT_CONTENT'\n",
+            "start=238 end=248 text='Smartphone' document_ids=['query_product_catalog:1:0'] type='TEXT_CONTENT'\n",
+            "start=251 end=254 text='500' document_ids=['query_product_catalog:1:0'] type='TEXT_CONTENT'\n",
+            "start=257 end=262 text='E1001' document_ids=['query_product_catalog:1:0'] type='TEXT_CONTENT'\n",
+            "start=265 end=267 text='20' document_ids=['query_product_catalog:1:0'] type='TEXT_CONTENT'\n",
+            "start=272 end=278 text='Laptop' document_ids=['query_product_catalog:1:0'] type='TEXT_CONTENT'\n",
+            "start=281 end=285 text='1000' document_ids=['query_product_catalog:1:0'] type='TEXT_CONTENT'\n",
+            "start=288 end=293 text='E1002' document_ids=['query_product_catalog:1:0'] type='TEXT_CONTENT'\n",
+            "start=296 end=298 text='15' document_ids=['query_product_catalog:1:0'] type='TEXT_CONTENT'\n",
+            "start=303 end=309 text='Tablet' document_ids=['query_product_catalog:1:0'] type='TEXT_CONTENT'\n",
+            "start=312 end=315 text='300' document_ids=['query_product_catalog:1:0'] type='TEXT_CONTENT'\n",
+            "start=318 end=323 text='E1003' document_ids=['query_product_catalog:1:0'] type='TEXT_CONTENT'\n",
+            "start=326 end=328 text='25' document_ids=['query_product_catalog:1:0'] type='TEXT_CONTENT'\n"
           ]
         }
       ],
@@ -546,7 +540,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 14,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -559,22 +553,20 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "On the **29th of September 2023**[1], there were **10,000 sales with 250 units sold.**[1] \n",
+            "On the 29th September 2023, the **total sales amount was 10,000**[1] and the **total units sold was 250.**[1]\n",
             "\n",
-            "The Electronics category contains **three products.**[2] There are details below:\n",
+            "Here are the details of the products in the 'Electronics' category:\n",
             "\n",
-            "| Product Name | Price | Stock Level |\n",
-            "| ------------ | ----- | ----------- |\n",
-            "| **Smartphone**[2] | **500**[2] | **20**[2] |\n",
-            "| **Laptop**[2] | **1000**[2] | **15**[2] |\n",
-            "| **Tablet**[2] | **300**[2] | **25**[2] | \n",
-            "\n",
-            "The total stock level for Electronics items is 50.\n",
+            "| **Product Name**[2] | **Price**[2] | **Product ID**[2] | **Stock Level**[2] |\n",
+            "|---|---|---|---|\n",
+            "| **Smartphone**[2] | **500**[2] | **E1001**[2] | **20**[2] |\n",
+            "| **Laptop**[2] | **1000**[2] | **E1002**[2] | **15**[2] |\n",
+            "| **Tablet**[2] | **300**[2] | **E1003**[2] | **25**[2] |\n",
             "\n",
             "[1] source: [{'date': '2023-09-29', 'summary': 'Total Sales Amount: 10000, Total Units Sold: 250'}] \n",
-            "    based on tool call: {'name': 'query_daily_sales_report', 'parameters': {'day': '2023-09-29'}, 'generation_id': 'eaf955e3-623d-4796-bf51-23b07c66ed2c'}\n",
+            "    based on tool call: {'name': 'query_daily_sales_report', 'parameters': {'day': '2023-09-29'}}\n",
             "[2] source: [{'category': 'Electronics', 'products': [{'product_id': 'E1001', 'name': 'Smartphone', 'price': 500, 'stock_level': 20}, {'product_id': 'E1002', 'name': 'Laptop', 'price': 1000, 'stock_level': 15}, {'product_id': 'E1003', 'name': 'Tablet', 'price': 300, 'stock_level': 25}]}] \n",
-            "    based on tool call: {'name': 'query_product_catalog', 'parameters': {'category': 'Electronics'}, 'generation_id': 'eaf955e3-623d-4796-bf51-23b07c66ed2c'}\n"
+            "    based on tool call: {'name': 'query_product_catalog', 'parameters': {'category': 'Electronics'}}\n"
           ]
         }
       ],
@@ -591,14 +583,14 @@
         "    # Process citations, assigning numbers based on unique document_ids\n",
         "    for citation in citations:\n",
         "        citation_numbers = []\n",
-        "        for document_id in sorted(citation[\"document_ids\"]):\n",
+        "        for document_id in sorted(citation.document_ids):\n",
         "            if document_id not in document_id_to_number:\n",
         "                citation_number += 1  # Increment for a new document_id\n",
         "                document_id_to_number[document_id] = citation_number\n",
         "            citation_numbers.append(document_id_to_number[document_id])\n",
         "\n",
         "        # Adjust start/end with offset\n",
-        "        start, end = citation['start'] + offset, citation['end'] + offset\n",
+        "        start, end = citation.start + offset, citation.end + offset\n",
         "        placeholder = ''.join([f'[{number}]' for number in citation_numbers])\n",
         "        # Bold the cited text and append the placeholder\n",
         "        modification = f'**{text[start:end]}**{placeholder}'\n",
@@ -652,7 +644,7 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": "hackathon_demo",
+      "display_name": "venv (3.12.3)",
       "language": "python",
       "name": "python3"
     },
@@ -666,7 +658,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.11.5"
+      "version": "3.12.3"
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the basic tool use cookbook to use the latest Cohere Python SDK.

- The `model` parameter in the `co.chat` function calls is updated to `command-a-03-2025` from `command-r`.
- The `force_single_step` parameter is added to the final `co.chat` function call and set to `True`.
- The `generation_id` field is removed from the `tool_results` variable.
- The `serializable_results` variable is introduced to handle the serialization of tool results.
- The output formatting is adjusted to include `Product ID` and remove the total stock level summary.
- The citations are updated to reflect the new output format.
- The `execution_count` is updated for several code cells.
- The `cohere` package installation command is updated to remove the version constraint.
- The kernel and Python version metadata are updated.

<!-- end-generated-description -->