### PR TITLE
chore(Python/TS): bump generator vers to allow optional auth

### DIFF
--- a/fern/apis/sdks/generators.yml
+++ b/fern/apis/sdks/generators.yml
@@ -20,7 +20,7 @@ groups:
       - sdk-only
     generators:
       - name: fernapi/fern-typescript-node-sdk
-        version: 3.63.0
+        version: 3.85.0
         output:
           location: npm
           package-name: cohere-ai
@@ -29,6 +29,7 @@ groups:
           repository: cohere-ai/cohere-typescript
           mode: pull-request
         config:
+          optional-auth: true
           inlineFileProperties: false
           inlinePathParameters: false
           enableInlineTypes: false
@@ -132,9 +133,10 @@ groups:
       - sdk-only
     generators:
       - name: fernapi/fern-python-sdk
-        version: 5.22.1
+        version: 5.24.0
         smart-casing: true
         config:
+          optional-auth: true
           tcp_keepalive:
             enabled: true
             idle_seconds: 60


### PR DESCRIPTION
<!-- begin-generated-description -->

Generating pr description

<!-- end-generated-description -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SDK generation and client auth requirements; regenerated TypeScript/Python clients may differ in constructor/types until downstream SDK PRs are merged and released.
> 
> **Overview**
> Bumps the **TypeScript** (`fern-typescript-node-sdk` 3.63.0 → **3.85.0**) and **Python** (`fern-python-sdk` 5.22.1 → **5.24.0**) Fern generator versions in `generators.yml`, and turns on **`optional-auth: true`** for both.
> 
> The next SDK regen should treat API credentials as optional where the OpenAPI spec allows it, instead of requiring auth on every client construction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c62e68311e7fad0a2e37cb5f70a5c619e4fd06b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->