### PR TITLE
Fix response content handling in RAG quickstart

### DIFF
--- a/fern/pages/v2/get-started/quickstart/rag-quickstart.mdx
+++ b/fern/pages/v2/get-started/quickstart/rag-quickstart.mdx
@@ -142,7 +142,11 @@ response = co.chat(
 )
 
 # Display the response
-print(response.message.content[0].text)
+for content_item in response.message.content:
+    if content_item.type == "thinking":
+        print("thinking:", content_item.thinking)
+    if content_item.type == "text":
+        print("text:", content_item.text)
 ```
 
 </Tab>
@@ -161,7 +165,11 @@ response = co.chat(
 )
 
 # Display the response
-print(response.message.content[0].text)
+for content_item in response.message.content:
+    if content_item.type == "thinking":
+        print("thinking:", content_item.thinking)
+    if content_item.type == "text":
+        print("text:", content_item.text)
 ```
 
 </Tab>
@@ -180,7 +188,11 @@ response = co.chat(
 )
 
 # Display the response
-print(response.message.content[0].text)
+for content_item in response.message.content:
+    if content_item.type == "thinking":
+        print("thinking:", content_item.thinking)
+    if content_item.type == "text":
+        print("text:", content_item.text)
 ```
 
 </Tab>
@@ -199,7 +211,11 @@ response = co.chat(
 )
 
 # Display the response
-print(response.message.content[0].text)
+for content_item in response.message.content:
+    if content_item.type == "thinking":
+        print("thinking:", content_item.thinking)
+    if content_item.type == "text":
+        print("text:", content_item.text)
 ```
 
 </Tab>
@@ -218,7 +234,11 @@ response = co.chat(
 )
 
 # Display the response
-print(response.message.content[0].text)
+for content_item in response.message.content:
+    if content_item.type == "thinking":
+        print("thinking:", content_item.thinking)
+    if content_item.type == "text":
+        print("text:", content_item.text)
 ```
 
 </Tab>


### PR DESCRIPTION
## Summary

`fern/pages/v2/get-started/quickstart/rag-quickstart.mdx` has five occurrences of `response.message.content[0].text`. Since the snippets use `command-a-plus-05-2026`, which has thinking enabled by default, `content[0]` is a thinking block and every one of them raises:

```
AttributeError: 'ThinkingAssistantMessageResponseContentItem' object has no attribute 'text'
```

## Changes

Applied the same pattern already used in `text-gen-quickstart.mdx` in the same directory: iterate over `message.content` and branch on `type` instead of indexing position 0.

Verified against the live API; all five now print correctly.

## Related

Same root cause as #796, fixed for the text generation tutorial in #798.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to example code; no runtime or API behavior is modified.
> 
> **Overview**
> Updates the **RAG quickstart** (`rag-quickstart.mdx`) so the “Display the response” snippets work with **Command A+** models that return **thinking** content before text.
> 
> In all five deployment tabs (Cohere Platform, Private Deployment, Bedrock, SageMaker, Azure AI), the examples no longer use `response.message.content[0].text`, which fails when the first item is a thinking block. They now **loop over** `response.message.content` and print **thinking** vs **text** based on `content_item.type`, matching the pattern already used in `text-gen-quickstart.mdx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 636d7e71260c0e6a0a6536be8b8c42c855b386e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->