### PR TITLE
Resize SageMaker Parse images to stay under the invoke payload limit

### DIFF
--- a/notebooks/sagemaker/Parse Models.ipynb
+++ b/notebooks/sagemaker/Parse Models.ipynb
@@ -28,7 +28,7 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "%pip install --upgrade --quiet sagemaker boto3 cohere"
+        "%pip install --upgrade --quiet sagemaker boto3 cohere pillow"
       ],
       "execution_count": null,
       "outputs": []
@@ -106,25 +106,24 @@
       "metadata": {},
       "source": [
         "import base64\n",
-        "from pathlib import Path\n",
+        "from io import BytesIO\n",
+        "\n",
+        "from PIL import Image\n",
+        "\n",
+        "IMG_MAX_SIZE = 2048\n",
         "\n",
         "\n",
         "def image_to_data_uri(image_path: str) -> str:\n",
-        "    \"\"\"Convert a local image file to a base64-encoded data URI.\"\"\"\n",
-        "    path = Path(image_path)\n",
-        "    suffix = path.suffix.lower().lstrip(\".\")\n",
-        "    mime_type = {\n",
-        "        \"jpg\": \"image/jpeg\",\n",
-        "        \"jpeg\": \"image/jpeg\",\n",
-        "        \"png\": \"image/png\",\n",
-        "        \"gif\": \"image/gif\",\n",
-        "        \"webp\": \"image/webp\",\n",
-        "    }.get(suffix, \"image/png\")\n",
+        "    \"\"\"Resize and convert a local image to a WebP data URI under the payload limit.\"\"\"\n",
+        "    buffer = BytesIO()\n",
+        "    with Image.open(image_path) as img:\n",
+        "        img.thumbnail((IMG_MAX_SIZE, IMG_MAX_SIZE), Image.Resampling.LANCZOS)\n",
+        "        if img.mode != \"RGB\":\n",
+        "            img = img.convert(\"RGB\")\n",
+        "        img.save(buffer, format=\"WEBP\", quality=90)\n",
         "\n",
-        "    with open(path, \"rb\") as f:\n",
-        "        encoded = base64.b64encode(f.read()).decode(\"utf-8\")\n",
-        "\n",
-        "    return f\"data:{mime_type};base64,{encoded}\""
+        "    b64 = base64.b64encode(buffer.getvalue()).decode()\n",
+        "    return f\"data:image/webp;base64,{b64}\""
       ],
       "execution_count": null,
       "outputs": []


### PR DESCRIPTION
## Summary
- The SageMaker Parse getting-started notebook encoded source images as-is, so typical document scans exceeded SageMaker’s invoke payload limit.
- `image_to_data_uri()` now resizes to 2048px and converts to WebP quality 90, matching the SageMaker setup guide. Pillow is added to the notebook install cell.

## Test plan
- [ ] Open `notebooks/sagemaker/Parse Models.ipynb` and confirm the helper resizes/converts before encoding
- [ ] Run the install cell and confirm `pillow` is installed
- [ ] If a SageMaker endpoint is available, parse a large document scan and confirm the request succeeds


Made with [Cursor](https://cursor.com)