### PR TITLE
Fixes to Command A+ Materials TW-629

### DIFF
--- a/fern/pages/models/models.mdx
+++ b/fern/pages/models/models.mdx
@@ -76,7 +76,7 @@ In this table, we provide some important context for using Cohere Command models
 
 | Model Name                       | Amazon Bedrock Model ID         | Amazon SageMaker      | Azure AI Foundry         | Oracle OCI Generative AI Service |
 | :------------------------------- | :------------------------------ | :-------------------- | :----------------------- | :------------------------------- |
-| `command-a-plus-05-2026`         | N/A                             | N/A                   | Coming soon              | N/A                              |
+| `command-a-plus-05-2026`         | N/A                             | N/A                   | 'coherelabs-command-a-plus-05-2026-w4a4' | N/A              |
 | `command-a-03-2025`              | (Coming Soon)                   | Unique per deployment | Unique per deployment    | `cohere.command-a-03-2025`       |
 | `command-r7b-12-2024`            | N/A                             | N/A                   | N/A                      | N/A                              |
 | `command-r-plus`                 | `cohere.command-r-plus-v1:0`    | Unique per deployment | Unique per deployment    | `cohere.command-r-plus v1.2`     |

--- a/fern/pages/models/models.mdx
+++ b/fern/pages/models/models.mdx
@@ -76,7 +76,7 @@ In this table, we provide some important context for using Cohere Command models
 
 | Model Name                       | Amazon Bedrock Model ID         | Amazon SageMaker      | Azure AI Foundry         | Oracle OCI Generative AI Service |
 | :------------------------------- | :------------------------------ | :-------------------- | :----------------------- | :------------------------------- |
-| `command-a-plus-05-2026`         | N/A                             | N/A                   | `command-a-plus-05-2026`  | N/A                              |
+| `command-a-plus-05-2026`         | N/A                             | N/A                   | Coming soon              | N/A                              |
 | `command-a-03-2025`              | (Coming Soon)                   | Unique per deployment | Unique per deployment    | `cohere.command-a-03-2025`       |
 | `command-r7b-12-2024`            | N/A                             | N/A                   | N/A                      | N/A                              |
 | `command-r-plus`                 | `cohere.command-r-plus-v1:0`    | Unique per deployment | Unique per deployment    | `cohere.command-r-plus v1.2`     |

--- a/fern/pages/models/the-command-family-of-models/command-a-plus.mdx
+++ b/fern/pages/models/the-command-family-of-models/command-a-plus.mdx
@@ -1,5 +1,5 @@
 ---
-title: Cohere's Command A Plus Model
+title: Cohere's Command A+ Model
 slug: docs/command-a-plus
 hidden: false
 description: >-

--- a/fern/pages/v2/deployment-options/model-vault/model-vault.mdx
+++ b/fern/pages/v2/deployment-options/model-vault/model-vault.mdx
@@ -37,6 +37,7 @@ When Zero Data Retention (ZDR) is enabled for a Model Vault (Standalone) deploym
 
 | Model Name | Type of Model | Supported | Self-Serve Ability |
 | --- | --- | --- | --- |
+| Command A+ | Generative | Yes | No - Behind a Waitlist |
 | Cohere Transcribe | Speech recognition (ASR) | Yes | No - Behind a Waitlist |
 | Command-A | Generative | Yes | No - Behind a Waitlist |
 | Command-A Reasoning | Generative | Yes | No - Behind a Waitlist |


### PR DESCRIPTION
Adding minor fixes and missing references

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation corrections with no runtime or API behavior changes.
> 
> **Overview**
> Documentation updates for **Command A+** (`command-a-plus-05-2026`): the models overview now lists the correct **Azure AI Foundry** deployment id (`coherelabs-command-a-plus-05-2026-w4a4`) instead of the API model name.
> 
> The Command A+ overview page title is aligned to **“Command A+”** branding, and **Model Vault** docs add Command A+ to the supported-models table (generative, waitlist-only). A trailing newline is restored at the end of the Model Vault **Performance Tiers** section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f235bb918f42f491077b6287fa892f09304e8335. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->