### PR TITLE
chore: remove api credit code promo thing for cr+

### DIFF
--- a/fern/pages/models/the-command-family-of-models/command-r-plus.mdx
+++ b/fern/pages/models/the-command-family-of-models/command-r-plus.mdx
@@ -108,6 +108,3 @@ For more information, check out our dedicated guide on [retrieval augmented gene
 Tool use comes in single-step and multi-step variants. In the former, the model has access to a bevy of tools to generate a response, and it can call multiple tools, but it must do all of this in a single step. The model cannot execute a sequence of steps, and it cannot use the results from one tool call in a subsequent step. In the latter, however, the model can call more than one tool in a sequence of steps, using the results from one tool call in a subsequent step. This process allows the language model to reason, perform dynamic actions, and quickly adapt on the basis of information coming from external sources.
 
 Command R+ has been trained with multi-step tool use capabilities, with which it is possible to build simple agents. This functionality takes a conversation as input (with an optional user-system preamble), along with a list of available tools. The model will then generate a json-formatted list of actions to execute on a subset of those tools. For more information, check out our dedicated [multi-step tool use](/docs/multi-hop-tool-use) guide.
-
----
-Congrats on reaching the end of this page! Get an extra $1 API credit by entering the `CommandR+Docs` credit code in [your Cohere dashboard](https://dashboard.cohere.com/billing?tab=payment)


### PR DESCRIPTION
<!-- begin-generated-description -->

## Description
This PR updates the Command R+ documentation by removing the final section of the page.

## Highlights
- Removes the final section of the Command R+ documentation page, which congratulates the reader for reaching the end of the page and offers them a $1 API credit.

<!-- end-generated-description -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only removal of marketing copy; no product, API, or runtime behavior changes.
> 
> **Overview**
> Removes the end-of-page **Command R+** docs promo that offered **$1 API credit** via the `CommandR+Docs` code on the Cohere dashboard. The **Multi-Step Tool Use** section now ends after the multi-hop tool use guide link, with no trailing congratulations or billing CTA.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a870da385f04ced77fbce9ef0f81a1f8cdf5d206. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->