### PR TITLE
Update command-a wording on gpus usage

### DIFF
--- a/fern/pages/models/the-command-family-of-models/command-a-reasoning.mdx
+++ b/fern/pages/models/the-command-family-of-models/command-a-reasoning.mdx
@@ -38,7 +38,7 @@ import { ModelShowcase, Capability, Endpoint} from "../../../components/model-sh
 
 ## Description
 
-Command A Reasoning is Cohere's first reasoning model to date, excelling at real world enterprise tasks including tool use, retrieval augmented generation (RAG), agents, and multilingual use cases. At 111B parameters, Command A has a context length of 256K, and can run on one or two GPUs (A100s / H100s).
+Command A Reasoning is Cohere's first reasoning model to date, excelling at real world enterprise tasks including tool use, retrieval augmented generation (RAG), agents, and multilingual use cases. At 111B parameters, Command A has a context length of 256K. Command-a-Reasoning (CAR) is optimized to run on 4x H100 GPUs for production workloads. For non-production tasks such as tryouts and evaluations, it can also run on 4x A100 GPUs.
 
 ## What Can Command A Reasoning Be Used For?
 Command A is excellent for:


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the description of Command A Reasoning, Cohere's first reasoning model.

- Removes the statement that Command A can run on one or two GPUs (A100s / H100s)
- Adds that Command A has a context length of 256K
- Adds that Command-a-Reasoning (CAR) is optimized to run on 4x H100 GPUs for production workloads
- Adds that for non-production tasks such as tryouts and evaluations, it can also run on 4x A100 GPUs

<!-- end-generated-description -->