### PR TITLE
Add Microsoft Foundry link to Parse changelog

### DIFF
--- a/fern/pages/changelog/2026-08-27-parse-v5.mdx
+++ b/fern/pages/changelog/2026-08-27-parse-v5.mdx
@@ -17,7 +17,7 @@ Key specs: 8K context window · ~4.6GB model size · Markdown output
 
 ## Availability
 
-Cohere Parse is available through the Parse API, as well as Microsoft Foundry and [AWS SageMaker](https://aws.amazon.com/marketplace/pp/prodview-25vdn5x53zqgo).
+Cohere Parse is available through the Parse API, as well as [Microsoft Foundry](https://ai.azure.com/catalog/models/Cohere-parse-v5) and [AWS SageMaker](https://aws.amazon.com/marketplace/pp/prodview-25vdn5x53zqgo).
 For single-tenant deployment, Parse is also available in [Model Vault](/docs/model-vault).
 
 For more details, see the [model documentation](/docs/parse).


### PR DESCRIPTION
## Summary
- Adds an inline Microsoft Foundry catalog link for Parse v5 in the Availability section of the Parse changelog, matching the existing AWS SageMaker link pattern.

## Test plan
- [ ] Confirm the Foundry link opens https://ai.azure.com/catalog/models/Cohere-parse-v5
- [ ] Spot-check the changelog Availability sentence renders correctly with both links


Made with [Cursor](https://cursor.com)