### PR TITLE
chore(python): bump fern-python-sdk generator 5.14.6 -> 5.14.8

### DIFF
--- a/fern/apis/sdks/generators.yml
+++ b/fern/apis/sdks/generators.yml
@@ -132,7 +132,7 @@ groups:
       - sdk-only
     generators:
       - name: fernapi/fern-python-sdk
-        version: 5.14.6
+        version: 5.14.8
         smart-casing: true
         config:
           inline_request_params: false


### PR DESCRIPTION
## Bump `fernapi/fern-python-sdk` generator 5.14.6 → 5.14.8

Picks up the `construct_type` fix for bare unparameterized `dict` / `list` / `set` types in the generated Python SDK runtime (`core/unchecked_base_model.py`).

### Background
`construct_type` crashed when handed a bare, unparameterized container:
- bare `dict` → `ValueError: not enough values to unpack` (from `get_args(dict) == ()`)
- bare `list` / `set` → `IndexError: tuple index out of range`

Reported in cohere-ai/cohere-python#774. Fixed upstream in the Fern Python generator via fern-api/fern#16159 (released in `fern-python-sdk` 5.14.8). All three branches now fall back to passthrough (`Dict[Any, Any]` / `List[Any]` / `Set[Any]` semantics).

### Validation
- `fern generate --preview --group python --api sdks` succeeds (0 errors).
- Confirmed the generated `src/cohere/core/unchecked_base_model.py` contains the guard in all three branches:
  ```python
  type_args = get_args(type_)
  if not type_args:
      return object_
  ```
- Generator 5.14.8 passed Fern's own CI (including the `python-sdk` seed fixtures).

### Notes
- Supersedes the downstream patch in cohere-ai/cohere-python#775, which edited a generator-managed (non-`.fernignore`) file and would be reverted on regeneration.

Linear: FER-10934

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single version pin in generators.yml; behavior change is limited to regenerated Python SDK deserialization edge cases.
> 
> **Overview**
> Bumps the **`fernapi/fern-python-sdk`** generator in `fern/apis/sdks/generators.yml` from **5.14.6** to **5.14.8** so the next Python SDK regen picks up an upstream fix in generated `construct_type` handling.
> 
> That release stops crashes when deserializing bare unparameterized **`dict`**, **`list`**, or **`set`** types (empty `get_args`); those cases now pass through instead of raising **`ValueError`** / **`IndexError`**. No other generator config or API surface changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f342544aecf311b7e15a212eac6573795d9028e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->