### PR TITLE
Fix banner link to not be relative

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1,5 +1,5 @@
 announcement:
-  message: "🚀 New Mixture of Experts (MoE) model: command-a-plus-05-2026! (<a href=\"docs/command-a-plus\" target=\"_blank\">Learn more</a>)"
+  message: "🚀 New Mixture of Experts (MoE) model: command-a-plus-05-2026! (<a href=\"https://docs.cohere.com/docs/command-a-plus\" target=\"_blank\">Learn more</a>)"
 
 instances:
   - url: cohere.docs.buildwithfern.com


### PR DESCRIPTION
<!-- begin-generated-description -->

**Description:**
The PR updates the announcement message in the `docs.yml` file.

**Changes:**
- The `message` field in the `docs.yml` file has been updated to include a new URL for the Mixture of Experts (MoE) model documentation.
- The new URL is `https://docs.cohere.com/docs/command-a-plus`.
- The previous URL was `docs/command-a-plus`.

<!-- end-generated-description -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that updates a single docs banner link; impact is limited to navigation from the announcement.
> 
> **Overview**
> Updates the `fern/docs.yml` announcement banner to use an absolute `https://docs.cohere.com/docs/command-a-plus` URL instead of a relative `docs/command-a-plus` link, ensuring the “Learn more” CTA resolves correctly across deployments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6ba32bb4194b2206a7d847f19b113ca99793883. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->