### PR TITLE
Update navigation structure in v1 and v2 YAML files to hide 'Safety M…

### DIFF
--- a/fern/v1.yml
+++ b/fern/v1.yml
@@ -231,8 +231,6 @@ navigation:
             path: pages/text-generation/migrating-from-cogenerate-to-cochat.mdx
           - page: Summarizing Text
             path: pages/text-generation/summarizing-text.mdx
-          - page: Safety Modes
-            path: pages/text-generation/safety-modes.mdx
       - section: Embeddings (Vectors, Search, Retrieval)
         contents:
           - page: Introduction to Embeddings at Cohere
@@ -494,6 +492,9 @@ navigation:
       - page: Documents and Citations
         hidden: true
         path: pages/text-generation/documents-and-citations.mdx
+      - page: Safety Modes
+        hidden: true
+        path: pages/text-generation/safety-modes.mdx
       - page: Sending Feedback
         hidden: true
         path: pages/text-generation/feedback.mdx

--- a/fern/v2.yml
+++ b/fern/v2.yml
@@ -239,8 +239,6 @@ navigation:
                     path: pages/v2/text-generation/prompt-engineering/prompt-library/multilingual-interpreter.mdx
           - page: Summarizing Text
             path: pages/v2/text-generation/summarizing-text.mdx
-          - page: Safety Modes
-            path: pages/v2/text-generation/safety-modes.mdx
       - section: Embeddings (Vectors, Search, Retrieval)
         contents:
           - page: Introduction to Embeddings at Cohere
@@ -530,6 +528,9 @@ navigation:
       - page: Documents and Citations
         hidden: true
         path: pages/v2/text-generation/documents-and-citations.mdx
+      - page: Safety Modes
+        hidden: true
+        path: pages/v2/text-generation/safety-modes.mdx
       - page: Sending Feedback
         hidden: true
         path: pages/text-generation/feedback.mdx


### PR DESCRIPTION
…odes' page while retaining its reference for future use.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only Fern navigation changes with no API or application code impact; existing inbound links may still resolve depending on how hidden pages are published.
> 
> **Overview**
> Removes **Safety Modes** from the visible **Text Generation** sidebar in both `fern/v1.yml` and `fern/v2.yml`, and re-registers the same pages under the docs **hidden** block with `hidden: true` (v1: `pages/text-generation/safety-modes.mdx`, v2: `pages/v2/text-generation/safety-modes.mdx`).
> 
> The guide stays in the site config for direct links and future reuse; it no longer appears in the main navigation tree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00458c9d37dc5cde105fc5eba8f3790e0fbe3a3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->