### PR TITLE
docs(model-vault): update Docker image version to latest in encrypted…

### DIFF
--- a/fern/pages/model-vault/encrypted/api-usage.mdx
+++ b/fern/pages/model-vault/encrypted/api-usage.mdx
@@ -43,7 +43,7 @@ Run the container using a container platform such as Docker:
 docker run -it --rm --network host \
   -e IN_HOST=0.0.0.0 -e IN_PORT=8080 \
   -e TARGET_URL=<YOUR_VAULT_ENDPOINT_URL> \
-  ghcr.io/cohere-ai/tng-ingress:0.6.0
+  ghcr.io/cohere-ai/tng-ingress:latest
 ```
 
 Then use the Cohere SDK via the proxy:


### PR DESCRIPTION
Update tag in docs now that `latest` tag corresponds to latest semvar stable release (fixed in [this PR](https://github.com/cohere-ai/TNG/pull/42)).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a Docker image tag in an example command; no runtime or application code affected.
> 
> **Overview**
> Updates the **encrypted vault API usage** Docker example so the Cohere OHTTP proxy image is **`ghcr.io/cohere-ai/tng-ingress:latest`** instead of the pinned **`0.6.0`** tag, matching upstream behavior where `latest` tracks the current stable release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89ee82d559efae8f3002e107dd0c4b6ce9edf107. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->