### PR TITLE
docs: add Parse to the v2 API reference

### DIFF
--- a/fern/v2.yml
+++ b/fern/v2.yml
@@ -593,6 +593,12 @@ navigation:
                 skip-slug: true
                 contents:
                   - POST /v2/embed
+              - section: "v2/parse"
+                skip-slug: true
+                contents:
+                  - endpoint: POST /v2/parse
+                    slug: parse
+                    title: Parse
               - embedJobs:
                   title: "v1/embed-jobs"
                   skip-slug: true


### PR DESCRIPTION
## Summary
- Add `POST /v2/parse` to the v2 API reference layout in `fern/v2.yml`.
- The OpenAPI spec and code snippets are already on main from the blobheart sync; they were not in the hand-written nav, so Parse did not show on docs.cohere.com.

## Test plan
- [ ] Confirm the DX docs preview (or local `make dev`) shows **Parse** under v2 API reference.
- [ ] Page includes markdown/blocks examples and does not mention `raw_generation`.


Made with [Cursor](https://cursor.com)