### PR TITLE
Upgrade Fern Version

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "cohere",
-  "version": "5.44.6"
+  "version": "5.49.1"
 }


### PR DESCRIPTION
## What

Bumps the Fern CLI version in `fern/fern.config.json` from `5.44.6` to `5.49.1`.

## Why

The v2 chat endpoint's `messages` field (`/v2/reference/chat`) was rendering as
"list of any" with no variant selector, instead of showing the **Show 4 variants**
dropdown (User / Assistant / System / Tool messages).

Upgrading the pinned version picks up the fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single config version pin with no application or auth logic changes; impact is limited to Fern doc generation output.
> 
> **Overview**
> Pins the **Fern CLI** in `fern/fern.config.json` from `5.44.6` to **`5.49.1`** so generated API docs pick up upstream rendering fixes.
> 
> The v2 **chat** `messages` field was showing as a generic “list of any” instead of the discriminated **User / Assistant / System / Tool** variant UI; this version bump is intended to restore the correct **Show variants** behavior on `/v2/reference/chat`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1183cee4f69985d3ed919eb0c9c744e2ad7f5b25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->