### PR TITLE
docs(model-vault): update Model Vault Encrypted usage

### DIFF
--- a/fern/pages/model-vault/encrypted/api-usage.mdx
+++ b/fern/pages/model-vault/encrypted/api-usage.mdx
@@ -22,6 +22,7 @@ The Cohere OHTTP proxy comes in two forms, and which one you use determines whic
 | Form | What it is | Clients you can use |
 | --- | --- | --- |
 | **Embedded Cohere OHTTP client** | Built into the Cohere SDK; it verifies attestation and handles OHTTP for you | Cohere SDK |
+| **Python Cohere wrapping package** | A python package that verifies attestation and handles OHTTP by wrapping communication from httpx-based SDKs | Cohere SDK, OpenAI SDK, other httpx-based Python SDKs |
 | **Standalone Cohere OHTTP proxy** | A standalone local proxy you run; it verifies attestation and handles OHTTP transparently | Cohere SDK, raw HTTP, **or** OpenAI-compatible (point any of them at the local proxy) |
 
 In both cases, the Cohere OHTTP proxy does the same two things on your behalf:
@@ -33,7 +34,8 @@ In both cases, the Cohere OHTTP proxy does the same two things on your behalf:
 ## Option 1: Cohere SDK with the embedded Cohere OHTTP client
 
 With the embedded client, point the Cohere SDK at the vault as usual; the SDK verifies attestation and
-encrypts to the TEE transparently. Your application code is unchanged from a standard vault.
+encrypts to the TEE transparently using an encrypted vault URL. Your application code is unchanged from
+a standard vault.
 
 ```python PYTHON
 import cohere
@@ -53,7 +55,34 @@ response = co.chat(
 print(response.message.content[0].text)
 ```
 
-## Option 2: Cohere OHTTP proxy with any client
+## Option 2: Cohere SDK with the Python Wrapping Package
+
+Use our 'conseel' package to replace the httpx Transport layer of the Cohere SDK with
+one that verifies attestation and encrypts all traffic to the TEE. Beside the change in cohere client
+construction, the Cohere SDK usage remains unchanged from a standard vault.
+
+```python PYTHON
+import cohere
+import httpx
+from conseel import Transport
+
+co = cohere.ClientV2(
+    api_key="<COHERE_API_KEY>",
+    base_url="<YOUR_VAULT_ENDPOINT_URL>",
+    httpx_client=httpx.Client(transport=Transport()),
+)
+
+response = co.chat(
+    model="<YOUR_VAULT_MODEL_NAME>",
+    messages=[
+        {"role": "user", "content": "Hello from an encrypted vault!"}
+    ],
+)
+
+print(response.message.content[0].text)
+```
+
+## Option 3: Cohere OHTTP proxy with any client
 
 Run the Cohere OHTTP proxy locally, then point **any** client at the local proxy URL instead of the vault
 endpoint. The proxy verifies attestation and applies OHTTP, so from your code's perspective the call
@@ -127,9 +156,9 @@ modes are off, that firmware and code measurements match the approved policy, an
 key belongs to that environment. Only then does it encrypt and send your request. Attestation tokens
 are short-lived and refreshed periodically, so the guarantee reflects the environment's current state.
 
-Verification is not limited to setup time: every inference response includes an attestation
-certificate that your client can check programmatically, so you can confirm proof of the policy, CPU,
-GPU, and software for the environment that served each response.
+Verification is not limited to setup time: With the Cohere Python OHTTP Wrapper (conseel), every inference response 
+includes an attestation certificate (under the `x-tng-attestation-token` header) that your client can check programmatically,
+so you can view proof of the policy, CPU, GPU, and software for the environment that served each response.
 
 For the full list of what is checked and how to inspect it, see
 [Verifying Your Deployment](/docs/model-vault/encrypted/verifying-deployment).

--- a/fern/pages/model-vault/encrypted/api-usage.mdx
+++ b/fern/pages/model-vault/encrypted/api-usage.mdx
@@ -23,7 +23,7 @@ The Cohere OHTTP proxy comes in three forms, and which one you use determines wh
 | --- | --- | --- |
 | **Embedded Cohere OHTTP client (coming soon)** | Built into the Cohere Python SDK; it verifies attestation and handles OHTTP for you | Cohere SDK |
 | **Cohere Python OHTTP wrapper (conseel)** | A Python package that verifies attestation and handles OHTTP by wrapping httpx-based communication | Cohere SDK, OpenAI SDK, other httpx-based Python SDKs |
-| **Standalone Cohere OHTTP proxy (coming soon)** | A standalone local proxy container you run; it verifies attestation and handles OHTTP transparently | Cohere SDK, raw HTTP, **or** OpenAI-compatible (point any of them at the local proxy) |
+| **Standalone Cohere OHTTP proxy** | A standalone local proxy container you run; it verifies attestation and handles OHTTP transparently | Cohere SDK, raw HTTP, **or** OpenAI-compatible (point any of them at the local proxy) |
 
 In all cases, the Cohere OHTTP proxy does the same two things on your behalf:
 
@@ -37,7 +37,7 @@ With the embedded client, point the Cohere SDK at the vault as usual; the SDK ve
 encrypts all traffic to the attested environment transparently using an encrypted vault URL. Your application
 code remains unchanged from a standard vault.
 
-Install Cohere client with encrypted vault support via PyPI (for x86/ARM machines running Linux/Mac):
+Install Cohere client with encrypted vault support via PyPI (for x86/ARM machines running Linux/Mac OS):
 ```bash BASH
 pip install cohere[mve]
 ```
@@ -116,14 +116,14 @@ response = client.chat.completions.create(
 print(response.choices[0].message.content)
 ```
 
-## Option 3: Cohere OHTTP proxy with any client (coming soon)
+## Option 3: Cohere OHTTP proxy with any client
 
 Run the Cohere OHTTP proxy container locally, then point **any** client at the local proxy address instead 
 of the vault endpoint. The proxy verifies attestation and encrypts all traffic to the attested environment,
 so from your client's perspective the call looks like an ordinary plaintext request to a local address. This
 means any clients producing HTTP Cohere/OpenAI API requests work without changes. The only change required is
-the addition of an `X-Gateway-Model-Name` header to any requests to aid in routing through load balancers that
-cannot inspect the request body.
+the addition of an `X-Gateway-Model-Name` header to any requests to aid in routing through load balancers since
+they cannot inspect the request body for encrypted vaults.
 
 
 Run the container using a container platform such as Docker:
@@ -131,7 +131,7 @@ Run the container using a container platform such as Docker:
 docker run -it --rm --network host \
   -e IN_HOST=0.0.0.0 -e IN_PORT=8080 \
   -e TARGET_URL=<YOUR_VAULT_ENDPOINT_URL> \
-  ghcr.io/cohere-ai/tng-ingress:latest
+  ghcr.io/cohere-ai/tng-ingress:0.5.0
 ```
 
 Then use the Cohere SDK via the proxy:

--- a/fern/pages/model-vault/encrypted/api-usage.mdx
+++ b/fern/pages/model-vault/encrypted/api-usage.mdx
@@ -15,28 +15,34 @@ your environment and, before any data leaves it, **verifies the deployment's
 [remote attestation](/docs/model-vault/encrypted/attestation) and encrypts your request end to end**,
 refusing the connection if verification does not pass.
 
-## Two ways to connect through the Cohere OHTTP proxy
+## Three ways to connect through the Cohere OHTTP proxy
 
-The Cohere OHTTP proxy comes in two forms, and which one you use determines which clients you can use:
+The Cohere OHTTP proxy comes in three forms, and which one you use determines which clients you can use:
 
 | Form | What it is | Clients you can use |
 | --- | --- | --- |
-| **Embedded Cohere OHTTP client** | Built into the Cohere SDK; it verifies attestation and handles OHTTP for you | Cohere SDK |
-| **Python Cohere wrapping package** | A python package that verifies attestation and handles OHTTP by wrapping communication from httpx-based SDKs | Cohere SDK, OpenAI SDK, other httpx-based Python SDKs |
-| **Standalone Cohere OHTTP proxy** | A standalone local proxy you run; it verifies attestation and handles OHTTP transparently | Cohere SDK, raw HTTP, **or** OpenAI-compatible (point any of them at the local proxy) |
+| **Embedded Cohere OHTTP client (coming soon)** | Built into the Cohere Python SDK; it verifies attestation and handles OHTTP for you | Cohere SDK |
+| **Cohere Python OHTTP wrapper (conseel)** | A Python package that verifies attestation and handles OHTTP by wrapping httpx-based communication | Cohere SDK, OpenAI SDK, other httpx-based Python SDKs |
+| **Standalone Cohere OHTTP proxy (coming soon)** | A standalone local proxy container you run; it verifies attestation and handles OHTTP transparently | Cohere SDK, raw HTTP, **or** OpenAI-compatible (point any of them at the local proxy) |
 
-In both cases, the Cohere OHTTP proxy does the same two things on your behalf:
+In all cases, the Cohere OHTTP proxy does the same two things on your behalf:
 
-- **Verifies attestation**: it fetches the vault's attestation token and OHTTP public key, confirms the token was genuinely signed by Intel Trust Authority, checks that the attested measurements match the approved policy, and confirms the OHTTP key is bound to that attested environment.
+- **Verifies attestation**: it fetches the environment's attestation token and OHTTP public key, confirms the token was genuinely signed by Intel Trust Authority, checks that the attested measurements match the approved policy, and confirms the OHTTP key is bound to that attested environment.
 - **Encrypts end to end**: it encrypts every request to the attested environment using OHTTP and decrypts the response, so the load balancer and network only ever see ciphertext.
 
 
-## Option 1: Cohere SDK with the embedded Cohere OHTTP client
+## Option 1: Cohere SDK with the embedded Cohere OHTTP client (coming soon)
 
 With the embedded client, point the Cohere SDK at the vault as usual; the SDK verifies attestation and
-encrypts to the TEE transparently using an encrypted vault URL. Your application code is unchanged from
-a standard vault.
+encrypts all traffic to the attested environment transparently using an encrypted vault URL. Your application
+code remains unchanged from a standard vault.
 
+Install Cohere client with encrypted vault support via PyPI (for x86/ARM machines running Linux/Mac):
+```bash BASH
+pip install cohere[mve]
+```
+
+Use Cohere client as normal:
 ```python PYTHON
 import cohere
 
@@ -48,19 +54,25 @@ co = cohere.ClientV2(
 response = co.chat(
     model="<YOUR_VAULT_MODEL_NAME>",
     messages=[
-        {"role": "user", "content": "Hello from an encrypted vault!"}
+        {"role": "user", "content": "Hello to an encrypted vault!"}
     ],
 )
 
 print(response.message.content[0].text)
 ```
 
-## Option 2: Cohere SDK with the Python Wrapping Package
+## Option 2: Cohere Python OHTTP Wrapper
 
-Use our 'conseel' package to replace the httpx Transport layer of the Cohere SDK with
-one that verifies attestation and encrypts all traffic to the TEE. Beside the change in cohere client
-construction, the Cohere SDK usage remains unchanged from a standard vault.
+Use our 'conseel' package to replace the transport layer in any httpx-based Python SDK with
+one that verifies attestation and encrypts all traffic to the attested environment. Besides the
+change in client construction, the SDK usage remains unchanged from a standard vault.
 
+Install package via PyPI (for x86/ARM machines running Linux/Mac):
+```
+pip install conseel
+```
+
+Use with Cohere SDK:
 ```python PYTHON
 import cohere
 import httpx
@@ -75,67 +87,101 @@ co = cohere.ClientV2(
 response = co.chat(
     model="<YOUR_VAULT_MODEL_NAME>",
     messages=[
-        {"role": "user", "content": "Hello from an encrypted vault!"}
+        {"role": "user", "content": "Hello to an encrypted vault!"}
     ],
 )
 
 print(response.message.content[0].text)
 ```
 
-## Option 3: Cohere OHTTP proxy with any client
-
-Run the Cohere OHTTP proxy locally, then point **any** client at the local proxy URL instead of the vault
-endpoint. The proxy verifies attestation and applies OHTTP, so from your code's perspective the call
-looks like an ordinary plaintext request to a local address, which means raw HTTP and
-OpenAI-compatible clients work without changes.
-
-**Cohere SDK via the proxy:**
-
+Use with other httpx-based clients such as the OpenAI SDK:
 ```python PYTHON
-import cohere
+import openai
+import httpx
+from conseel import Transport
 
-# Point the SDK at the local Cohere OHTTP proxy instead of the vault endpoint.
-co = cohere.ClientV2(
+client = openai.OpenAI(
     api_key="<COHERE_API_KEY>",
-    base_url="<LOCAL_OHTTP_PROXY_URL>",
-)
-
-response = co.chat(
-    model="<YOUR_VAULT_MODEL_NAME>",
-    messages=[
-        {"role": "user", "content": "Hello from an encrypted vault!"}
-    ],
-)
-
-print(response.message.content[0].text)
-```
-
-**Raw HTTP via the proxy:**
-
-```bash cURL
-curl "<LOCAL_OHTTP_PROXY_URL>/v2/chat" \
-  -H "Authorization: bearer <COHERE_API_KEY>" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "<YOUR_VAULT_MODEL_NAME>",
-    "messages": [{"role": "user", "content": "Hello from an encrypted vault!"}]
-  }'
-```
-
-**OpenAI-compatible client via the proxy:**
-
-```python PYTHON
-from openai import OpenAI
-
-client = OpenAI(
-    api_key="<COHERE_API_KEY>",
-    base_url="<LOCAL_OHTTP_PROXY_URL>/compatibility/v1",
+    base_url="<YOUR_VAULT_ENDPOINT_URL>/v1",
+    httpx_client=httpx.Client(transport=Transport()),
 )
 
 response = client.chat.completions.create(
     model="<YOUR_VAULT_MODEL_NAME>",
     messages=[
-        {"role": "user", "content": "Hello from an encrypted vault!"}
+        {"role": "user", "content": "Hello to an encrypted vault!"}
+    ],
+)
+
+print(response.choices[0].message.content)
+```
+
+## Option 3: Cohere OHTTP proxy with any client (coming soon)
+
+Run the Cohere OHTTP proxy container locally, then point **any** client at the local proxy address instead 
+of the vault endpoint. The proxy verifies attestation and encrypts all traffic to the attested environment,
+so from your client's perspective the call looks like an ordinary plaintext request to a local address. This
+means any clients producing HTTP Cohere/OpenAI API requests work without changes. The only change required is
+the addition of an `X-Gateway-Model-Name` header to any requests to aid in routing through load balancers that
+cannot inspect the request body.
+
+
+Run the container using a container platform such as Docker:
+```bash BASH
+docker run -it --rm --network host \
+  -e IN_HOST=0.0.0.0 -e IN_PORT=8080 \
+  -e TARGET_URL=<YOUR_VAULT_ENDPOINT_URL> \
+  ghcr.io/cohere-ai/tng-ingress:latest
+```
+
+Then use the Cohere SDK via the proxy:
+```python PYTHON
+import cohere
+import httpx
+
+# Point the SDK at the local Cohere OHTTP proxy instead of the vault endpoint.
+co = cohere.ClientV2(
+    api_key="<COHERE_API_KEY>",
+    base_url="<LOCAL_OHTTP_PROXY_URL>",
+    httpx_client=httpx.Client(headers={"X-Gateway-Model-Name": "<YOUR_VAULT_MODEL_NAME>"}),
+)
+
+response = co.chat(
+    model="<YOUR_VAULT_MODEL_NAME>",
+    messages=[
+        {"role": "user", "content": "Hello to an encrypted vault!"}
+    ],
+)
+
+print(response.message.content[0].text)
+```
+
+Make a raw HTTP request via the proxy:
+```bash cURL
+curl "<LOCAL_OHTTP_PROXY_URL>/v2/chat" \
+  -H "Authorization: Bearer <COHERE_API_KEY>" \
+  -H "Content-Type: application/json" \
+  -H "X-Gateway-Model-Name: <YOUR_VAULT_MODEL_NAME>" \
+  -d '{
+    "model": "<YOUR_VAULT_MODEL_NAME>",
+    "messages": [{"role": "user", "content": "Hello to an encrypted vault!"}]
+  }'
+```
+
+Use OpenAI-compatible client via the proxy:
+```python PYTHON
+from openai import OpenAI
+
+client = OpenAI(
+    api_key="<COHERE_API_KEY>",
+    base_url="<LOCAL_OHTTP_PROXY_URL>/v1",
+    default_headers={"X-Gateway-Model-Name": "<YOUR_VAULT_MODEL_NAME>"}
+)
+
+response = client.chat.completions.create(
+    model="<YOUR_VAULT_MODEL_NAME>",
+    messages=[
+        {"role": "user", "content": "Hello to an encrypted vault!"}
     ],
 )
 
@@ -156,9 +202,9 @@ modes are off, that firmware and code measurements match the approved policy, an
 key belongs to that environment. Only then does it encrypt and send your request. Attestation tokens
 are short-lived and refreshed periodically, so the guarantee reflects the environment's current state.
 
-Verification is not limited to setup time: With the Cohere Python OHTTP Wrapper (conseel), every inference response 
+Verification is not limited to setup time: With the Cohere Python OHTTP wrapper (conseel), every inference response 
 includes an attestation certificate (under the `x-tng-attestation-token` header) that your client can check programmatically,
-so you can view proof of the policy, CPU, GPU, and software for the environment that served each response.
+so you can inspect proof of the policy, CPU, GPU, and software for the environment that served each response.
 
 For the full list of what is checked and how to inspect it, see
 [Verifying Your Deployment](/docs/model-vault/encrypted/verifying-deployment).
@@ -170,10 +216,24 @@ exposed to an unverified environment. Common causes include an invalid token sig
 did not match (the measured software differs from the approved stack), an expired token, or an
 encryption key that is not bound to the attested environment.
 
-When this happens, do not bypass the check. Confirm the vault's status in the Model Vault app, and if it
+When this happens, confirm the vault's status in the Model Vault app, and if it
 consistently fails verification, contact Cohere support. See
 [Verifying Your Deployment](/docs/model-vault/encrypted/verifying-deployment) for what each failure
 means.
+
+## Hosted Cohere OHTTP proxy for demos
+Cohere also offers a hosted OHTTP proxy that allows you to interact with an encrypted vault as though
+it were a standard vault, without running any of the client-side options described above. This option
+is intended strictly for demo purposes, as it changes the security model by requiring you to trust
+Cohere with the proxy layer. To use the hosted OHTTP proxy, send requests to the encrypted vault as you
+would a standard vault and include the following headers with all requests:
+```
+"X-Cohere-Demo-Encrypt": "1"
+"X-Gateway-Model-Name": "<YOUR_VAULT_MODEL_NAME>"
+```
+<Note>
+For security reasons, the hosted OHTTP proxy is disabled by default. Please reach out to us to enable it for your vault.
+</Note>
 
 ## Related pages
 


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the Cohere OHTTP proxy documentation to include a new form of the proxy, the Cohere Python OHTTP wrapper (conseel). It also updates the instructions for using the Cohere SDK with the embedded Cohere OHTTP client and adds a new section on using the hosted Cohere OHTTP proxy for demos.

**Changes:**
- Added a new form of the Cohere OHTTP proxy, the Cohere Python OHTTP wrapper (conseel), which is a Python package that verifies attestation and handles OHTTP by wrapping httpx-based communication.
- Updated the instructions for using the Cohere SDK with the embedded Cohere OHTTP client, noting that it is coming soon and providing installation instructions for the Cohere client with encrypted vault support via PyPI.
- Added a new section on using the Cohere Python OHTTP wrapper (conseel) with the Cohere SDK and other httpx-based clients such as the OpenAI SDK.
- Updated the instructions for using the standalone Cohere OHTTP proxy, including information on running the proxy container locally and using it with various clients.
- Added a new section on using the hosted Cohere OHTTP proxy for demos, including instructions on including the necessary headers in requests to the encrypted vault.
- Updated the verification process to include information on checking the attestation certificate programmatically with the Cohere Python OHTTP wrapper (conseel).
- Made minor updates to the wording and formatting throughout the document for clarity and consistency.

<!-- end-generated-description -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to Fern MDX with no runtime or security-sensitive code paths modified.
> 
> **Overview**
> Updates **Calling an Encrypted Vault over the API** so OHTTP integration is documented as **three** paths instead of two, and refreshes examples for the standalone proxy and embedded SDK.
> 
> **Option 2** is new: the **`conseel`** Python package as an httpx `Transport` for Cohere, OpenAI, and other httpx SDKs, with install and sample code. **Option 1** is labeled **coming soon**, adds `pip install cohere[mve]`, and clarifies encrypted-vault URL behavior. **Option 3** (local container) adds a `docker run` for `tng-ingress:0.5.0`, documents required **`X-Gateway-Model-Name`** routing, and fixes proxy URLs (`/v1` vs compatibility path) plus Bearer auth in cURL.
> 
> Per-response attestation is scoped to **conseel** via **`x-tng-attestation-token`**. A new **hosted demo OHTTP proxy** section describes **`X-Cohere-Demo-Encrypt`** and opt-in enablement, with explicit trust-model caveats.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a4f30f15900a4e905c1c7e9ff7c2a2790a9fb57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->