### PR TITLE
Fixes some broken links TW-666

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -176,11 +176,23 @@ redirects:
   - source: "/docs/reranking"
     destination: "/docs/rerank-overview"
     permanent: true
+  - source: "/v1/docs/reranking"
+    destination: "/v1/docs/rerank-overview"
+    permanent: true
+  - source: "/v2/docs/reranking"
+    destination: "/v2/docs/rerank-overview"
+    permanent: true
   - source: "/docs/multilingual-movie-search"
     destination: "/docs/intro-semantic-search"
     permanent: true
   - source: "/reference/rerank-1"
     destination: "/reference/rerank"
+    permanent: true
+  - source: "/v1/reference/rerank-1"
+    destination: "/v1/reference/rerank"
+    permanent: true
+  - source: "/v2/reference/rerank-1"
+    destination: "/v2/reference/rerank"
     permanent: true
   - source: "/reference/datasets"
     destination: "/reference/create-dataset"
@@ -190,6 +202,12 @@ redirects:
     permanent: true
   - source: "/reference/embed-jobs"
     destination: "/reference/create-embed-job"
+    permanent: true
+  - source: "/v1/reference/embed-jobs"
+    destination: "/v1/reference/create-embed-job"
+    permanent: true
+  - source: "/v2/reference/embed-jobs"
+    destination: "/v2/reference/create-embed-job"
     permanent: true
   - source: "/reference/finetuning"
     destination: "/reference/listfinetunedmodels"
@@ -770,6 +788,7 @@ redirects:
   - source: "/docs/generate-fine-tuning/generate-improving-the-results"
     destination: "/docs/chat-improving-the-results"
     permanent: true
+
   - source: "/docs/chat-fine-tuning"
     destination: "/docs/fine-tuning"
     permanent: true

--- a/fern/pages/cohere-api/about.mdx
+++ b/fern/pages/cohere-api/about.mdx
@@ -15,7 +15,7 @@ The Cohere platform allows you to leverage the power of
 lines of code and an [API key](https://dashboard.cohere.com/api-keys?_gl=1*14v2pj5*_gcl_au*NTczMTgyMTIzLjE3MzQ1NTY2OTA.*_ga*MTAxNTg1NTM1MS4xNjk1MjMwODQw*_ga_CRGS116RZS*MTczNjI3NzU2NS4xOS4xLjE3MzYyODExMTkuNDkuMC4w).
 
 Our [Command](../docs/command-a-plus), [Embed](../docs/cohere-embed), [Rerank](../docs/rerank), 
-[Aya](../docs/aya), and [Cohere Transcribe](../docs/transcribe) models excel at a variety of applications, 
+[Aya](../docs/aya), and [Cohere Transcribe](../../v2/docs/transcribe) models excel at a variety of applications, 
 from the relatively simple [semantic search](../docs/semantic-search-embed), and 
 [content generation](../docs/introduction-to-text-generation-at-cohere) to the more advanced 
 [retrieval augmented generation](../docs/retrieval-augmented-generation-rag) and 

--- a/fern/pages/going-to-production/rate-limits.mdx
+++ b/fern/pages/going-to-production/rate-limits.mdx
@@ -29,14 +29,14 @@ Cohere offers two kinds of API keys: evaluation keys (free but limited in usage)
 
 ## Other API Endpoints
 
-| Endpoint                                                        | Trial rate limit   | Production rate limit                               |
-|-----------------------------------------------------------------|--------------------|-----------------------------------------------------|
-| [Audio Transcriptions](../reference/create-audio-transcription) | 5 req / min        | Contact [sales@cohere.com](mailto:sales@cohere.com) |
-| [Embed](../reference/embed)                                     | 2,000 inputs / min | 2,000 inputs / min                                  |
-| [Embed (Images)](../reference/embed)                            | 5 inputs / min     | 400 inputs / min                                    |
-| [EmbedJob](../reference/embed-jobs)                             | 5 req / min        | 50 req / min                                        |
-| [Rerank](../reference/rerank)                                   | 10 req / min       | 1,000 req / min                                     |
-| [Tokenize](../reference/tokenize)                               | 100 req / min      | 2,000 req / min                                     |
-| Default (anything not covered above)                            | 500 req / min      | 500 req / min                                       |
+| Endpoint                                                              | Trial rate limit   | Production rate limit                               |
+|-----------------------------------------------------------------------|--------------------|-----------------------------------------------------|
+| [Audio Transcriptions](../../v2/reference/create-audio-transcription) | 5 req / min        | Contact [sales@cohere.com](mailto:sales@cohere.com) |
+| [Embed](../reference/embed)                                           | 2,000 inputs / min | 2,000 inputs / min                                  |
+| [Embed (Images)](../reference/embed)                                  | 5 inputs / min     | 400 inputs / min                                    |
+| [EmbedJob](../reference/embed-jobs)                                   | 5 req / min        | 50 req / min                                        |
+| [Rerank](../reference/rerank)                                         | 10 req / min       | 1,000 req / min                                     |
+| [Tokenize](../reference/tokenize)                                     | 100 req / min      | 2,000 req / min                                     |
+| Default (anything not covered above)                                  | 500 req / min      | 500 req / min                                       |
 
 If you have any questions or want to speak about getting a rate limit increase, reach out to support@cohere.com.

--- a/fern/pages/integrations/cohere-and-langchain/chat-on-langchain.mdx
+++ b/fern/pages/integrations/cohere-and-langchain/chat-on-langchain.mdx
@@ -44,7 +44,7 @@ print(llm.invoke(current_message_and_history))
 
 ### Reasoning with LangChain
 
-When you select a reasoning model (like `command-a-reasoning-08-2025`), its response includes both the model's reasoning and its final answer as structured content blocks—no extra parameters required. For background on how reasoning models work, see Cohere's [Reasoning](../docs/reasoning) guide.
+When you select a reasoning model (like `command-a-reasoning-08-2025`), its response includes both the model's reasoning and its final answer as structured content blocks—no extra parameters required. For background on how reasoning models work, see Cohere's [Reasoning](../../v2/docs/reasoning) guide.
 
 Reasoning support requires `langchain-cohere >= 0.5.1`.
 
@@ -78,7 +78,7 @@ for block in response.content:
 
 ### Image Inputs with LangChain
 
-Command A Vision (`command-a-vision-07-2025`) can interpret images. Pass image content blocks using the `image_url` type—a publicly accessible image URL or a base64 data URI—together with your text prompt. For more on Cohere's vision capabilities, see the [Image Inputs](../docs/image-inputs) guide.
+Command A Vision (`command-a-vision-07-2025`) can interpret images. Pass image content blocks using the `image_url` type—a publicly accessible image URL or a base64 data URI—together with your text prompt. For more on Cohere's vision capabilities, see the [Image Inputs](../../v2/docs/image-inputs) guide.
 
 Vision support requires `langchain-cohere >= 0.6.0`.
 

--- a/fern/pages/models/models.mdx
+++ b/fern/pages/models/models.mdx
@@ -42,9 +42,9 @@ are.
   RAG.
 - [Rerank](https://cohere.com/blog/rerank/?_gl=1*1t6ls4x*_ga*MTAxNTg1NTM1MS4xNjk1MjMwODQw*_ga_CRGS116RZS*MTcxNzYwMzYxMy4zNTEuMS4xNzE3NjAzNjUxLjIyLjAuMA..) is the fastest way to inject the intelligence of a language model into an existing search system. It can be accessed via the [Rerank](../reference/rerank-1) endpoint.
 - [Embed](https://cohere.com/models/embed?_gl=1*1t6ls4x*_ga*MTAxNTg1NTM1MS4xNjk1MjMwODQw*_ga_CRGS116RZS*MTcxNzYwMzYxMy4zNTEuMS4xNzE3NjAzNjUxLjIyLjAuMA..) improves the accuracy of search, classification, clustering, and RAG results. It powers the [Embed](../reference/embed) endpoint.
-- [Cohere Transcribe](transcribe) is Cohere's dedicated audio transcription model for automatic speech 
-  recognition (ASR). It powers the [Audio Transcriptions](../reference/create-audio-transcription) endpoint. 
-  [Cohere Transcribe Arabic](transcribe-arabic) is a version of the model optimized for Arabic-language 
+- [Cohere Transcribe](../../v2/docs/transcribe) is Cohere's dedicated audio transcription model for automatic speech 
+  recognition (ASR). It powers the [Audio Transcriptions](../../v2/reference/create-audio-transcription) endpoint. 
+  [Cohere Transcribe Arabic](../../v2/docs/transcribe-arabic) is a version of the model optimized for Arabic-language 
   audio. 
 - The [Aya](aya) family of models are aimed at expanding the number of languages covered by 
   generative AI. Aya Expanse covers 23 languages, and Aya Vision is fully multimodal, allowing you to pass 
@@ -55,7 +55,7 @@ are.
 
 Command is Cohere's default generation model that takes a user instruction (or command) and generates text 
 following the instruction. Our Command models also have conversational capabilities, meaning they are 
-well-suited for chat applications, and Command A Vision can interact with [image inputs](image-inputs).
+well-suited for chat applications, and Command A Vision can interact with [image inputs](../../v2/docs/image-inputs).
 
 | Model Name                    | Status                   | Description                                                                                                                                                                                                                                                                                                                                            | Modality     | Context Length | Maximum Output Tokens | Endpoints               |
 |-------------------------------|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------|----------------|-----------------------|-------------------------|
@@ -156,7 +156,7 @@ Cohere Transcribe is our dedicated model for audio-in, text-out automatic speech
 
 | Model Name                    | Status | Description                                                                                 | Maximum file size | Endpoints                                                      |
 |-------------------------------|--------|---------------------------------------------------------------------------------------------|-------------------|----------------------------------------------------------------|
-| `cohere-transcribe-03-2026`   | Live   | Open source research release focused on high-accuracy, multilingual speech transcription. | 25MB              | [Audio Transcriptions](../reference/create-audio-transcription) |
+| `cohere-transcribe-03-2026`   | Live   | Open source research release focused on high-accuracy, multilingual speech transcription. | 25MB              | [Audio Transcriptions](../../v2/reference/create-audio-transcription) |
 
 ### Using Audio Models on Different Platforms
 

--- a/fern/pages/models/north/north-mini-code-1.0.mdx
+++ b/fern/pages/models/north/north-mini-code-1.0.mdx
@@ -28,7 +28,7 @@ import { ModelShowcase, Capability, Endpoint} from "../../../components/model-sh
   endpoints: [
     Endpoint.ChatV2,
   ],
-  usageMessage: <p>North Mini Code can be used in production through Cohere's <a href="model-vault" target="_blank" rel="noopener noreferrer">Model Vault</a>.</p>
+  usageMessage: <p>North Mini Code can be used in production through Cohere's <a href="../../v2/docs/model-vault" target="_blank" rel="noopener noreferrer">Model Vault</a>.</p>
 }}/>
 
 ## Description

--- a/fern/pages/models/the-command-family-of-models/command-a-plus.mdx
+++ b/fern/pages/models/the-command-family-of-models/command-a-plus.mdx
@@ -35,7 +35,7 @@ import { ModelShowcase, Capability, Endpoint} from "../../../components/model-sh
     Endpoint.ChatV2,
     Endpoint.ChatCompletions,
   ],
-  usageMessage: <p>Command A+ can be used in production through Cohere's <a href="model-vault" target="_blank" rel="noopener noreferrer">Model Vault</a>.</p>
+  usageMessage: <p>Command A+ can be used in production through Cohere's <a href="../../v2/docs/model-vault" target="_blank" rel="noopener noreferrer">Model Vault</a>.</p>
 }}/>
 
 
@@ -49,7 +49,7 @@ Command A+ is excellent for:
 - **Multilingual Tasks**: With support for 48 languages, combined with the model's reasoning, agentic problem solving & vision processing capabilities, Command A+ expands not only the number of languages supported, but what enterprises across the globe can do with Cohere's models.
 - **Balancing Accuracy & Efficiency**: Providing support for deploying the model with as few as a single B200 or two H100 chips, and with vast improvements in reasoning, image processing, and agentic tasks over the rest of the Command A family, Command A+ is the fastest and most performant model in the Command A family by far.
 
-There's more to be said about token budgets, enabling and disabling the `thinking` operation, etc., which can be found in our dedicated [Reasoning guide](reasoning).
+There's more to be said about token budgets, enabling and disabling the `thinking` operation, etc., which can be found in our dedicated [Reasoning guide](../../v2/docs/reasoning).
 
 ## General
 - **Name of the model provider**: Cohere Inc. 


### PR DESCRIPTION
- fixes broken links found by muffet in advance of adding muffet to CI, as of this PR, the upcoming CI is green
- extends the redirects for renamed files to include the versioned prefixes 
- adds v2 prefix for links to v2-only content linked from v1/v2 shared pages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and redirect-only changes with no application or API behavior impact.
> 
> **Overview**
> Fixes **broken internal links** flagged ahead of adding muffet link checking to CI, mainly by routing v2-only docs and reference pages correctly from shared v1-era MDX paths.
> 
> **`fern/docs.yml`** adds permanent redirects for **`/v1` and `/v2`** variants of old paths (`reranking` → `rerank-overview`, `rerank-1` → `rerank`, `embed-jobs` → `create-embed-job`), mirroring existing unversioned rules.
> 
> Several MDX pages now use **`../../v2/docs/...`** and **`../../v2/reference/...`** for content that lives on the v2 API surface—e.g. Transcribe, Reasoning, Image Inputs, Model Vault, and Audio Transcriptions—on the API about page, rate limits, LangChain integration, models overview, and Command A+ / North Mini Code model pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2592cf39746737a197fc83bb653bfa2bc4320ef1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->