### PR TITLE
feat(python): add OciClient to additional_init_exports

### DIFF
--- a/fern/apis/sdks/generators.yml
+++ b/fern/apis/sdks/generators.yml
@@ -152,6 +152,10 @@ groups:
             - from: aws_client
               imports:
                 - AwsClient
+            - from: oci_client
+              imports:
+                - OciClient
+                - OciClientV2
             - from: client_v2
               imports:
                 - AsyncClientV2


### PR DESCRIPTION
## Summary

Add `OciClient` and `OciClientV2` to the Python SDK's `additional_init_exports` in `fern/apis/sdks/generators.yml`, so they survive Fern regeneration of `__init__.py`.

This is a one-line config change that follows the exact same pattern as `BedrockClient`, `SagemakerClient`, and `AwsClient`.

## Why

`oci_client.py` is a manually maintained file (listed in `.fernignore` in cohere-python). But `__init__.py` is auto-generated by Fern — without this config entry, the `OciClient`/`OciClientV2` exports get wiped on every regeneration, breaking `import cohere; cohere.OciClientV2(...)`.

## Related

- cohere-ai/cohere-python#718 — OCI client implementation PR
- cohere-ai/cohere-python#735 — Feature request issue
- cohere-ai/cohere-python#737 — Fern-support integration branch

## Change

```yaml
- from: oci_client
  imports:
    - OciClient
    - OciClientV2
```