### PR TITLE
fix: typo 'sepcs' -> 'specs' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ We support the following SDKs which can be used to interact with the Cohere plat
 
 ## How to contribute to this repository
 
-We welcome contributions to this repository! Feel free to pull request any of the content you see and we will work with you to merge it. The OpenAPI sepcs and snippets are one-way synced from our internal repositories so we will need to take your changes and merge them behind the scenes.
+We welcome contributions to this repository! Feel free to pull request any of the content you see and we will work with you to merge it. The OpenAPI specs and snippets are one-way synced from our internal repositories so we will need to take your changes and merge them behind the scenes.
 
 ## Making local builds
 


### PR DESCRIPTION
## Summary
The contributing section of the README says "The OpenAPI sepcs and snippets are one-way synced" — `sepcs` is a typo for `specs`. Small but it appears right in the section contributors read before submitting changes.

## How to reproduce
Open README.md and search for "sepcs" on line 31.

## Test plan
Confirm the word reads "specs" after the change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording fix with no runtime or behavioral impact.
> 
> **Overview**
> Fixes a typo in the **How to contribute** section of `README.md`: **OpenAPI sepcs** is now **OpenAPI specs** in the sentence about one-way sync from internal repositories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ee0898c5068aa5c6fd0c5cff20d64bf0de8cc75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->