### PR TITLE
Add site-level SEO metadata block to docs.yml

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -653,6 +653,22 @@ redirects:
     destination: /docs/system-instructions
     permanent: true
 
+metadata:
+  og:site_name: "Cohere Documentation"
+  og:title: "Cohere Documentation"
+  og:description: "Cohere's API documentation helps developers easily integrate natural language processing and generation into their products."
+  og:url: "https://docs.cohere.com"
+  og:locale: "en_US"
+  og:image: "https://docs.cohere.com/assets/images/f1cc130-cohere_meta_image.jpg"
+  og:image:width: 1200
+  og:image:height: 630
+  twitter:card: "summary_large_image"
+  twitter:site: "@cohere"
+  twitter:title: "Cohere Documentation"
+  twitter:description: "Cohere's API documentation helps developers easily integrate natural language processing and generation into their products."
+  twitter:image: "https://docs.cohere.com/assets/images/f1cc130-cohere_meta_image.jpg"
+  canonical-host: "docs.cohere.com"
+
 analytics:
   segment:
     write-key: ${SEGMENT_WRITE_KEY}


### PR DESCRIPTION
Adds a metadata block to docs.yml to set og:description, og:title, og:image, twitter card, and canonical-host. Without this block, Fern does not emit a <meta name="description"> tag that Google can read, causing the search snippet to fall back to scraping navbar text (DASHBOARD PLAYGROUND DOCS COMMUNITY LOG IN).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-site configuration only; no runtime, auth, or application logic changes.
> 
> **Overview**
> Adds a **`metadata`** block to `fern/docs.yml` so Fern emits proper HTML meta tags for search and social sharing instead of leaving snippets to scrape navbar copy (e.g. “DASHBOARD PLAYGROUND DOCS…”).
> 
> The block sets **Open Graph** fields (`og:title`, `og:description`, `og:url`, `og:image` with dimensions, `og:locale`, `og:site_name`), **Twitter** card tags (`summary_large_image`, `@cohere`, matching title/description/image), and **`canonical-host: docs.cohere.com`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9030d1a67b66b06b9d878c2daa5b8dd6108c7826. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->