### PR TITLE
Adds new Transcribe Arabic model to nav, fixes link, adds fern file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,4 @@ virtualenv/
 # Fern files
 fern/**/.preview
 fern/**/.definition
+.fern-docs-dev.pgid

--- a/fern/pages/models/models.mdx
+++ b/fern/pages/models/models.mdx
@@ -41,7 +41,10 @@ are.
   RAG.
 - [Rerank](https://cohere.com/blog/rerank/?_gl=1*1t6ls4x*_ga*MTAxNTg1NTM1MS4xNjk1MjMwODQw*_ga_CRGS116RZS*MTcxNzYwMzYxMy4zNTEuMS4xNzE3NjAzNjUxLjIyLjAuMA..) is the fastest way to inject the intelligence of a language model into an existing search system. It can be accessed via the [Rerank](../reference/rerank-1) endpoint.
 - [Embed](https://cohere.com/models/embed?_gl=1*1t6ls4x*_ga*MTAxNTg1NTM1MS4xNjk1MjMwODQw*_ga_CRGS116RZS*MTcxNzYwMzYxMy4zNTEuMS4xNzE3NjAzNjUxLjIyLjAuMA..) improves the accuracy of search, classification, clustering, and RAG results. It powers the [Embed](../reference/embed) endpoint.
-- [Cohere Transcribe](transcribe) is Cohere's dedicated audio transcription model for automatic speech recognition (ASR). [Cohere Transcribe Arabic](..docs/transcribe-arabic) is a version of the model optimized for Arabic-language audio. It powers the [Audio Transcriptions](../reference/create-audio-transcription) endpoint.
+- [Cohere Transcribe](transcribe) is Cohere's dedicated audio transcription model for automatic speech 
+  recognition (ASR). It powers the [Audio Transcriptions](../reference/create-audio-transcription) endpoint. 
+  [Cohere Transcribe Arabic](transcribe-arabic) is a version of the model optimized for Arabic-language 
+  audio. 
 - The [Aya](aya) family of models are aimed at expanding the number of languages covered by 
   generative AI. Aya Expanse covers 23 languages, and Aya Vision is fully multimodal, allowing you to pass 
   in images and text and get a single coherent response. Both are available on the [Chat](../reference/chat) 

--- a/fern/v2.yml
+++ b/fern/v2.yml
@@ -58,6 +58,8 @@ navigation:
             contents:
               - page: Cohere Transcribe
                 path: pages/models/transcribe.mdx
+              - page: Cohere Transcribe Arabic
+                path: pages/models/transcribe-arabic.mdx
           - section: Aya
             path: pages/models/aya.mdx
             contents:


### PR DESCRIPTION
<!-- begin-generated-description -->

Generating pr description

<!-- end-generated-description -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and navigation-only changes with no runtime or API behavior impact.
> 
> **Overview**
> Surfaces **Cohere Transcribe Arabic** in the docs site by registering `pages/models/transcribe-arabic.mdx` under **Models → Audio** in `fern/v2.yml`, alongside the existing Transcribe page.
> 
> On the models overview (`models.mdx`), the Transcribe bullet is rewritten so the Arabic variant links to `transcribe-arabic` instead of the broken `..docs/transcribe-arabic` path, with clearer copy that Transcribe powers the Audio Transcriptions endpoint and Arabic is the dialect-optimized variant.
> 
> Also ignores local Fern dev output by adding `.fern-docs-dev.pgid` to `.gitignore`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af43ac051fa60bac1ab6f3d65123252681d7605f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->