### PR TITLE
chore: bump generator v to 5.14.4

### DIFF
--- a/fern/apis/sdks/generators.yml
+++ b/fern/apis/sdks/generators.yml
@@ -132,7 +132,7 @@ groups:
       - sdk-only
     generators:
       - name: fernapi/fern-python-sdk
-        version: 5.14.1
+        version: 5.14.4
         smart-casing: true
         config:
           inline_request_params: false


### PR DESCRIPTION
<!-- begin-generated-description -->

**Description**

This PR updates the version of the fernapi/fern-python-sdk generator in the fern/apis/sdks/generators.yml file.

**Changes**

- The version of the fernapi/fern-python-sdk generator has been updated from 5.14.1 to 5.14.4.

<!-- end-generated-description -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only version pin for code generation; no runtime application or auth logic changes in this diff.
> 
> **Overview**
> Bumps the **Python** Fern SDK generator (`fernapi/fern-python-sdk`) from **5.14.1** to **5.14.4** in `fern/apis/sdks/generators.yml`. No other generator versions or Python generator config change in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d47d492ea8545b64c294cf3806e71b56a78ef7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->