### PR TITLE
Upgrades

### DIFF
--- a/fern/apis/sdks/generators.yml
+++ b/fern/apis/sdks/generators.yml
@@ -84,7 +84,7 @@ groups:
       - sdk-only
     generators:
       - name: fernapi/fern-go-sdk
-        version: 1.33.3
+        version: 1.33.4
         github:
           repository: cohere-ai/cohere-go
           mode: pull-request
@@ -102,7 +102,7 @@ groups:
       - sdk-only
     generators:
       - name: fernapi/fern-java-sdk
-        version: 4.1.1
+        version: 4.1.2
         publish-metadata:
           author: cohere
           email: platform@cohere.com
@@ -132,7 +132,7 @@ groups:
       - sdk-only
     generators:
       - name: fernapi/fern-python-sdk
-        version: 5.3.1
+        version: 5.3.3
         smart-casing: true
         config:
           inline_request_params: false

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "cohere",
-  "version": "4.62.5"
+  "version": "4.63.2"
 }


### PR DESCRIPTION
<!-- begin-generated-description -->

**Description**
The PR updates the versions of the Go, Java, and Python SDKs, as well as the Fern configuration file.

**Changes**
- The Go SDK version has been updated from 1.33.3 to 1.33.4.
- The Java SDK version has been updated from 4.1.1 to 4.1.2.
- The Python SDK version has been updated from 5.3.1 to 5.3.3.
- The Fern configuration file version has been updated from 4.62.5 to 4.63.2.

<!-- end-generated-description -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version bumps to Fern generator/CLI configuration only; no runtime logic changes, but regenerated SDK output may change due to upstream generator updates.
> 
> **Overview**
> Updates Fern configuration versions to pick up newer toolchain releases.
> 
> Bumps the Go (`fernapi/fern-go-sdk` 1.33.3→1.33.4), Java (`fernapi/fern-java-sdk` 4.1.1→4.1.2), and Python (`fernapi/fern-python-sdk` 5.3.1→5.3.3) generator versions in `fern/apis/sdks/generators.yml`, and updates the Fern CLI/project version in `fern/fern.config.json` (4.62.5→4.63.2).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97e5ff8afc74414581ce3c4a4c999468c5176a2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->