### PR TITLE
Fix response content handling in text generation tutorial

### DIFF
--- a/fern/pages/v2/tutorials/build-things-with-cohere/text-generation-tutorial.mdx
+++ b/fern/pages/v2/tutorials/build-things-with-cohere/text-generation-tutorial.mdx
@@ -44,8 +44,6 @@ co = cohere.ClientV2(api_key="COHERE_API_KEY")
 
 To get started with Chat, we need to pass two parameters, `model` for the LLM model ID and `messages`, which we add a single user message. We then call the Chat endpoint through the client we created earlier.
 
-The response contains several objects. For simplicity, what we want right now is the `message.content[0].text` object.
-
 Here's an example of the assistant responding to a new hire's query asking for help to make introductions.
 
 
@@ -60,7 +58,11 @@ response = co.chat(
 )
 #    messages=[cohere.UserMessage(content=message)])
 
-print(response.message.content[0].text)
+for content_item in response.message.content:
+    if content_item.type == "thinking":
+        print("thinking:", content_item.thinking)
+    if content_item.type == "text":
+        print("text:", content_item.text)
 ```
 
 ```
@@ -103,7 +105,11 @@ response = co.chat(
 )
 #    messages=[cohere.UserMessage(content=message)])
 
-print(response.message.content[0].text)
+for content_item in response.message.content:
+    if content_item.type == "thinking":
+        print("thinking:", content_item.thinking)
+    if content_item.type == "text":
+        print("text:", content_item.text)
 ```
 
 ```
@@ -144,7 +150,11 @@ response = co.chat(
     messages=[{"role": "user", "content": message}],
 )
 
-print(response.message.content[0].text)
+for content_item in response.message.content:
+    if content_item.type == "thinking":
+        print("thinking:", content_item.thinking)
+    if content_item.type == "text":
+        print("text:", content_item.text)
 ```
 
 ```
@@ -173,7 +183,11 @@ response = co.chat(
     messages=[{"role": "user", "content": message}],
 )
 
-print(response.message.content[0].text)
+for content_item in response.message.content:
+    if content_item.type == "thinking":
+        print("thinking:", content_item.thinking)
+    if content_item.type == "text":
+        print("text:", content_item.text)
 ```
 
 ```
@@ -201,7 +215,9 @@ for idx in range(3):
         temperature=0,
     )
 
-    print(f"{idx+1}: {response.message.content[0].text}\n")
+    for content_item in response.message.content:
+        if content_item.type == "text":
+            print(f"{idx+1}: {content_item.text}\n")
 ```
 
 ```
@@ -228,7 +244,9 @@ for idx in range(3):
         temperature=1,
     )
 
-    print(f"{idx+1}: {response.message.content[0].text}\n")
+    for content_item in response.message.content:
+        if content_item.type == "text":
+            print(f"{idx+1}: {content_item.text}\n")
 ```
 
 ```
@@ -293,7 +311,10 @@ response = co.chat(
     },
 )
 
-json_object = json.loads(response.message.content[0].text)
+for content_item in response.message.content:
+    if content_item.type == "text":
+        json_object = json.loads(content_item.text)
+        break
 
 print(json_object)
 ```

--- a/fern/pages/v2/tutorials/build-things-with-cohere/text-generation-tutorial.mdx
+++ b/fern/pages/v2/tutorials/build-things-with-cohere/text-generation-tutorial.mdx
@@ -335,7 +335,7 @@ The Chat endpoint also provides streaming support. In a streamed response, the e
 
 To activate it, use `co.chat_stream()` instead of `co.chat()`.
 
-In streaming mode, the endpoint will generate a series of objects. To get the actual text contents, we take objects whose `event_type` is `content-delta`.
+In streaming mode, the endpoint will generate a series of objects. To get the actual text contents, we take objects whose `event.type` is `content-delta`.
 
 
 ```python PYTHON
@@ -349,9 +349,9 @@ response = co.chat_stream(
 )
 
 for event in response:
-    if event:
-        if event.type == "content-delta":
-            print(event.delta.message.content.text, end="")
+    if event and event.type == "content-delta":
+        if event.delta.message.content.text:
+            print(event.delta.message.content.text, end="", flush=True)
 ```
 
 ```


### PR DESCRIPTION
## Summary

This PR fixes additional occurrences of direct `response.message.content[0].text` access in the text generation tutorial.

This follows the issue discussed in #796, where `message.content[0]` could contain a `thinking` block rather than a `text` block. The initial snippets were addressed in #797, but I found additional examples in the tutorial with the same assumption.

## Changes

- Updated additional response handling examples to account for different content item types.
- Replaced direct `response.message.content[0].text` access where appropriate.
- Updated related documentation that assumed the first content item always contained text.

## Related

Related to #796.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to tutorial code samples; no runtime or API behavior.
> 
> **Overview**
> **Updates the v2 text generation tutorial** so sample code no longer assumes the first `message.content` entry is always text—matching the fix from #797 for the rest of the doc (#796).
> 
> Non-streaming examples now **iterate `response.message.content`** and branch on `type` (`thinking` vs `text`) instead of using `response.message.content[0].text`. Temperature and structured-output snippets only read **text** items (JSON parsing uses the first text block). The **streaming** section is aligned with current event shape: prose refers to `event.type`, and the loop prints `content-delta` deltas with a guard and `flush=True`.
> 
> A short note that pointed readers only at `message.content[0].text` was removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96b3cc491444642e7672148da4fb223df1e57da1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->