### PR TITLE
TW-621 Fixes supply chain pwn issue

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   run:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write  # Only for commenting
@@ -17,8 +18,7 @@ jobs:
 
       - name: Checkout PR
         if: |
-          github.event_name == 'pull_request_target' &&
-          github.event.pull_request.head.repo.full_name == github.repository
+          github.event_name == 'pull_request_target'
         run: |
           git fetch origin pull/${{ github.event.pull_request.number }}/head:pr-${{ github.event.pull_request.number }}
           git checkout pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -16,7 +16,9 @@ jobs:
         #   ref: "${{ github.event.pull_request.merge_commit_sha }}"
 
       - name: Checkout PR
-        if: github.event_name == 'pull_request_target'
+        if: |
+          github.event_name == 'pull_request_target' &&
+          github.event.pull_request.head.repo.full_name == github.repository
         run: |
           git fetch origin pull/${{ github.event.pull_request.number }}/head:pr-${{ github.event.pull_request.number }}
           git checkout pr-${{ github.event.pull_request.number }}


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the .github/workflows/preview-docs.yml file to add a new condition to the if statement in the Checkout PR job.

- The if statement now checks if the github.event.pull_request.head.repo.full_name is equal to github.repository in addition to the existing condition.
- This change ensures that the Checkout PR job only runs for pull requests from the same repository.

<!-- end-generated-description -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GitHub Actions execution conditions in a `pull_request_target` workflow, which is security-sensitive and could impact whether preview docs run for forked PRs.
> 
> **Overview**
> Hardens the `preview-docs` GitHub Actions workflow by gating the `Checkout PR` step on the PR head repository matching `github.repository`, preventing `pull_request_target` runs from fetching/checking out code from forks.
> 
> This mitigates supply-chain risk in the workflow at the cost of not generating doc previews for fork-based PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 285b53cd7b09a10b2668bbe728b8124c9a716801. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->