### PR TITLE
Fix accidental model name replacement

### DIFF
--- a/fern/pages/models/the-command-family-of-models/command-a.mdx
+++ b/fern/pages/models/the-command-family-of-models/command-a.mdx
@@ -17,7 +17,7 @@ import { ModelShowcase, Capability, Endpoint} from "../../../components/model-sh
 
 <ModelShowcase model={{
   name: 'Command A',
-  id: 'command-a-plus-05-2026',
+  id: 'command-a-03-2025',
   capabilities: [
     Capability.SafetyModes,
     Capability.Citations,


### PR DESCRIPTION
<!-- begin-generated-description -->

Generating pr description

<!-- end-generated-description -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only correction to a single model id string; no runtime or API behavior changes.
> 
> **Overview**
> Reverts an accidental model identifier change on the **Command A** docs page: the `ModelShowcase` `id` is set back to **`command-a-03-2025`** instead of **`command-a-plus-05-2026`**, aligning the page with the correct Command A API model name used elsewhere in the docs and OpenAPI examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ce8cbecb410a6b365855fad1f26793d0fe8d66a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->