### PR TITLE
Update Python Generator to 5.29.3

### DIFF
--- a/fern/apis/sdks/generators.yml
+++ b/fern/apis/sdks/generators.yml
@@ -132,7 +132,7 @@ groups:
       - sdk-only
     generators:
       - name: fernapi/fern-python-sdk
-        version: 5.22.1
+        version: 5.29.3
         smart-casing: true
         config:
           tcp_keepalive:


### PR DESCRIPTION
<!-- begin-generated-description -->

Generating pr description

<!-- end-generated-description -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only generator version bump; risk is limited to differences in the next generated Python SDK output, not runtime API behavior in this repo.
> 
> **Overview**
> Bumps the **fernapi/fern-python-sdk** generator pin in `fern/apis/sdks/generators.yml` from **5.22.1** to **5.29.3**. All other Python generator settings (TCP keepalive, `inline_request_params`, OCI extras, PyPI output, etc.) are unchanged.
> 
> The next Python SDK regen will use the newer Fern generator, which may change generated client code compared to the previous pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2920324bb23724a432307cb34fab831d46899615. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->