### PR TITLE
docs: Add native Cohere Python SDK support for OCI Generative AI

### DIFF
--- a/.github/workflows/check-python-code-snippets.yml
+++ b/.github/workflows/check-python-code-snippets.yml
@@ -11,13 +11,16 @@ on:
 jobs:
   run:
     runs-on: ubuntu-latest
-    permissions: write-all
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          # Fork PRs: head branch exists only on the fork; use head repo + SHA.
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/fern/pages/deployment-options/cohere-works-everywhere.mdx
+++ b/fern/pages/deployment-options/cohere-works-everywhere.mdx
@@ -23,7 +23,7 @@ The table below summarizes the environments in which Cohere models can be deploy
 | sdk                                                          | [Cohere platform](/reference/about) | [Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-cohere.html) | Sagemaker                       | Azure                       | OCI                        | Private Deployment                 |
 | ------------------------------------------------------------ | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------- | ------------------------------- | --------------------------- | -------------------------- | ------------------------------ |
 | [Typescript](https://github.com/cohere-ai/cohere-typescript) | [✅ docs](#cohere-platform)                             | [✅ docs](#bedrock)                                                                | [✅ docs](#sagemaker) | [✅ docs](#azure) | [🟠 soon]() | [✅ docs](#private-deployment) |
-| [Python](https://github.com/cohere-ai/cohere-python)         | [✅ docs](#cohere-platform)                                 | [✅ docs](#bedrock)                                                                    | [✅ docs](#sagemaker)     | [✅ docs](#azure)     | [🟠 soon]()     | [✅ docs](#private-deployment)     |
+| [Python](https://github.com/cohere-ai/cohere-python)         | [✅ docs](#cohere-platform)                                 | [✅ docs](#bedrock)                                                                    | [✅ docs](#sagemaker)     | [✅ docs](#azure)     | [✅ docs](#oci)     | [✅ docs](#private-deployment)     |
 | [Go](https://github.com/cohere-ai/cohere-go)                 | [✅ docs](#cohere-platform)                                     | [🟠 soon](#bedrock)                                                                       | [🟠 soon](#sagemaker)        | [✅ docs](#azure)         | [🟠 soon](#)         | [✅ docs](#private-deployment)         |
 | [Java](https://github.com/cohere-ai/cohere-java)             | [✅ docs](#cohere-platform)                                   | [🟠 soon](#bedrock)                                                                     | [🟠 soon](#sagemaker)      | [✅ docs](#azure)       | [🟠 soon]()       | [✅ docs](#private-deployment)       |
 
@@ -35,8 +35,8 @@ The most complete set of features is found on the cohere platform, while each of
 | --------------- | --------------- | ----------- | ----------- | ----------- | ----------- | -------------- |
 | chat_stream     | ✅               | ✅           | ✅           | ✅           | ✅           | ✅              |
 | chat            | ✅               | ✅           | ✅           | ✅           | ✅           | ✅              |
-| generate_stream | ✅               | ✅           | ✅           | ✅           | ✅           | ✅              |
-| generate        | ✅               | ✅           | ✅           | ✅           | ✅           | ✅              |
+| generate_stream | ✅               | ✅           | ✅           | ✅           | ⬜️           | ✅              |
+| generate        | ✅               | ✅           | ✅           | ✅           | ⬜️           | ✅              |
 | embed           | ✅               | ✅           | ✅           | ✅           | ✅           | ✅              |
 | rerank          | ✅               | ✅           | ✅           | ✅           | ⬜️           | ✅              |
 | classify        | ✅               | ⬜️           | ⬜️           | ⬜️           | ⬜️           | ✅              |
@@ -593,5 +593,32 @@ public class ChatPost {
         System.out.println(response);
     }
 }
+```
+</CodeBlocks>
+
+#### OCI
+
+<CodeBlocks>
+```python PYTHON
+import cohere
+
+co = cohere.OciClient(
+    oci_region="us-chicago-1",
+    oci_compartment_id="ocid1.compartment.oc1...",
+)
+
+response = co.chat(
+    model="command-r-plus-08-2024",
+    chat_history=[
+        {"role": "USER", "message": "Who discovered gravity?"},
+        {
+            "role": "CHATBOT",
+            "message": "The man who is widely credited with discovering gravity is Sir Isaac Newton",
+        },
+    ],
+    message="What year was he born?",
+)
+
+print(response)
 ```
 </CodeBlocks>

--- a/fern/pages/deployment-options/oracle-cloud-infrastructure-oci.mdx
+++ b/fern/pages/deployment-options/oracle-cloud-infrastructure-oci.mdx
@@ -18,28 +18,7 @@ Under the hood, the SDK handles URL rewriting, request and response format trans
 
 ## Available Models
 
-The following Cohere models are available on OCI Generative AI:
-
-**Chat models (V2 API via `OciClientV2`):**
-- Command A (`command-a-03-2025`)
-- Command A Vision (`command-a-vision`)
-- Command A Reasoning (`command-a-reasoning`) -- dedicated endpoints only
-
-**Chat models (V1 API via `OciClient`):**
-- Command R+ 08-2024 (`command-r-plus-08-2024`)
-- Command R 08-2024 (`command-r-08-2024`)
-
-**Embedding models (both clients):**
-- Embed v4 (`embed-v4.0`)
-- Embed English v3 (`embed-english-v3.0`)
-- Embed English Light v3 (`embed-english-light-v3.0`)
-- Embed Multilingual v3 (`embed-multilingual-v3.0`)
-- Embed Multilingual Light v3 (`embed-multilingual-light-v3.0`)
-
-**Rerank models (dedicated endpoints only):**
-- Rerank v3.5 (`rerank-v3.5`)
-
-For the most updated list, see the [OCI Generative AI documentation](https://docs.oracle.com/en-us/iaas/Content/generative-ai/pretrained-models.htm).
+The SDK supports all Cohere models available on OCI Generative AI, including the Command A family (via `OciClientV2`), the Command R family (via `OciClient`), Embed models, and Rerank models. For the current list of available models and their IDs, see the [OCI Generative AI pretrained models documentation](https://docs.oracle.com/en-us/iaas/Content/generative-ai/pretrained-models.htm).
 
 ## Installation
 

--- a/fern/pages/deployment-options/oracle-cloud-infrastructure-oci.mdx
+++ b/fern/pages/deployment-options/oracle-cloud-infrastructure-oci.mdx
@@ -44,7 +44,10 @@ response = client.chat(
     model="command-a-03-2025",
     messages=[
         {"role": "system", "content": "You are a helpful assistant."},
-        {"role": "user", "content": "Explain RAG in three sentences."},
+        {
+            "role": "user",
+            "content": "Explain RAG in three sentences.",
+        },
     ],
 )
 
@@ -101,7 +104,9 @@ client = cohere.OciClientV2(
 
 for event in client.chat_stream(
     model="command-a-03-2025",
-    messages=[{"role": "user", "content": "Explain RAG in three sentences."}],
+    messages=[
+        {"role": "user", "content": "Explain RAG in three sentences."}
+    ],
 ):
     if event.type == "content-delta":
         print(event.delta.message.content.text, end="")
@@ -232,22 +237,29 @@ client = cohere.OciClientV2(
 
 response = client.chat(
     model="command-a-03-2025",
-    messages=[{"role": "user", "content": "What's the weather in Toronto?"}],
+    messages=[
+        {"role": "user", "content": "What's the weather in Toronto?"}
+    ],
     max_tokens=200,
-    tools=[{
-        "type": "function",
-        "function": {
-            "name": "get_weather",
-            "description": "Get current weather for a location",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "location": {"type": "string", "description": "City name"}
+    tools=[
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get current weather for a location",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "location": {
+                            "type": "string",
+                            "description": "City name",
+                        }
+                    },
+                    "required": ["location"],
                 },
-                "required": ["location"],
             },
-        },
-    }],
+        }
+    ],
 )
 
 if response.message.tool_calls:
@@ -275,13 +287,23 @@ with open("document.png", "rb") as f:
 
 response = client.chat(
     model="command-a-vision",
-    messages=[{
-        "role": "user",
-        "content": [
-            {"type": "text", "text": "Describe what you see in this image."},
-            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{img_b64}"}},
-        ],
-    }],
+    messages=[
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Describe what you see in this image.",
+                },
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/png;base64,{img_b64}"
+                    },
+                },
+            ],
+        }
+    ],
 )
 
 print(response.message.content[0].text)
@@ -361,7 +383,9 @@ query_embedding = client.embed(
 # Find the most relevant document (cosine similarity)
 best_idx = max(
     range(len(documents)),
-    key=lambda i: sum(a * b for a, b in zip(query_embedding, doc_embeddings[i])),
+    key=lambda i: sum(
+        a * b for a, b in zip(query_embedding, doc_embeddings[i])
+    ),
 )
 print(f"Best match: {documents[best_idx]}")
 
@@ -370,8 +394,14 @@ print(f"Best match: {documents[best_idx]}")
 response = client.chat(
     model="command-a-03-2025",
     messages=[
-        {"role": "system", "content": "Answer based on the provided context only."},
-        {"role": "user", "content": f"Context: {documents[best_idx]}\n\nWhat certifications does OCI have?"},
+        {
+            "role": "system",
+            "content": "Answer based on the provided context only.",
+        },
+        {
+            "role": "user",
+            "content": f"Context: {documents[best_idx]}\n\nWhat certifications does OCI have?",
+        },
     ],
     temperature=0.3,
 )
@@ -381,55 +411,86 @@ print(f"Answer: {response.message.content[0].text}")
 
 response = client.chat(
     model="command-a-03-2025",
-    messages=[{"role": "user", "content": "What's the current stock price of ORCL?"}],
-    tools=[{
-        "type": "function",
-        "function": {
-            "name": "get_stock_price",
-            "description": "Get the current stock price for a ticker symbol",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "ticker": {"type": "string", "description": "Stock ticker symbol"}
+    messages=[
+        {
+            "role": "user",
+            "content": "What's the current stock price of ORCL?",
+        }
+    ],
+    tools=[
+        {
+            "type": "function",
+            "function": {
+                "name": "get_stock_price",
+                "description": "Get the current stock price for a ticker symbol",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "ticker": {
+                            "type": "string",
+                            "description": "Stock ticker symbol",
+                        }
+                    },
+                    "required": ["ticker"],
                 },
-                "required": ["ticker"],
             },
-        },
-    }],
+        }
+    ],
 )
 
 # Model returns a tool call
 tool_call = response.message.tool_calls[0]
-print(f"Tool call: {tool_call.function.name}({tool_call.function.arguments})")
+print(
+    f"Tool call: {tool_call.function.name}({tool_call.function.arguments})"
+)
 
 # Send the tool result back
 final = client.chat(
     model="command-a-03-2025",
     messages=[
-        {"role": "user", "content": "What's the current stock price of ORCL?"},
+        {
+            "role": "user",
+            "content": "What's the current stock price of ORCL?",
+        },
         {
             "role": "assistant",
-            "tool_calls": [{"id": tool_call.id, "type": "function", "function": {"name": tool_call.function.name, "arguments": tool_call.function.arguments}}],
+            "tool_calls": [
+                {
+                    "id": tool_call.id,
+                    "type": "function",
+                    "function": {
+                        "name": tool_call.function.name,
+                        "arguments": tool_call.function.arguments,
+                    },
+                }
+            ],
             "tool_plan": response.message.tool_plan,
         },
         {
             "role": "tool",
             "tool_call_id": tool_call.id,
-            "content": [{"type": "text", "text": '{"ticker": "ORCL", "price": 187.42, "currency": "USD"}'}],
+            "content": [
+                {
+                    "type": "text",
+                    "text": '{"ticker": "ORCL", "price": 187.42, "currency": "USD"}',
+                }
+            ],
         },
     ],
-    tools=[{
-        "type": "function",
-        "function": {
-            "name": "get_stock_price",
-            "description": "Get the current stock price for a ticker symbol",
-            "parameters": {
-                "type": "object",
-                "properties": {"ticker": {"type": "string"}},
-                "required": ["ticker"],
+    tools=[
+        {
+            "type": "function",
+            "function": {
+                "name": "get_stock_price",
+                "description": "Get the current stock price for a ticker symbol",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"ticker": {"type": "string"}},
+                    "required": ["ticker"],
+                },
             },
-        },
-    }],
+        }
+    ],
 )
 print(f"Final answer: {final.message.content[0].text}")
 
@@ -440,13 +501,23 @@ with open("chart.png", "rb") as f:
 
 response = client.chat(
     model="command-a-vision",
-    messages=[{
-        "role": "user",
-        "content": [
-            {"type": "text", "text": "Describe the trend shown in this chart."},
-            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{img_b64}"}},
-        ],
-    }],
+    messages=[
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Describe the trend shown in this chart.",
+                },
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/png;base64,{img_b64}"
+                    },
+                },
+            ],
+        }
+    ],
 )
 print(f"Vision: {response.message.content[0].text}")
 
@@ -455,7 +526,12 @@ print(f"Vision: {response.message.content[0].text}")
 print("Streaming: ", end="")
 for event in client.chat_stream(
     model="command-a-03-2025",
-    messages=[{"role": "user", "content": "Summarize why enterprises choose OCI for AI."}],
+    messages=[
+        {
+            "role": "user",
+            "content": "Summarize why enterprises choose OCI for AI.",
+        }
+    ],
 ):
     if event.type == "content-delta":
         print(event.delta.message.content.text, end="")

--- a/fern/pages/deployment-options/oracle-cloud-infrastructure-oci.mdx
+++ b/fern/pages/deployment-options/oracle-cloud-infrastructure-oci.mdx
@@ -544,4 +544,4 @@ print()
 - [OCI Generative AI Documentation](https://docs.oracle.com/en-us/iaas/Content/generative-ai/home.htm)
 - [OCI Generative AI Pretrained Models](https://docs.oracle.com/en-us/iaas/Content/generative-ai/pretrained-models.htm)
 
-You can also work with Cohere models on OCI through the [OCI Console](https://docs.oracle.com/en-us/iaas/Content/generative-ai/use-playground-chat.htm), the [OCI CLI](https://docs.oracle.com/en-us/iaas/Content/generative-ai/use-playground-embed.htm), or the [OCI API](https://docs.oracle.com/en-us/iaas/api/#/en/generative-ai-inference/) directly.
+You can also work with Cohere models on OCI through the [OCI Console](https://docs.oracle.com/en-us/iaas/Content/generative-ai/overview.htm), the [OCI CLI](https://docs.oracle.com/en-us/iaas/tools/oci-cli/latest/oci_cli_docs/cmdref/generative-ai-inference.html), or the [OCI API](https://docs.oracle.com/en-us/iaas/api/#/en/generative-ai-inference/) directly.

--- a/fern/pages/deployment-options/oracle-cloud-infrastructure-oci.mdx
+++ b/fern/pages/deployment-options/oracle-cloud-infrastructure-oci.mdx
@@ -4,80 +4,489 @@ slug: "docs/oracle-cloud-infrastructure-oci"
 
 hidden: false
  
-description: "This page describes how to work with Cohere models on Oracle Cloud Infrastructure (OCI)"
+description: "Use Cohere models on OCI Generative AI with the native Cohere Python SDK"
 image: "../../assets/images/f1cc130-cohere_meta_image.jpg"  
-keywords: "generative AI, large language models, Oracle Cloud Infrastructure, OCI"
+keywords: "generative AI, large language models, Oracle Cloud Infrastructure, OCI, Cohere SDK"
 
 createdAt: "Mon Feb 22 2024 14:53:59 GMT+0000 (Coordinated Universal Time)"
-updatedAt: "Wed May 31 2024 16:11:36 GMT+0000 (Coordinated Universal Time)"
+updatedAt: "Fri Apr 11 2026 00:00:00 GMT+0000 (Coordinated Universal Time)"
 ---
-In an effort to make our language-model capabilities more widely available, we've partnered with a few major platforms to create hosted versions of our offerings.
 
-Here, you'll learn how to use Oracle Cloud Infrastructure (OCI) to deploy both the Cohere Command and the Cohere Embed models on the AWS cloud computing platform. The following models are available on OCI:
+The Cohere Python SDK natively supports Oracle Cloud Infrastructure (OCI) Generative AI service. With `pip install cohere[oci]`, you get `OciClient` and `OciClientV2` classes that behave identically to the Cohere-hosted `Client` and `ClientV2` -- same methods, same response types, same streaming format. Switching from Cohere's hosted API to OCI Generative AI means changing one constructor.
 
-- Command A Reasoning 
-- Command A Vision
-- Command A 
-- Command R+ 08-2024
-- Command R 08-2024
-- Command R+ (retired)
-- Command R (retired)
-- Command (deprecated)
-- Command light (deprecated)
-- Embed v4
-- Embed English v3
-- Embed English v3 light 
-- Embed Multilingual v3
-- Embed Multilingual v3 light
-- Rerank v3.5
+Under the hood, the SDK handles URL rewriting, request and response format translation, OCI cryptographic request signing, and streaming event transformation. Your application code never sees the OCI-specific details.
 
-We also support fine-tuning for Command R (`command-r-04-2024` and `command-r-08-2024`) on OCI. 
+## Available Models
 
-For the most updated list of available models, see the [OCI documentation](https://docs.oracle.com/en-us/iaas/Content/generative-ai/pretrained-models.htm).
+The following Cohere models are available on OCI Generative AI:
 
-## Working With Cohere Models on OCI
+**Chat models (V2 API via `OciClientV2`):**
+- Command A (`command-a-03-2025`)
+- Command A Vision (`command-a-vision`)
+- Command A Reasoning (`command-a-reasoning`) -- dedicated endpoints only
 
-- [Embeddings generation](https://docs.oracle.com/en-us/iaas/Content/generative-ai/use-playground-embed.htm#playground-embed)
+**Chat models (V1 API via `OciClient`):**
+- Command R+ 08-2024 (`command-r-plus-08-2024`)
+- Command R 08-2024 (`command-r-08-2024`)
 
-And OCI offers three ways to perform these workloads:
+**Embedding models (both clients):**
+- Embed v4 (`embed-v4.0`)
+- Embed English v3 (`embed-english-v3.0`)
+- Embed English Light v3 (`embed-english-light-v3.0`)
+- Embed Multilingual v3 (`embed-multilingual-v3.0`)
+- Embed Multilingual Light v3 (`embed-multilingual-light-v3.0`)
 
-- The console
-- The CLI
-- The API
+**Rerank models (dedicated endpoints only):**
+- Rerank v3.5 (`rerank-v3.5`)
 
-In the sections that follow, we'll briefly outline how to use each, and link out to other documentation to fill in any remaining gaps. 
+For the most updated list, see the [OCI Generative AI documentation](https://docs.oracle.com/en-us/iaas/Content/generative-ai/pretrained-models.htm).
 
-### The Console
+## Installation
 
-OCI offers a console through which you can perform many generative AI tasks. It allows you to select your region and the model you wish to use, then pass a prompt to the underlying model, configuring parameters as you wish.
+```bash
+pip install cohere[oci]
+```
 
-![](../../assets/images/oracle-cloud-infrastructure-oci-1.png)
+This installs the Cohere SDK along with the OCI SDK dependency required for authentication and request signing.
 
+## Quick Start
 
-If you want to use the console for [chat](https://docs.oracle.com/en-us/iaas/Content/generative-ai/use-playground-chat.htm), [text generation](https://docs.oracle.com/en-us/iaas/Content/generative-ai/use-playground-generate.htm#playground-generate), [summarization](https://docs.oracle.com/en-us/iaas/Content/generative-ai/use-playground-summarize.htm#playground-summarize), and [embeddings](https://docs.oracle.com/en-us/iaas/Content/generative-ai/use-playground-embed.htm#playground-embed), visit those links and select "console."
+### Chat with Command A (V2 API)
 
-![](../../assets/images/oracle-cloud-infrastructure-oci-2.png)
+```python
+import cohere
 
+client = cohere.OciClientV2(
+    oci_region="us-chicago-1",
+    oci_compartment_id="ocid1.compartment.oc1...",
+)
 
-### The CLI
+response = client.chat(
+    model="command-a-03-2025",
+    messages=[
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Explain RAG in three sentences."},
+    ],
+)
 
-With OCI's command line interface (CLI), it's possible to use Cohere models to generate text, get embeddings, or extract information. 
+print(response.message.content[0].text)
+```
 
-![](../../assets/images/oracle-cloud-infrastructure-oci-3.png)
+### Chat with Command R (V1 API)
 
+```python
+import cohere
 
-If you want to use the console for [text generation](https://docs.oracle.com/en-us/iaas/Content/generative-ai/use-playground-generate.htm#playground-generate), [summarization](https://docs.oracle.com/en-us/iaas/Content/generative-ai/use-playground-summarize.htm#playground-summarize), and [embeddings](https://docs.oracle.com/en-us/iaas/Content/generative-ai/use-playground-embed.htm#playground-embed), visit those links and select "CLI."
+client = cohere.OciClient(
+    oci_region="us-chicago-1",
+    oci_compartment_id="ocid1.compartment.oc1...",
+)
 
-![](../../assets/images/oracle-cloud-infrastructure-oci-4.png)
+response = client.chat(
+    model="command-r-plus-08-2024",
+    message="Explain RAG in three sentences.",
+)
 
+print(response.text)
+```
 
-### The API
+### Embeddings
 
-If you're trying to use Cohere models on OCI programmatically -- i.e. as part of software development, or while building an application -- you'll likely want to use the API.
+```python
+import cohere
 
-![](../../assets/images/oracle-cloud-infrastructure-oci-5.png)
+client = cohere.OciClientV2(
+    oci_region="us-chicago-1",
+    oci_compartment_id="ocid1.compartment.oc1...",
+)
 
+response = client.embed(
+    model="embed-english-v3.0",
+    texts=["Oracle Cloud Infrastructure", "Generative AI service"],
+    input_type="search_document",
+)
 
-If you want to use the console for [text generation](https://docs.oracle.com/en-us/iaas/Content/generative-ai/use-playground-generate.htm#playground-generate), [summarization](https://docs.oracle.com/en-us/iaas/Content/generative-ai/use-playground-summarize.htm#playground-summarize), and [embeddings](https://docs.oracle.com/en-us/iaas/Content/generative-ai/use-playground-embed.htm#playground-embed), visit those links and select "API."
+for i, embedding in enumerate(response.embeddings.float_):
+    print(f"Text {i}: {len(embedding)} dimensions")
+```
 
-![](../../assets/images/oracle-cloud-infrastructure-oci-6.png)
+### Streaming (V2)
+
+```python
+import cohere
+
+client = cohere.OciClientV2(
+    oci_region="us-chicago-1",
+    oci_compartment_id="ocid1.compartment.oc1...",
+)
+
+for event in client.chat_stream(
+    model="command-a-03-2025",
+    messages=[{"role": "user", "content": "Explain RAG in three sentences."}],
+):
+    if event.type == "content-delta":
+        print(event.delta.message.content.text, end="")
+```
+
+### Streaming (V1)
+
+```python
+import cohere
+
+client = cohere.OciClient(
+    oci_region="us-chicago-1",
+    oci_compartment_id="ocid1.compartment.oc1...",
+)
+
+for event in client.chat_stream(
+    model="command-r-plus-08-2024",
+    message="Explain RAG in three sentences.",
+):
+    if hasattr(event, "text") and event.text:
+        print(event.text, end="")
+```
+
+The SDK transforms OCI's streaming format to match Cohere's standard streaming events. V2 uses `message-start`, `content-delta`, `content-end`, `message-end`; V1 uses `stream-start`, `text-generation`, `stream-end`.
+
+## Authentication
+
+The SDK supports five authentication methods, covering every deployment scenario from local development to serverless production.
+
+### 1. Config File (Default)
+
+Uses `~/.oci/config` with the `DEFAULT` profile. No additional parameters needed beyond region and compartment.
+
+```python
+client = cohere.OciClientV2(
+    oci_region="us-chicago-1",
+    oci_compartment_id="ocid1.compartment.oc1...",
+)
+```
+
+### 2. Custom Profile
+
+Use a specific profile from your OCI config file.
+
+```python
+client = cohere.OciClientV2(
+    oci_profile="MY_PROFILE",
+    oci_region="us-chicago-1",
+    oci_compartment_id="ocid1.compartment.oc1...",
+)
+```
+
+### 3. Session-based Authentication
+
+Works with OCI CLI session tokens. The SDK automatically re-reads the token file on each request, so `oci session refresh` is picked up without restarting the client.
+
+```python
+client = cohere.OciClientV2(
+    oci_profile="MY_SESSION_PROFILE",  # Profile with security_token_file
+    oci_region="us-chicago-1",
+    oci_compartment_id="ocid1.compartment.oc1...",
+)
+```
+
+### 4. Direct Credentials
+
+Pass OCI credentials directly without a config file. Useful for CI/CD pipelines or containerized deployments.
+
+```python
+client = cohere.OciClientV2(
+    oci_user_id="ocid1.user.oc1...",
+    oci_fingerprint="xx:xx:xx:...",
+    oci_tenancy_id="ocid1.tenancy.oc1...",
+    oci_private_key_path="~/.oci/key.pem",
+    oci_region="us-chicago-1",
+    oci_compartment_id="ocid1.compartment.oc1...",
+)
+```
+
+### 5. Instance Principal
+
+For applications running on OCI Compute instances. No credentials needed -- the instance's identity is used automatically.
+
+```python
+client = cohere.OciClientV2(
+    auth_type="instance_principal",
+    oci_region="us-chicago-1",
+    oci_compartment_id="ocid1.compartment.oc1...",
+)
+```
+
+### 6. Resource Principal
+
+For OCI Functions (serverless). Zero credentials in the deployment -- the function inherits the compartment's security posture.
+
+```python
+client = cohere.OciClientV2(
+    auth_type="resource_principal",
+    oci_region="us-chicago-1",
+    oci_compartment_id="ocid1.compartment.oc1...",
+)
+```
+
+## V1 vs V2 API
+
+The SDK provides two client classes that map to the two OCI Generative AI API formats:
+
+| | `OciClient` (V1) | `OciClientV2` (V2) |
+|---|---|---|
+| **Chat models** | Command R family | Command A family |
+| **Chat format** | Single `message` string | `messages` array |
+| **Streaming events** | `text-generation`, `stream-end` | `message-start`, `content-delta`, `message-end` |
+| **Embed response** | `response.embeddings` (list of floats) | `response.embeddings.float_` (dict by type) |
+| **Tool use** | `tools` + `tool_results` | `tools` + `tool_calls` + `tool_choice` |
+| **Thinking** | Not supported | Supported via `thinking` parameter |
+
+## Tool Use (V2)
+
+Command A supports native tool use on OCI Generative AI. Define tools and the model will return `tool_calls` with structured arguments.
+
+```python
+import cohere
+
+client = cohere.OciClientV2(
+    oci_region="us-chicago-1",
+    oci_compartment_id="ocid1.compartment.oc1...",
+)
+
+response = client.chat(
+    model="command-a-03-2025",
+    messages=[{"role": "user", "content": "What's the weather in Toronto?"}],
+    max_tokens=200,
+    tools=[{
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get current weather for a location",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string", "description": "City name"}
+                },
+                "required": ["location"],
+            },
+        },
+    }],
+)
+
+if response.message.tool_calls:
+    for tc in response.message.tool_calls:
+        print(f"{tc.function.name}({tc.function.arguments})")
+# Output: get_weather({"location":"Toronto"})
+```
+
+## Vision (V2)
+
+Command A Vision can reason over images alongside text. Pass images as base64 data URIs or URLs in the message content.
+
+```python
+import cohere
+import base64
+
+client = cohere.OciClientV2(
+    oci_region="us-chicago-1",
+    oci_compartment_id="ocid1.compartment.oc1...",
+)
+
+# Read and encode an image
+with open("document.png", "rb") as f:
+    img_b64 = base64.b64encode(f.read()).decode()
+
+response = client.chat(
+    model="command-a-vision",
+    messages=[{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Describe what you see in this image."},
+            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{img_b64}"}},
+        ],
+    }],
+)
+
+print(response.message.content[0].text)
+```
+
+## Embed v4
+
+Embed v4 is Cohere's latest embedding model with 1536 dimensions, available alongside the Embed v3 family.
+
+```python
+import cohere
+
+client = cohere.OciClientV2(
+    oci_region="us-chicago-1",
+    oci_compartment_id="ocid1.compartment.oc1...",
+)
+
+response = client.embed(
+    model="embed-v4.0",
+    texts=["Oracle Cloud Infrastructure", "Generative AI service"],
+    input_type="search_document",
+)
+
+for i, embedding in enumerate(response.embeddings.float_):
+    print(f"Text {i}: {len(embedding)} dimensions")
+# Output: 1536 dimensions per text
+```
+
+## Supported Features
+
+| Feature | OCI Support |
+|---|---|
+| `chat` | Supported |
+| `chat_stream` | Supported |
+| `embed` | Supported |
+| `rerank` | Dedicated endpoints only |
+| `generate` | Not supported (OCI base models require fine-tuning) |
+| `classify` | Not supported |
+| `summarize` | Not supported |
+| `tokenize` | Offline only |
+| `detokenize` | Offline only |
+
+## End-to-End Example
+
+The following example demonstrates a complete application flow on OCI Generative AI: embedding documents for a knowledge base, retrieving relevant context, using tool calling for live data, processing images with vision, and streaming a final response.
+
+```python
+import cohere
+import base64
+
+# Initialize V2 client for Command A models
+client = cohere.OciClientV2(
+    oci_region="us-chicago-1",
+    oci_compartment_id="ocid1.compartment.oc1...",
+)
+
+# --- Step 1: Build a knowledge base with embeddings ---
+
+documents = [
+    "Oracle Cloud Infrastructure provides enterprise-grade AI services.",
+    "Cohere Command A is a 111B parameter model with 256K context window.",
+    "OCI Generative AI is FedRAMP High and DISA IL5 authorized.",
+]
+
+doc_embeddings = client.embed(
+    model="embed-english-v3.0",
+    texts=documents,
+    input_type="search_document",
+).embeddings.float_
+
+query_embedding = client.embed(
+    model="embed-english-v3.0",
+    texts=["What security certifications does OCI have?"],
+    input_type="search_query",
+).embeddings.float_[0]
+
+# Find the most relevant document (cosine similarity)
+best_idx = max(
+    range(len(documents)),
+    key=lambda i: sum(a * b for a, b in zip(query_embedding, doc_embeddings[i])),
+)
+print(f"Best match: {documents[best_idx]}")
+
+# --- Step 2: Grounded chat with retrieved context ---
+
+response = client.chat(
+    model="command-a-03-2025",
+    messages=[
+        {"role": "system", "content": "Answer based on the provided context only."},
+        {"role": "user", "content": f"Context: {documents[best_idx]}\n\nWhat certifications does OCI have?"},
+    ],
+    temperature=0.3,
+)
+print(f"Answer: {response.message.content[0].text}")
+
+# --- Step 3: Tool use — call an external API ---
+
+response = client.chat(
+    model="command-a-03-2025",
+    messages=[{"role": "user", "content": "What's the current stock price of ORCL?"}],
+    tools=[{
+        "type": "function",
+        "function": {
+            "name": "get_stock_price",
+            "description": "Get the current stock price for a ticker symbol",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "ticker": {"type": "string", "description": "Stock ticker symbol"}
+                },
+                "required": ["ticker"],
+            },
+        },
+    }],
+)
+
+# Model returns a tool call
+tool_call = response.message.tool_calls[0]
+print(f"Tool call: {tool_call.function.name}({tool_call.function.arguments})")
+
+# Send the tool result back
+final = client.chat(
+    model="command-a-03-2025",
+    messages=[
+        {"role": "user", "content": "What's the current stock price of ORCL?"},
+        {
+            "role": "assistant",
+            "tool_calls": [{"id": tool_call.id, "type": "function", "function": {"name": tool_call.function.name, "arguments": tool_call.function.arguments}}],
+            "tool_plan": response.message.tool_plan,
+        },
+        {
+            "role": "tool",
+            "tool_call_id": tool_call.id,
+            "content": [{"type": "text", "text": '{"ticker": "ORCL", "price": 187.42, "currency": "USD"}'}],
+        },
+    ],
+    tools=[{
+        "type": "function",
+        "function": {
+            "name": "get_stock_price",
+            "description": "Get the current stock price for a ticker symbol",
+            "parameters": {
+                "type": "object",
+                "properties": {"ticker": {"type": "string"}},
+                "required": ["ticker"],
+            },
+        },
+    }],
+)
+print(f"Final answer: {final.message.content[0].text}")
+
+# --- Step 4: Vision — analyze an image ---
+
+with open("chart.png", "rb") as f:
+    img_b64 = base64.b64encode(f.read()).decode()
+
+response = client.chat(
+    model="command-a-vision",
+    messages=[{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Describe the trend shown in this chart."},
+            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{img_b64}"}},
+        ],
+    }],
+)
+print(f"Vision: {response.message.content[0].text}")
+
+# --- Step 5: Stream a response in real time ---
+
+print("Streaming: ", end="")
+for event in client.chat_stream(
+    model="command-a-03-2025",
+    messages=[{"role": "user", "content": "Summarize why enterprises choose OCI for AI."}],
+):
+    if event.type == "content-delta":
+        print(event.delta.message.content.text, end="")
+print()
+```
+
+## Additional Resources
+
+- [Cohere Python SDK on GitHub](https://github.com/cohere-ai/cohere-python)
+- [OCI Generative AI Documentation](https://docs.oracle.com/en-us/iaas/Content/generative-ai/home.htm)
+- [OCI Generative AI Pretrained Models](https://docs.oracle.com/en-us/iaas/Content/generative-ai/pretrained-models.htm)
+
+You can also work with Cohere models on OCI through the [OCI Console](https://docs.oracle.com/en-us/iaas/Content/generative-ai/use-playground-chat.htm), the [OCI CLI](https://docs.oracle.com/en-us/iaas/Content/generative-ai/use-playground-embed.htm), or the [OCI API](https://docs.oracle.com/en-us/iaas/api/#/en/generative-ai-inference/) directly.

--- a/fern/pages/v2/deployment-options/cohere-works-everywhere.mdx
+++ b/fern/pages/v2/deployment-options/cohere-works-everywhere.mdx
@@ -21,13 +21,13 @@ Note that the code snippets presented in this document should be more than enoug
 The table below summarizes the environments in which Cohere models can be deployed. You'll notice it contains many links; the links in the "sdk" column take you to Github pages with more information on Cohere's language-specific SDKs, while all the others take you to relevant sections in this document.
 
 <Note title="Note"> 
-The Cohere v2 API is not yet supported for cloud deployments (Bedrock, SageMaker, Azure, and OCI) and will be coming soon. The code examples shown for these cloud deployments use the v1 API.
+The Cohere v2 API is not yet supported for some cloud deployments (Bedrock, SageMaker, Azure). OCI supports the v2 API via `OciClientV2`. The code examples shown for Bedrock, SageMaker, and Azure use the v1 API.
 </Note>
 
 | sdk                                                          | [Cohere platform](/reference/about) | [Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-cohere.html) | Sagemaker                       | Azure                       | OCI                        | Private Deployment                 |
 | ------------------------------------------------------------ | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------- | ------------------------------- | --------------------------- | -------------------------- | ------------------------------ |
 | [Typescript](https://github.com/cohere-ai/cohere-typescript) | [✅ docs](#cohere-platform)                             | [✅ docs](#bedrock)                                                                | [✅ docs](#sagemaker) | [✅ docs](#azure) | [🟠 soon]() | [✅ docs](#private-deployment) |
-| [Python](https://github.com/cohere-ai/cohere-python)         | [✅ docs](#cohere-platform)                                 | [✅ docs](#bedrock)                                                                    | [✅ docs](#sagemaker)     | [✅ docs](#azure)     | [🟠 soon]()     | [✅ docs](#private-deployment)     |
+| [Python](https://github.com/cohere-ai/cohere-python)         | [✅ docs](#cohere-platform)                                 | [✅ docs](#bedrock)                                                                    | [✅ docs](#sagemaker)     | [✅ docs](#azure)     | [✅ docs](#oci)     | [✅ docs](#private-deployment)     |
 | [Go](https://github.com/cohere-ai/cohere-go)                 | [✅ docs](#cohere-platform)                                     | [🟠 soon](#bedrock)                                                                       | [🟠 soon](#sagemaker)        | [✅ docs](#azure)         | [🟠 soon](#)         | [✅ docs](#private-deployment)         |
 | [Java](https://github.com/cohere-ai/cohere-java)             | [✅ docs](#cohere-platform)                                   | [🟠 soon](#bedrock)                                                                     | [🟠 soon](#sagemaker)      | [✅ docs](#azure)       | [🟠 soon]()       | [✅ docs](#private-deployment)       |
 
@@ -39,8 +39,8 @@ The most complete set of features is found on the cohere platform, while each of
 | --------------- | --------------- | ----------- | ----------- | ----------- | ----------- | -------------- |
 | chat_stream     | ✅               | ✅           | ✅           | ✅           | ✅           | ✅              |
 | chat            | ✅               | ✅           | ✅           | ✅           | ✅           | ✅              |
-| generate_stream | ✅               | ✅           | ✅           | ✅           | ✅           | ✅              |
-| generate        | ✅               | ✅           | ✅           | ✅           | ✅           | ✅              |
+| generate_stream | ✅               | ✅           | ✅           | ✅           | ⬜️           | ✅              |
+| generate        | ✅               | ✅           | ✅           | ✅           | ⬜️           | ✅              |
 | embed           | ✅               | ✅           | ✅           | ✅           | ✅           | ✅              |
 | rerank          | ✅               | ✅           | ✅           | ✅           | ⬜️           | ✅              |
 | classify        | ✅               | ⬜️           | ⬜️           | ⬜️           | ⬜️           | ✅              |
@@ -601,5 +601,27 @@ public class ChatPost {
         System.out.println(response);
     }
 }
+```
+</CodeBlocks>
+
+#### OCI
+
+<CodeBlocks>
+```python PYTHON
+import cohere
+
+co = cohere.OciClientV2(
+    oci_region="us-chicago-1",
+    oci_compartment_id="ocid1.compartment.oc1...",
+)
+
+response = co.chat(
+    model="command-a-03-2025",
+    messages=[
+        {"role": "user", "content": "Who discovered gravity?"},
+    ],
+)
+
+print(response)
 ```
 </CodeBlocks>


### PR DESCRIPTION
## Summary

Updates the OCI documentation to reflect the new native Cohere Python SDK integration with OCI Generative AI, contributed via [cohere-ai/cohere-python#718](https://github.com/cohere-ai/cohere-python/pull/718).

### Changes

**`oracle-cloud-infrastructure-oci.mdx`** — Complete rewrite:
- Installation instructions (`pip install cohere[oci]`)
- Quick start examples for chat (V1 + V2), embeddings, and streaming
- All 5 authentication methods: config file, custom profile, session tokens, direct credentials, instance principal, resource principal
- V1 vs V2 API comparison table (`OciClient` vs `OciClientV2`)
- Advanced features: tool use, thinking/reasoning (Command A Reasoning)
- Supported features table
- Removed stale "deploy on the AWS cloud computing platform" copy-paste error

**`cohere-works-everywhere.mdx`** (v1):
- Changed OCI Python SDK status from "soon" to "docs" in the supported environments table
- Fixed `generate` and `generate_stream` as unsupported on OCI (they were incorrectly marked as supported)
- Added OCI V1 code snippet section

**`cohere-works-everywhere.mdx`** (v2):
- Removed outdated note saying "v2 API is not yet supported for OCI"
- Changed OCI Python SDK status from "soon" to "docs"
- Fixed `generate` and `generate_stream` as unsupported on OCI
- Added OCI V2 code snippet section

## Context

The Cohere Python SDK now natively supports OCI Generative AI via `OciClient` (V1 API for Command R family) and `OciClientV2` (V2 API for Command A family). The SDK handles URL rewriting, request/response format translation, OCI cryptographic request signing, and streaming event transformation transparently.

## Test plan

- [ ] Verify the OCI page renders correctly on docs.cohere.com
- [ ] Verify code snippets in the OCI page are syntactically correct
- [ ] Verify the "cohere-works-everywhere" tables render correctly in both v1 and v2 docs
- [ ] Verify the OCI snippet sections link correctly from the table anchors (#oci)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are documentation updates plus a GitHub Actions permission/checkout tweak; main risk is broken docs rendering or incorrect code snippets/feature tables.
> 
> **Overview**
> Adds **native OCI Generative AI** documentation for the Cohere Python SDK, including install (`cohere[oci]`), V1/V2 client usage (`OciClient`/`OciClientV2`), auth options, streaming, and advanced examples (tools/vision/embed).
> 
> Updates the "Cohere works everywhere" pages (v1 and v2) to mark Python-on-OCI as **supported with docs**, add OCI code snippets, clarify that OCI supports v2 via `OciClientV2`, and correct the feature matrix to show `generate`/`generate_stream` as **not supported** on OCI.
> 
> Hardens the `check-python-code-snippets` workflow by reducing permissions and checking out fork PRs via the PR head repo + SHA.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84a8791d1ef72bfe83d842aa77e65039121bbbeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->