### PR TITLE
Remove 'North Large' from pricing table

### DIFF
--- a/fern/pages/model-vault/standard/pricing.mdx
+++ b/fern/pages/model-vault/standard/pricing.mdx
@@ -51,7 +51,6 @@ rates are per instance, per hour.
 | Command A Translate | $40.00 | $48.00 |
 | Command A Reasoning | $48.00 | $57.50 |
 | Command A+ | -- | $57.50 |
-| North Large | -- | $57.50 |
 | North Mini Code | -- | $57.50 |
 
 Monthly and annual commitment pricing follows the same Fixed and Flex plans described above;


### PR DESCRIPTION
Removed 'North Large' pricing entry from the table.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update to published pricing copy with no application or billing logic changes.
> 
> **Overview**
> Removes the **North Large** row from the generative models hourly-rate table on the Standard Vault pricing page (`pricing.mdx`). **North Mini Code** and the Command A family entries are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50258833cad3094b07df5d0583cd5496d61f91eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->