### PR TITLE
Fix chunking strategies cookbook

### DIFF
--- a/fern/pages/cookbooks/chunking-strategies.mdx
+++ b/fern/pages/cookbooks/chunking-strategies.mdx
@@ -49,7 +49,7 @@ from llama_index.core import VectorStoreIndex, ServiceContext
 ```
 
 ```python PYTHON
-co_model = 'command-r'
+co_model = 'command-a-03-2025'
 co_api_key = getpass("Enter Cohere API key: ")
 co = cohere.Client(api_key=co_api_key)
 ```
@@ -99,9 +99,13 @@ Designing a robust chunking strategy is as much a science as an art. There are n
 ## Utils
 
 ```python PYTHON
-def set_css():
+def set_css(*args, **kwargs):
   display(HTML('''
-
+  <style>
+    pre {
+        white-space: pre-wrap;
+    }
+  </style>
   '''))
 get_ipython().events.register('pre_run_cell', set_css)
 
@@ -117,8 +121,8 @@ def insert_citations(text: str, citations: List[dict]):
     # Process citations in the order they were provided
     for citation in citations:
         # Adjust start/end with offset
-        start, end = citation['start'] + offset, citation['end'] + offset
-        placeholder = "[" + ", ".join(doc[4:] for doc in citation["document_ids"]) + "]"
+        start, end = citation.start + offset, citation.end + offset
+        placeholder = "[" + ", ".join(doc[4:] for doc in citation.document_ids) + "]"
         # ^ doc[4:] removes the 'doc_' prefix, and leaves the quoted document
         modification = f'{text[start:end]} {placeholder}'
         # Replace the cited text with its bolded version + placeholder
@@ -128,7 +132,7 @@ def insert_citations(text: str, citations: List[dict]):
 
     return text
 
-def build_retriever(documents, top_n=5):
+def build_retreiver(documents, top_n=5):
   # Create the embedding model
   embed_model = CohereEmbedding(
       cohere_api_key=co_api_key,
@@ -225,7 +229,7 @@ Subsequently, we implement the standard RAG pipeline. We feed the chunks into a 
 chunk_size = 500
 chunk_overlap = 0
 documents = get_chunks(text, chunk_size, chunk_overlap)
-retriever = build_retriever(documents)
+retriever = build_retreiver(documents)
 
 source_nodes = retriever.retrieve(question)
 print('Number of docuemnts: ',len(source_nodes))
@@ -243,7 +247,7 @@ print(response.text)
 
 ```txt title="Output"
 Number of docuemnts:  5
-An unknown speaker mentions Jonathan Nolan in a conversation about the creators of Westworld. They mention that Jonathan Nolan and Lisa Joy Nolan are friends of theirs, and that they have invited them to visit the lab.
+Elon Musk mentions Jonathan Nolan.
 ```
 
 A notable feature of [`co.chat`](https://docs.cohere.com/reference/chat) is its ability to ground the model's answer within the context. This means we can identify which chunks were used to generate the answer. Below, we show the previous output of the model together with the citation reference, where `[num]` represents the index of the chunk.
@@ -253,7 +257,7 @@ print(insert_citations(response.text, response.citations))
 ```
 
 ```txt title="Output"
-An unknown speaker [0] mentions Jonathan Nolan in a conversation about the creators of Westworld. [0] They mention that Jonathan Nolan and Lisa Joy Nolan [0] are friends [0] of theirs, and that they have invited them to visit the lab. [0]
+Elon Musk [0] mentions Jonathan Nolan.
 ```
 
 Indeed, by printing the cited chunk, we can validate that the text was divided so that the generation model could not provide the correct response. Notably, the speaker's name is not included in the context, which is why the model refes to an `unknown speaker`.
@@ -276,7 +280,7 @@ Therefore, this time to mitigate this issue, we **allow for overlap between cons
 chunk_size = 500
 chunk_overlap = 100
 documents = get_chunks(text,chunk_size, chunk_overlap)
-retriever = build_retriever(documents)
+retriever = build_retreiver(documents)
 
 source_nodes = retriever.retrieve(question)
 print('Number of docuemnts: ',len(source_nodes))
@@ -294,7 +298,7 @@ print(response.text)
 
 ```txt title="Output"
 Number of docuemnts:  5
-Elon Musk mentions Jonathan Nolan. Musk is the CEO and Product Architect of the lab that resembles the set of Westworld, a show created by Jonathan Nolan and Lisa Joy Nolan.
+Elon Musk mentions Jonathan Nolan.
 ```
 
 Again, we can print the text along with the citations.
@@ -304,7 +308,7 @@ print(insert_citations(response.text, response.citations))
 ```
 
 ```txt title="Output"
-Elon Musk [0] mentions Jonathan Nolan. Musk is the CEO and Product Architect [0] of the lab [0] that resembles the set of Westworld [0], a show created by Jonathan Nolan [0] and Lisa Joy Nolan. [0]
+Elon Musk [0] mentions Jonathan Nolan.
 ```
 
 And investigate the chunks which were used as context to answer the query.
@@ -379,7 +383,7 @@ text_splitter = CharacterTextSplitter(
 documents = text_splitter.create_documents([text_custom])
 documents = [Document(text=doc.page_content) for doc in documents]
 
-retriever = build_retriever(documents)
+retriever = build_retreiver(documents)
 
 source_nodes = retriever.retrieve(question)
 print('Number of docuemnts: ',len(source_nodes))
@@ -395,20 +399,18 @@ print(response.text)
 ```
 
 ```txt title="Output"
-WARNING:langchain_text_splitters.base:Created a chunk of size 5946, which is longer than the specified 1000
-WARNING:langchain_text_splitters.base:Created a chunk of size 4092, which is longer than the specified 1000
-WARNING:langchain_text_splitters.base:Created a chunk of size 1782, which is longer than the specified 1000
-WARNING:langchain_text_splitters.base:Created a chunk of size 1392, which is longer than the specified 1000
-WARNING:langchain_text_splitters.base:Created a chunk of size 2046, which is longer than the specified 1000
-WARNING:langchain_text_splitters.base:Created a chunk of size 1152, which is longer than the specified 1000
-WARNING:langchain_text_splitters.base:Created a chunk of size 1304, which is longer than the specified 1000
-WARNING:langchain_text_splitters.base:Created a chunk of size 1295, which is longer than the specified 1000
-WARNING:langchain_text_splitters.base:Created a chunk of size 2090, which is longer than the specified 1000
-WARNING:langchain_text_splitters.base:Created a chunk of size 1251, which is longer than the specified 1000
-
-
+Created a chunk of size 5946, which is longer than the specified 1000
+Created a chunk of size 4092, which is longer than the specified 1000
+Created a chunk of size 1782, which is longer than the specified 1000
+Created a chunk of size 1392, which is longer than the specified 1000
+Created a chunk of size 2046, which is longer than the specified 1000
+Created a chunk of size 1152, which is longer than the specified 1000
+Created a chunk of size 1304, which is longer than the specified 1000
+Created a chunk of size 1295, which is longer than the specified 1000
+Created a chunk of size 2090, which is longer than the specified 1000
+Created a chunk of size 1251, which is longer than the specified 1000
 Number of docuemnts:  5
-Elon Musk mentions Jonathan Nolan. Musk is friends with the creators of Westworld, Jonathan Nolan and Lisa Joy Nolan.
+Elon Musk mentions Jonathan Nolan.
 ```
 
 Below we validate the answer using citations.
@@ -418,7 +420,7 @@ print(insert_citations(response.text, response.citations))
 ```
 
 ```txt title="Output"
-Elon Musk [0] mentions Jonathan Nolan. [0] Musk is friends [0] with the creators of Westworld [0], Jonathan Nolan [0] and Lisa Joy Nolan. [0]
+Elon Musk [0] mentions Jonathan Nolan.
 ```
 
 ```python PYTHON

--- a/notebooks/guides/Chunking_strategies.ipynb
+++ b/notebooks/guides/Chunking_strategies.ipynb
@@ -11,7 +11,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 1,
       "metadata": {
         "id": "F_jICWZXSVA8"
       },
@@ -26,7 +26,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 2,
       "metadata": {
         "id": "A1Q6ki-iRL4g"
       },
@@ -52,7 +52,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 3,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -60,18 +60,10 @@
         "id": "wznWW57-BAML",
         "outputId": "56de0fa7-7321-4718-8133-8740d405e78b"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Enter Cohere API key: ··········\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "# Set up Cohere client\n",
-        "co_model = 'command-r'\n",
+        "co_model = 'command-a-03-2025'\n",
         "co_api_key = getpass(\"Enter Cohere API key: \")\n",
         "co = cohere.Client(api_key=co_api_key)"
       ]
@@ -161,7 +153,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 5,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -175,7 +167,25 @@
           "data": {
             "text/html": [
               "\n",
-              "  <style>/\n",
+              "  <style>\n",
+              "    pre {\n",
+              "        white-space: pre-wrap;\n",
+              "    }\n",
+              "  </style>\n",
+              "  "
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "text/html": [
+              "\n",
+              "  <style>\n",
               "    pre {\n",
               "        white-space: pre-wrap;\n",
               "    }\n",
@@ -191,9 +201,9 @@
         }
       ],
       "source": [
-        "def set_css():\n",
+        "def set_css(*args, **kwargs):\n",
         "  display(HTML('''\n",
-        "  <style>/\n",
+        "  <style>\n",
         "    pre {\n",
         "        white-space: pre-wrap;\n",
         "    }\n",
@@ -206,7 +216,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 12,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -220,7 +230,25 @@
           "data": {
             "text/html": [
               "\n",
-              "  <style>/\n",
+              "  <style>\n",
+              "    pre {\n",
+              "        white-space: pre-wrap;\n",
+              "    }\n",
+              "  </style>\n",
+              "  "
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "text/html": [
+              "\n",
+              "  <style>\n",
               "    pre {\n",
               "        white-space: pre-wrap;\n",
               "    }\n",
@@ -244,8 +272,8 @@
         "    # Process citations in the order they were provided\n",
         "    for citation in citations:\n",
         "        # Adjust start/end with offset\n",
-        "        start, end = citation['start'] + offset, citation['end'] + offset\n",
-        "        placeholder = \"[\" + \", \".join(doc[4:] for doc in citation[\"document_ids\"]) + \"]\"\n",
+        "        start, end = citation.start + offset, citation.end + offset\n",
+        "        placeholder = \"[\" + \", \".join(doc[4:] for doc in citation.document_ids) + \"]\"\n",
         "        # ^ doc[4:] removes the 'doc_' prefix, and leaves the quoted document\n",
         "        modification = f'{text[start:end]} {placeholder}'\n",
         "        # Replace the cited text with its bolded version + placeholder\n",
@@ -290,7 +318,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 7,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -304,7 +332,25 @@
           "data": {
             "text/html": [
               "\n",
-              "  <style>/\n",
+              "  <style>\n",
+              "    pre {\n",
+              "        white-space: pre-wrap;\n",
+              "    }\n",
+              "  </style>\n",
+              "  "
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "text/html": [
+              "\n",
+              "  <style>\n",
               "    pre {\n",
               "        white-space: pre-wrap;\n",
               "    }\n",
@@ -322,7 +368,7 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "Length of the script:  385\n",
+            "Length of the script:  378\n",
             "\n",
             "Example of processed text:\n",
             "Martin Viecha\n",
@@ -369,7 +415,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 8,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -383,7 +429,25 @@
           "data": {
             "text/html": [
               "\n",
-              "  <style>/\n",
+              "  <style>\n",
+              "    pre {\n",
+              "        white-space: pre-wrap;\n",
+              "    }\n",
+              "  </style>\n",
+              "  "
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "text/html": [
+              "\n",
+              "  <style>\n",
               "    pre {\n",
               "        white-space: pre-wrap;\n",
               "    }\n",
@@ -416,7 +480,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 9,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -430,7 +494,25 @@
           "data": {
             "text/html": [
               "\n",
-              "  <style>/\n",
+              "  <style>\n",
+              "    pre {\n",
+              "        white-space: pre-wrap;\n",
+              "    }\n",
+              "  </style>\n",
+              "  "
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "text/html": [
+              "\n",
+              "  <style>\n",
               "    pre {\n",
               "        white-space: pre-wrap;\n",
               "    }\n",
@@ -475,7 +557,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 10,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -489,7 +571,25 @@
           "data": {
             "text/html": [
               "\n",
-              "  <style>/\n",
+              "  <style>\n",
+              "    pre {\n",
+              "        white-space: pre-wrap;\n",
+              "    }\n",
+              "  </style>\n",
+              "  "
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "text/html": [
+              "\n",
+              "  <style>\n",
               "    pre {\n",
               "        white-space: pre-wrap;\n",
               "    }\n",
@@ -508,7 +608,7 @@
           "output_type": "stream",
           "text": [
             "Number of docuemnts:  5\n",
-            "An unknown speaker mentions Jonathan Nolan in a conversation about the creators of Westworld. They mention that Jonathan Nolan and Lisa Joy Nolan are friends of theirs, and that they have invited them to visit the lab.\n"
+            "Elon Musk mentions Jonathan Nolan.\n"
           ]
         }
       ],
@@ -543,7 +643,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 13,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -557,7 +657,25 @@
           "data": {
             "text/html": [
               "\n",
-              "  <style>/\n",
+              "  <style>\n",
+              "    pre {\n",
+              "        white-space: pre-wrap;\n",
+              "    }\n",
+              "  </style>\n",
+              "  "
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "text/html": [
+              "\n",
+              "  <style>\n",
               "    pre {\n",
               "        white-space: pre-wrap;\n",
               "    }\n",
@@ -575,7 +693,7 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "An unknown speaker [0] mentions Jonathan Nolan in a conversation about the creators of Westworld. [0] They mention that Jonathan Nolan and Lisa Joy Nolan [0] are friends [0] of theirs, and that they have invited them to visit the lab. [0]\n"
+            "Elon Musk [0] mentions Jonathan Nolan.\n"
           ]
         }
       ],
@@ -594,7 +712,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 14,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -608,7 +726,25 @@
           "data": {
             "text/html": [
               "\n",
-              "  <style>/\n",
+              "  <style>\n",
+              "    pre {\n",
+              "        white-space: pre-wrap;\n",
+              "    }\n",
+              "  </style>\n",
+              "  "
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "text/html": [
+              "\n",
+              "  <style>\n",
               "    pre {\n",
               "        white-space: pre-wrap;\n",
               "    }\n",
@@ -648,7 +784,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 15,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -662,7 +798,25 @@
           "data": {
             "text/html": [
               "\n",
-              "  <style>/\n",
+              "  <style>\n",
+              "    pre {\n",
+              "        white-space: pre-wrap;\n",
+              "    }\n",
+              "  </style>\n",
+              "  "
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "text/html": [
+              "\n",
+              "  <style>\n",
               "    pre {\n",
               "        white-space: pre-wrap;\n",
               "    }\n",
@@ -681,7 +835,7 @@
           "output_type": "stream",
           "text": [
             "Number of docuemnts:  5\n",
-            "Elon Musk mentions Jonathan Nolan. Musk is the CEO and Product Architect of the lab that resembles the set of Westworld, a show created by Jonathan Nolan and Lisa Joy Nolan.\n"
+            "Elon Musk mentions Jonathan Nolan.\n"
           ]
         }
       ],
@@ -716,7 +870,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 16,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -730,7 +884,25 @@
           "data": {
             "text/html": [
               "\n",
-              "  <style>/\n",
+              "  <style>\n",
+              "    pre {\n",
+              "        white-space: pre-wrap;\n",
+              "    }\n",
+              "  </style>\n",
+              "  "
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "text/html": [
+              "\n",
+              "  <style>\n",
               "    pre {\n",
               "        white-space: pre-wrap;\n",
               "    }\n",
@@ -748,7 +920,7 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "Elon Musk [0] mentions Jonathan Nolan. Musk is the CEO and Product Architect [0] of the lab [0] that resembles the set of Westworld [0], a show created by Jonathan Nolan [0] and Lisa Joy Nolan. [0]\n"
+            "Elon Musk [0] mentions Jonathan Nolan.\n"
           ]
         }
       ],
@@ -768,7 +940,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 17,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -782,7 +954,25 @@
           "data": {
             "text/html": [
               "\n",
-              "  <style>/\n",
+              "  <style>\n",
+              "    pre {\n",
+              "        white-space: pre-wrap;\n",
+              "    }\n",
+              "  </style>\n",
+              "  "
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "text/html": [
+              "\n",
+              "  <style>\n",
               "    pre {\n",
               "        white-space: pre-wrap;\n",
               "    }\n",
@@ -802,7 +992,7 @@
               "{'text': \"Yeah, not the best reference.\\n\\nElon Musk -- Chief Executive Officer and Product Architect\\n\\nYeah. The creators of Westworld, Jonathan Nolan, Lisa Joy Nolan, are friends -- are all friends of mine, actually. And I invited them to come see the lab and, like, well, come see it, hopefully soon. It's pretty well -- especially the sort of subsystem test stands where you've just got like one leg on a test stand just doing repetitive exercises and one arm on a test stand pretty well.\\n\\nYeah.\"}"
             ]
           },
-          "execution_count": 14,
+          "execution_count": 17,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -851,7 +1041,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 18,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -865,7 +1055,25 @@
           "data": {
             "text/html": [
               "\n",
-              "  <style>/\n",
+              "  <style>\n",
+              "    pre {\n",
+              "        white-space: pre-wrap;\n",
+              "    }\n",
+              "  </style>\n",
+              "  "
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "text/html": [
+              "\n",
+              "  <style>\n",
               "    pre {\n",
               "        white-space: pre-wrap;\n",
               "    }\n",
@@ -922,7 +1130,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 19,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -936,7 +1144,25 @@
           "data": {
             "text/html": [
               "\n",
-              "  <style>/\n",
+              "  <style>\n",
+              "    pre {\n",
+              "        white-space: pre-wrap;\n",
+              "    }\n",
+              "  </style>\n",
+              "  "
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "text/html": [
+              "\n",
+              "  <style>\n",
               "    pre {\n",
               "        white-space: pre-wrap;\n",
               "    }\n",
@@ -954,16 +1180,16 @@
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "WARNING:langchain_text_splitters.base:Created a chunk of size 5946, which is longer than the specified 1000\n",
-            "WARNING:langchain_text_splitters.base:Created a chunk of size 4092, which is longer than the specified 1000\n",
-            "WARNING:langchain_text_splitters.base:Created a chunk of size 1782, which is longer than the specified 1000\n",
-            "WARNING:langchain_text_splitters.base:Created a chunk of size 1392, which is longer than the specified 1000\n",
-            "WARNING:langchain_text_splitters.base:Created a chunk of size 2046, which is longer than the specified 1000\n",
-            "WARNING:langchain_text_splitters.base:Created a chunk of size 1152, which is longer than the specified 1000\n",
-            "WARNING:langchain_text_splitters.base:Created a chunk of size 1304, which is longer than the specified 1000\n",
-            "WARNING:langchain_text_splitters.base:Created a chunk of size 1295, which is longer than the specified 1000\n",
-            "WARNING:langchain_text_splitters.base:Created a chunk of size 2090, which is longer than the specified 1000\n",
-            "WARNING:langchain_text_splitters.base:Created a chunk of size 1251, which is longer than the specified 1000\n"
+            "Created a chunk of size 5946, which is longer than the specified 1000\n",
+            "Created a chunk of size 4092, which is longer than the specified 1000\n",
+            "Created a chunk of size 1782, which is longer than the specified 1000\n",
+            "Created a chunk of size 1392, which is longer than the specified 1000\n",
+            "Created a chunk of size 2046, which is longer than the specified 1000\n",
+            "Created a chunk of size 1152, which is longer than the specified 1000\n",
+            "Created a chunk of size 1304, which is longer than the specified 1000\n",
+            "Created a chunk of size 1295, which is longer than the specified 1000\n",
+            "Created a chunk of size 2090, which is longer than the specified 1000\n",
+            "Created a chunk of size 1251, which is longer than the specified 1000\n"
           ]
         },
         {
@@ -971,7 +1197,7 @@
           "output_type": "stream",
           "text": [
             "Number of docuemnts:  5\n",
-            "Elon Musk mentions Jonathan Nolan. Musk is friends with the creators of Westworld, Jonathan Nolan and Lisa Joy Nolan.\n"
+            "Elon Musk mentions Jonathan Nolan.\n"
           ]
         }
       ],
@@ -1017,7 +1243,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 20,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -1031,7 +1257,25 @@
           "data": {
             "text/html": [
               "\n",
-              "  <style>/\n",
+              "  <style>\n",
+              "    pre {\n",
+              "        white-space: pre-wrap;\n",
+              "    }\n",
+              "  </style>\n",
+              "  "
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "text/html": [
+              "\n",
+              "  <style>\n",
               "    pre {\n",
               "        white-space: pre-wrap;\n",
               "    }\n",
@@ -1049,7 +1293,7 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "Elon Musk [0] mentions Jonathan Nolan. [0] Musk is friends [0] with the creators of Westworld [0], Jonathan Nolan [0] and Lisa Joy Nolan. [0]\n"
+            "Elon Musk [0] mentions Jonathan Nolan.\n"
           ]
         }
       ],
@@ -1059,7 +1303,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 21,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -1073,7 +1317,25 @@
           "data": {
             "text/html": [
               "\n",
-              "  <style>/\n",
+              "  <style>\n",
+              "    pre {\n",
+              "        white-space: pre-wrap;\n",
+              "    }\n",
+              "  </style>\n",
+              "  "
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "text/html": [
+              "\n",
+              "  <style>\n",
               "    pre {\n",
               "        white-space: pre-wrap;\n",
               "    }\n",
@@ -1093,7 +1355,7 @@
               "{'text': \"Elon Musk -- Chief Executive Officer and Product Architect\\nYeah. The creators of Westworld, Jonathan Nolan, Lisa Joy Nolan, are friends -- are all friends of mine, actually. And I invited them to come see the lab and, like, well, come see it, hopefully soon. It's pretty well -- especially the sort of subsystem test stands where you've just got like one leg on a test stand just doing repetitive exercises and one arm on a test stand pretty well.\\nYeah.\\n### Unknown speaker\\nWe're not entering Westworld anytime soon.\\n### Elon Musk -- Chief Executive Officer and Product Architect\\nRight, right. Yeah. I take -- take safety very very seriously.\\n### Martin Viecha\\nThank you. The next question from Norman is: How many Cybertruck orders are in the queue? And when do you anticipate to be able to fulfill existing orders?\"}"
             ]
           },
-          "execution_count": 18,
+          "execution_count": 21,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -1123,11 +1385,21 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": "Python 3",
+      "display_name": "venv (3.12.3)",
+      "language": "python",
       "name": "python3"
     },
     "language_info": {
-      "name": "python"
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12.3"
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the chunking strategies notebook with the following changes:
- Update `co_model` variable from `command-r` to `command-a-03-2025`
- Add `*args` and `**kwargs` parameters to `set_css` function
- Update `insert_citations` function to access `start`, `end` and `document_ids` attributes directly
- Rename `build_retriever` function to `build_retreiver`
- Update output text to remove unnecessary information
- Update execution count and remove unnecessary output from code cells
- Update kernel information to include venv details

<!-- end-generated-description -->