### PR TITLE
Enable TCP keepalive on the Python SDK

### DIFF
--- a/fern/apis/sdks/generators.yml
+++ b/fern/apis/sdks/generators.yml
@@ -132,9 +132,14 @@ groups:
       - sdk-only
     generators:
       - name: fernapi/fern-python-sdk
-        version: 5.14.8
+        version: 5.20.0
         smart-casing: true
         config:
+          tcp_keepalive:
+            enabled: true
+            idle_seconds: 60
+            interval_seconds: 30
+            count: 5
           inline_request_params: false
           extras:
             oci: ["oci"]


### PR DESCRIPTION
Bumps `fern-python-sdk` to `5.20.0` and enables the new `tcp_keepalive` config.

This makes the generated Python SDK send TCP keepalive probes on idle connections, so long-running non-streaming requests aren't silently dropped by an intermediary (firewall / load balancer / NAT) mid-request.

```yaml
tcp_keepalive:
  enabled: true
  idle_seconds: 60
  interval_seconds: 30
  count: 5
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Generator-only networking defaults for the Python SDK; no auth, API contract, or runtime service changes in this repo.
> 
> **Overview**
> Bumps the Python SDK generator **`fernapi/fern-python-sdk`** from **5.14.8** to **5.20.0** and turns on **`tcp_keepalive`** in `generators.yml`.
> 
> Generated clients will probe idle TCP connections after **60s**, every **30s**, up to **5** times, so long non-streaming calls are less likely to die silently when a firewall, LB, or NAT drops quiet connections mid-request.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae748217b8effcc9c5783aa3ab8c0cc6fe8c654d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->