### PR TITLE
Fixes local builds, reverts changelog styling, and hardens Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,15 @@ install:
 	$(PNPM10) install --frozen-lockfile --filter .
 
 dev:
-	$(NODE24) ./node_modules/fern-api/cli.cjs docs dev
+	@# Temporary workaround for Fern preview bootstrap in pnpm workspaces.
+	@tmp_dir=$$(mktemp -d); \
+	trap 'rm -rf "$$tmp_dir"' EXIT INT TERM; \
+	{ \
+	  echo '#!/usr/bin/env bash'; \
+	  echo 'if [ "$$1" = "i" ] && [ "$$2" = "esbuild" ]; then'; \
+	  echo '  exec npx -y pnpm@10 i esbuild --workspace-root'; \
+	  echo 'fi'; \
+	  echo 'exec npx -y pnpm@10 "$$@"'; \
+	} > "$$tmp_dir/pnpm"; \
+	chmod +x "$$tmp_dir/pnpm"; \
+	PATH="$$tmp_dir:$$PATH" $(NODE24) ./node_modules/fern-api/cli.cjs docs dev

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,60 @@
-.PHONY: install dev
+.PHONY: install build dev run stop
 
 PNPM10 := npx -y pnpm@10
 NODE24 := npx -y node@24
+FERN_PGID_FILE := .fern-docs-dev.pgid
 
 install:
 	$(PNPM10) install --frozen-lockfile --filter .
 
-dev:
-	@# Temporary workaround for Fern preview bootstrap in pnpm workspaces.
-	@tmp_dir=$$(mktemp -d); \
-	trap 'rm -rf "$$tmp_dir"' EXIT INT TERM; \
-	{ \
-	  echo '#!/usr/bin/env bash'; \
-	  echo 'if [ "$$1" = "i" ] && [ "$$2" = "esbuild" ]; then'; \
-	  echo '  exec npx -y pnpm@10 i esbuild --workspace-root'; \
-	  echo 'fi'; \
-	  echo 'exec npx -y pnpm@10 "$$@"'; \
-	} > "$$tmp_dir/pnpm"; \
-	chmod +x "$$tmp_dir/pnpm"; \
-	PATH="$$tmp_dir:$$PATH" $(NODE24) ./node_modules/fern-api/cli.cjs docs dev
+build:
+	@$(PNPM10) run clean
+	$(PNPM10) install --frozen-lockfile --filter .
+
+stop:
+	@echo "Stopping Fern's next server..."
+	@if [ -f "$(FERN_PGID_FILE)" ]; then \
+		pgid=$$(cat "$(FERN_PGID_FILE)"); \
+		kill -TERM -$$pgid 2>/dev/null || true; \
+		sleep 1; \
+		kill -KILL -$$pgid 2>/dev/null || true; \
+		rm -f "$(FERN_PGID_FILE)"; \
+	fi
+	@echo "Clearing fern cache..."
+	@time rm -rf ~/.fern/app-preview || true
+	@echo "Done."
+
+dev: stop build
+	@bash -lc 'set -e; \
+		tmp_dir=$$(mktemp -d); \
+		cleaned=0; \
+		cleanup(){ \
+			[ "$$cleaned" -eq 1 ] && return; cleaned=1; \
+			if [ -f "$(FERN_PGID_FILE)" ]; then \
+				pgid=$$(cat "$(FERN_PGID_FILE)"); \
+				kill -TERM -$$pgid 2>/dev/null || true; \
+				sleep 1; \
+				kill -KILL -$$pgid 2>/dev/null || true; \
+				rm -f "$(FERN_PGID_FILE)"; \
+			fi; \
+			rm -rf "$$tmp_dir"; \
+		}; \
+		trap "cleanup; exit 0" INT TERM; \
+		trap "cleanup" EXIT; \
+		{ \
+			echo "#!/usr/bin/env bash"; \
+			echo "if [ \"\$$1\" = \"i\" ] && [ \"\$$2\" = \"esbuild\" ]; then"; \
+			echo "  exec npx -y pnpm@10 i esbuild --workspace-root"; \
+			echo "fi"; \
+			echo "exec npx -y pnpm@10 \"\$$@\""; \
+		} > "$$tmp_dir/pnpm"; \
+		chmod +x "$$tmp_dir/pnpm"; \
+		set -m; \
+		PATH="$$tmp_dir:$$PATH" $(NODE24) ./node_modules/fern-api/cli.cjs docs dev & \
+		pid=$$!; \
+		pgid=$$(ps -o pgid= -p $$pid | tr -d " "); \
+		echo $$pgid > "$(FERN_PGID_FILE)"; \
+		wait $$pid || true'
+
+run:
+	@make dev

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,12 @@ dev: stop build
 		pid=$$!; \
 		pgid=$$(ps -o pgid= -p $$pid | tr -d " "); \
 		echo $$pgid > "$(FERN_PGID_FILE)"; \
-		wait $$pid || true'
+				status=0; \
+		wait $$pid || status=$$?; \
+		if [ "$$status" -eq 130 ] || [ "$$status" -eq 143 ]; then \
+			exit 0; \
+		fi; \
+		exit "$$status"'
 
 run:
 	@make dev

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -95,6 +95,7 @@ layout:
   searchbar-placement: header-tabs
   header-height: 50px
   sidebar-width: 298px
+  changelog-layout: classic
 
 theme:
   body: canvas

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "cohere",
-  "version": "5.49.1"
+  "version": "5.55.0"
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "cohere-ai": "^7.14.0",
     "gray-matter": "^4.0.3",
-    "fern-api": "5.44.6",
+    "fern-api": "5.55.0",
     "react": "^18.3.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^7.14.0
         version: 7.14.0(@aws-sdk/client-sso-oidc@3.679.0(@aws-sdk/client-sts@3.679.0))
       fern-api:
-        specifier: 5.44.6
-        version: 5.44.6
+        specifier: 5.55.0
+        version: 5.55.0
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
@@ -1941,8 +1941,8 @@ packages:
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
 
-  fern-api@5.44.6:
-    resolution: {integrity: sha512-3LTTQn5J63BMOja/wYiB/ZnrS6xFa9PupE+9G0FIsxz807gTgXlZpce2/LpB5gJkySWghvT2B0qxT39h5NavSw==}
+  fern-api@5.55.0:
+    resolution: {integrity: sha512-55HLDfDJR/YpJrrHfankxi9+NJYrMk+ESEsp+TT88LQAHs0XWApSuOc0qUYMJNY7n86yTdlVplH7EY/yaJ1gnw==}
     hasBin: true
 
   fill-range@7.1.1:
@@ -5528,7 +5528,7 @@ snapshots:
     dependencies:
       bser: 2.1.1
 
-  fern-api@5.44.6:
+  fern-api@5.55.0:
     optionalDependencies:
       '@boundaryml/baml': 0.219.0
 


### PR DESCRIPTION
- Addresses issue with local builds failing by adding a Makefile shim
- Upgrades Fern to 5.55.0 to make use of flag that allows us to maintain our existing changelog styling
- Hardens Makefile to prevent issues with local build corruption which can be very debilitating to local machines as far as CPU and memory

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to docs tooling, dependency versions, changelog layout config, and local dev scripts—no production API or auth paths.
> 
> **Overview**
> Upgrades **Fern** from `5.44.6` / `5.49.1` to **5.55.0** in `package.json`, `pnpm-lock.yaml`, and `fern/fern.config.json`, and sets **`changelog-layout: classic`** in `fern/docs.yml` so changelog pages keep the prior styling after the bump.
> 
> **Makefile** no longer runs a bare `fern docs dev`. It adds **`build`** (clean + frozen install), **`stop`** (kill the dev process group via `.fern-docs-dev.pgid`, clear `~/.fern/app-preview`), and **`run`** as an alias for **`dev`**. **`make dev`** runs stop → build, then starts docs dev with a temporary **`pnpm` shim** (routes `pnpm i esbuild` to workspace-root install), tracks the process group for cleanup on exit/interrupt, and treats Ctrl+C exit codes as success.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53678ace0cb539e142253cdf684898ce8465570b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->