### PR TITLE
chore: Update generators.yml 5.22.1

### DIFF
--- a/fern/apis/sdks/generators.yml
+++ b/fern/apis/sdks/generators.yml
@@ -132,7 +132,7 @@ groups:
       - sdk-only
     generators:
       - name: fernapi/fern-python-sdk
-        version: 5.20.0
+        version: 5.22.1
         smart-casing: true
         config:
           tcp_keepalive:


### PR DESCRIPTION
<!-- begin-generated-description -->

Generating pr description

<!-- end-generated-description -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single version pin with no application or API logic changes; impact is limited to future Python SDK regeneration output.
> 
> **Overview**
> **Bumps the Fern Python SDK generator** (`fernapi/fern-python-sdk`) from **5.20.0** to **5.22.1** in `fern/apis/sdks/generators.yml`.
> 
> No other language generators or Python generator config (TCP keepalive, pydantic settings, exports, etc.) is changed—only the pinned generator version. Regenerating the Python SDK will pick up whatever fixes and codegen changes ship in 5.22.1.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 936773fb4218e19d121a2845523f487c7aa07a8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->