### PR TITLE
feat: add MCP tool use notebook with remote server example

### DIFF
--- a/notebooks/agents/MCP_Tool_Use_TWZRD.ipynb
+++ b/notebooks/agents/MCP_Tool_Use_TWZRD.ipynb
@@ -1,0 +1,170 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# MCP Tool Use with Cohere\n",
+    "\n",
+    "This notebook shows how to use the Cohere `command-a-03-2025` model with tools exposed by a\n",
+    "remote MCP server — using the standard [`mcp`](https://pypi.org/project/mcp/) Python SDK.\n",
+    "\n",
+    "We connect to [TWZRD Agent Intel](https://intel.twzrd.xyz), a live production MCP server that\n",
+    "provides trust scoring for Web3 AI agents. The free tools work without any API key, making\n",
+    "this example runnable out-of-the-box alongside your `COHERE_API_KEY`.\n",
+    "\n",
+    "**Tools used:**\n",
+    "- `score_agent(wallet)` — returns a 0–100 trust score + risk signals for a wallet address\n",
+    "- `preflight_check(wallet)` — quick go/no-go check before making an x402 payment\n",
+    "\n",
+    "**MCP config** (for Claude Desktop):\n",
+    "```json\n",
+    "{\"mcpServers\": {\"twzrd-agent-intel\": {\"url\": \"https://intel.twzrd.xyz/mcp\"}}}\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install dependencies\n",
+    "# !pip install cohere mcp"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asyncio\n",
+    "import json\n",
+    "import os\n",
+    "\n",
+    "import cohere\n",
+    "from mcp import ClientSession\n",
+    "from mcp.client.streamable_http import streamablehttp_client\n",
+    "\n",
+    "COHERE_API_KEY = os.environ.get(\"COHERE_API_KEY\", \"<YOUR_COHERE_API_KEY>\")\n",
+    "TWZRD_MCP_URL = \"https://intel.twzrd.xyz/mcp\"\n",
+    "MODEL = \"command-a-03-2025\"\n",
+    "\n",
+    "# Wallet to check — a known repeat x402 payer from the Dexter ecosystem\n",
+    "WALLET = \"D1QkbFJKiPsymJ65RKHhF6DFB8sPMfpBaFBzuHKfJGWi\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def get_mcp_tools():\n",
+    "    \"\"\"Fetch tool schemas from the TWZRD MCP server and convert to Cohere tool format.\"\"\"\n",
+    "    async with streamablehttp_client(TWZRD_MCP_URL) as (read, write, _):\n",
+    "        async with ClientSession(read, write) as session:\n",
+    "            await session.initialize()\n",
+    "            tools_result = await session.list_tools()\n",
+    "\n",
+    "            cohere_tools = []\n",
+    "            for tool in tools_result.tools:\n",
+    "                cohere_tool = {\n",
+    "                    \"name\": tool.name,\n",
+    "                    \"description\": tool.description or \"\",\n",
+    "                    \"parameter_definitions\": {\n",
+    "                        k: {\n",
+    "                            \"description\": v.get(\"description\", \"\"),\n",
+    "                            \"type\": v.get(\"type\", \"str\"),\n",
+    "                            \"required\": k in tool.inputSchema.get(\"required\", []),\n",
+    "                        }\n",
+    "                        for k, v in tool.inputSchema.get(\"properties\", {}).items()\n",
+    "                    },\n",
+    "                }\n",
+    "                cohere_tools.append(cohere_tool)\n",
+    "    return cohere_tools\n",
+    "\n",
+    "tools = asyncio.run(get_mcp_tools())\n",
+    "print(f\"Loaded {len(tools)} tools from TWZRD MCP server:\")\n",
+    "for t in tools:\n",
+    "    print(f\"  - {t['name']}: {t['description'][:60]}...\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def call_mcp_tool(tool_name: str, tool_input: dict) -> str:\n",
+    "    \"\"\"Execute a tool call against the TWZRD MCP server.\"\"\"\n",
+    "    async with streamablehttp_client(TWZRD_MCP_URL) as (read, write, _):\n",
+    "        async with ClientSession(read, write) as session:\n",
+    "            await session.initialize()\n",
+    "            result = await session.call_tool(tool_name, tool_input)\n",
+    "            return result.content[0].text\n",
+    "\n",
+    "\n",
+    "def run_agent(question: str, wallet: str) -> str:\n",
+    "    \"\"\"Agentic loop: Cohere decides which MCP tools to call, we execute them, loop until done.\"\"\"\n",
+    "    co = cohere.ClientV2(api_key=COHERE_API_KEY)\n",
+    "\n",
+    "    messages = [{\"role\": \"user\", \"content\": f\"{question} Wallet: {wallet}\"}]\n",
+    "    tool_results = []\n",
+    "\n",
+    "    while True:\n",
+    "        response = co.chat(\n",
+    "            model=MODEL,\n",
+    "            messages=messages,\n",
+    "            tools=tools,\n",
+    "        )\n",
+    "\n",
+    "        # No tool calls → final answer\n",
+    "        if not response.message.tool_calls:\n",
+    "            return response.message.content[0].text\n",
+    "\n",
+    "        # Execute each tool call\n",
+    "        messages.append(response.message)\n",
+    "        tool_results = []\n",
+    "        for tc in response.message.tool_calls:\n",
+    "            print(f\"  → Calling {tc.function.name}({tc.function.arguments})\")\n",
+    "            result = asyncio.run(\n",
+    "                call_mcp_tool(tc.function.name, json.loads(tc.function.arguments))\n",
+    "            )\n",
+    "            tool_results.append({\n",
+    "                \"role\": \"tool\",\n",
+    "                \"tool_call_id\": tc.id,\n",
+    "                \"content\": result,\n",
+    "            })\n",
+    "\n",
+    "        messages.extend(tool_results)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "question = \"Should I make an x402 payment to this Web3 agent wallet? Check its trust score and preflight status, then give a recommendation.\"\n",
+    "print(f\"Question: {question}\\n\"  )\n",
+    "answer = run_agent(question, WALLET)\n",
+    "print(f\"\\nFinal answer:\\n{answer}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Adds `notebooks/agents/MCP_Tool_Use_TWZRD.ipynb` — a working notebook showing how to use Cohere's `command-a-03-2025` model with tools from a **remote MCP server** via the standard `mcp` Python SDK.

## Why this is useful

The existing tool-use notebooks (`Vanilla_Tool_Use.ipynb`, `Multi_Step_Tool_Use.ipynb`) show tools defined inline as Python functions. This notebook shows the complementary pattern: connecting to an **already-deployed remote MCP server** and using its tools with Cohere's chat API — which is increasingly how real-world agents consume tools.

## What the notebook demonstrates

1. **Fetching tool schemas from a remote MCP server** and converting them to Cohere's tool format
2. **Agentic loop** — Cohere decides which tools to call, we execute them against the remote server, loop until a final answer
3. **streamable-http transport** — the recommended transport for hosted MCP servers

## Live server used

[TWZRD Agent Intel](https://intel.twzrd.xyz/mcp) — a production MCP server (streamable-http) with two free tools:
- `score_agent(wallet)` — 0–100 trust score for a Web3 agent wallet
- `preflight_check(wallet)` — go/no-go before making an x402 payment

**No API key needed** for the TWZRD tools — the notebook runs out-of-the-box with just a `COHERE_API_KEY`.

## Dependencies

```
pip install cohere mcp
```

## Test plan

- [ ] Set `COHERE_API_KEY` in environment
- [ ] Run all cells — should complete the agentic loop and print a trust recommendation
- [ ] Verify tool calls are visible in the output (the loop prints `→ Calling <tool>`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no production code, auth, or data-path changes; runtime depends on an external MCP endpoint and user-supplied API key.
> 
> **Overview**
> Adds **`notebooks/agents/MCP_Tool_Use_TWZRD.ipynb`**, a new agent example that wires Cohere **`command-a-03-2025`** to tools on a **hosted MCP server** (TWZRD Agent Intel over streamable HTTP) via the **`mcp`** Python SDK, instead of inline Python tool definitions like the existing vanilla tool-use notebooks.
> 
> The notebook **loads remote tool schemas** (`list_tools`), **maps MCP JSON Schema to Cohere `parameter_definitions`**, and runs a **multi-turn agent loop** with **`ClientV2.chat`**: the model chooses tools, the notebook executes **`call_tool`** on the server, appends tool results, and repeats until a final answer. The demo question drives **`score_agent`** / **`preflight_check`** for a sample Web3 wallet using only **`COHERE_API_KEY`** (TWZRD free tools need no key).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 021f41ceb23e989a72af0d55361b3ab056ca5f3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->